### PR TITLE
fix: handle JSX ignore-next pragma gaps

### DIFF
--- a/napi/test.mjs
+++ b/napi/test.mjs
@@ -165,8 +165,8 @@ function runInstrumented(result, filename, callExpression) {
   );
   const ternaryMap = JSON.parse(ternary.coverageMap);
   assert.equal(Object.keys(ternaryMap.fnMap).length, 1, 'enclosing function should still be tracked');
-  assert.equal(Object.keys(ternaryMap.branchMap).length, 1, 'non-ignored ternary arm should still be tracked');
-  assert.equal(ternaryMap.branchMap['0'].locations.length, 1, 'ignored ternary arm should be pruned from branch paths');
+  assert.equal(Object.keys(ternaryMap.branchMap).length, 0, 'one-path ternary branch stubs should be pruned');
+  assert.equal(Object.keys(ternaryMap.b).length, 0, 'branch hit arrays should match pruned branchMap');
 
   const fullyIgnoredTernary = instrument(
     'function f(x) { return x ? /* v8 ignore next */ 1 : /* v8 ignore next */ 2; }',
@@ -179,10 +179,40 @@ function runInstrumented(result, filename, callExpression) {
     'logical-leaf.js',
   );
   assert.equal(
-    JSON.parse(logicalLeaf.coverageMap).branchMap['0'].locations.length,
-    1,
-    'ignored logical leaf should be pruned from branch paths',
+    Object.keys(JSON.parse(logicalLeaf.coverageMap).branchMap).length,
+    0,
+    'one-path logical branch stubs should be pruned',
   );
+
+  for (const [label, source, path] of [
+    ['nullish rhs', 'function f(x) { return x ?? /* v8 ignore next -- @preserve */ [] }', 'issue-27-nullish.js'],
+    ['or rhs', 'function f(x) { return x || /* v8 ignore next -- @preserve */ true }', 'issue-27-or.js'],
+    ['and rhs', 'function f(x) { return x && /* v8 ignore next -- @preserve */ true }', 'issue-27-and.js'],
+    ['conditional rhs', 'function f(x) { return x ? 1 : /* v8 ignore next -- @preserve */ 2 }', 'issue-27-cond.js'],
+    [
+      'jsx attribute',
+      `function f(pass) {
+        return <Tag
+          /* v8 ignore next -- @preserve */
+          text={pass ? 'Pass' : 'Fail'}
+        />
+      }`,
+      'issue-28.tsx',
+    ],
+    [
+      'jsx child',
+      `function f(x) {
+        return <div>
+          {/* v8 ignore next -- @preserve */}
+          {x ? <a/> : <b/>}
+        </div>
+      }`,
+      'issue-29.tsx',
+    ],
+  ]) {
+    const map = JSON.parse(instrument(source, path).coverageMap);
+    assert.equal(Object.keys(map.branchMap).length, 0, `${label} should not leave branch entries`);
+  }
 
   const classMethod = instrument(
     `class C {

--- a/src/pragma.rs
+++ b/src/pragma.rs
@@ -55,7 +55,7 @@ impl PragmaMap {
             if let Some(ignore_type) = Self::parse_pragma(&text) {
                 match ignore_type {
                     PragmaResult::Ignore(it) => {
-                        let token_start = Self::next_token_start(source, comment.span.end)
+                        let token_start = Self::pragma_target_start(source, comment)
                             .unwrap_or(comment.attached_to);
                         ignores.insert(token_start, it);
                     }
@@ -142,6 +142,22 @@ impl PragmaMap {
             return Some(cursor as u32);
         }
         None
+    }
+
+    fn pragma_target_start(source: &str, comment: &Comment) -> Option<u32> {
+        let token_start = Self::next_token_start(source, comment.span.end)?;
+        if source[token_start as usize..].starts_with('}')
+            && Self::previous_non_whitespace(source, comment.span.start) == Some('{')
+            && let Some(after_close) = Self::next_token_start(source, token_start + 1)
+            && source[after_close as usize..].starts_with(['{', '<'])
+        {
+            return Some(after_close);
+        }
+        Some(token_start)
+    }
+
+    fn previous_non_whitespace(source: &str, offset: u32) -> Option<char> {
+        source[..offset as usize].chars().rev().find(|ch| !ch.is_whitespace())
     }
 
     /// Parse a pragma comment text into an ignore type.

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -560,6 +560,36 @@ fn is_ignored_case(case: &SwitchCase, pragmas: &PragmaMap) -> bool {
             .is_some_and(|stmt| pragmas.get(stmt.span().start) == Some(IgnoreType::Next))
 }
 
+fn jsx_attribute_ignored(attr: &JSXAttribute, pragmas: &PragmaMap, skip_next: bool) -> bool {
+    pragmas.get(attr.span.start) == Some(IgnoreType::Next)
+        || pragmas.get(attr.name.span().start) == Some(IgnoreType::Next)
+        || skip_next
+}
+
+fn jsx_spread_attribute_ignored(
+    attr: &JSXSpreadAttribute,
+    pragmas: &PragmaMap,
+    skip_next: bool,
+) -> bool {
+    pragmas.get(attr.span.start) == Some(IgnoreType::Next)
+        || pragmas.get(attr.argument.span().start) == Some(IgnoreType::Next)
+        || skip_next
+}
+
+fn jsx_child_ignored(child: &JSXChild, pragmas: &PragmaMap, skip_next: bool) -> bool {
+    pragmas.get(child.span().start) == Some(IgnoreType::Next)
+        || match child {
+            JSXChild::ExpressionContainer(container) => {
+                pragmas.get(container.expression.span().start) == Some(IgnoreType::Next)
+            }
+            JSXChild::Spread(spread) => {
+                pragmas.get(spread.expression.span().start) == Some(IgnoreType::Next)
+            }
+            _ => false,
+        }
+        || skip_next
+}
+
 struct LogicalWrapState<'b> {
     cov_fn_name: &'b str,
     /// Pre-interned `${cov_fn_name}_bt` helper, only set when `report_logic` is true.
@@ -1241,35 +1271,35 @@ impl<'a> Traverse<'a, CoverageState> for CoverageTransform<'_, 'a> {
         {
             return;
         }
-        let branch_id = self.add_branch("cond-expr", expr.span);
         let ignore_consequent =
             ctx.state.pragmas.get(expr.consequent.span().start) == Some(IgnoreType::Next);
         let ignore_alternate =
             ctx.state.pragmas.get(expr.alternate.span().start) == Some(IgnoreType::Next);
+        if ignore_consequent || ignore_alternate {
+            return;
+        }
+
+        let branch_id = self.add_branch("cond-expr", expr.span);
 
         let cov_fn = self.cov_fn_name;
 
-        if !ignore_consequent {
-            // Wrap consequent: (cov().b[id][path]++, originalExpr)
-            let path_idx = self.add_branch_path(branch_id, expr.consequent.span());
-            let counter = build_branch_counter_expr(cov_fn, branch_id, path_idx, ctx);
-            let orig_consequent = mem::replace(&mut expr.consequent, dummy_expr(ctx));
-            let mut items = ctx.ast.vec();
-            items.push(counter);
-            items.push(orig_consequent);
-            expr.consequent = ctx.ast.expression_sequence(SPAN, items);
-        }
+        // Wrap consequent: (cov().b[id][path]++, originalExpr)
+        let path_idx = self.add_branch_path(branch_id, expr.consequent.span());
+        let counter = build_branch_counter_expr(cov_fn, branch_id, path_idx, ctx);
+        let orig_consequent = mem::replace(&mut expr.consequent, dummy_expr(ctx));
+        let mut items = ctx.ast.vec();
+        items.push(counter);
+        items.push(orig_consequent);
+        expr.consequent = ctx.ast.expression_sequence(SPAN, items);
 
-        if !ignore_alternate {
-            // Wrap alternate: (cov().b[id][path]++, originalExpr)
-            let path_idx = self.add_branch_path(branch_id, expr.alternate.span());
-            let counter = build_branch_counter_expr(cov_fn, branch_id, path_idx, ctx);
-            let orig_alternate = mem::replace(&mut expr.alternate, dummy_expr(ctx));
-            let mut items = ctx.ast.vec();
-            items.push(counter);
-            items.push(orig_alternate);
-            expr.alternate = ctx.ast.expression_sequence(SPAN, items);
-        }
+        // Wrap alternate: (cov().b[id][path]++, originalExpr)
+        let path_idx = self.add_branch_path(branch_id, expr.alternate.span());
+        let counter = build_branch_counter_expr(cov_fn, branch_id, path_idx, ctx);
+        let orig_alternate = mem::replace(&mut expr.alternate, dummy_expr(ctx));
+        let mut items = ctx.ast.vec();
+        items.push(counter);
+        items.push(orig_alternate);
+        expr.alternate = ctx.ast.expression_sequence(SPAN, items);
     }
 
     fn enter_switch_statement(
@@ -1309,6 +1339,66 @@ impl<'a> Traverse<'a, CoverageState> for CoverageTransform<'_, 'a> {
         self.ignored_switch_case_stack.pop();
     }
 
+    fn enter_jsx_attribute(
+        &mut self,
+        attr: &mut JSXAttribute<'a>,
+        ctx: &mut TraverseCtx<'a, CoverageState>,
+    ) {
+        let ignored = jsx_attribute_ignored(attr, &ctx.state.pragmas, self.skip_next);
+        self.ignored_prop_stack.push(ignored);
+        if ignored {
+            self.skip_next = false;
+        }
+    }
+
+    fn exit_jsx_attribute(
+        &mut self,
+        _attr: &mut JSXAttribute<'a>,
+        _ctx: &mut TraverseCtx<'a, CoverageState>,
+    ) {
+        self.ignored_prop_stack.pop();
+    }
+
+    fn enter_jsx_spread_attribute(
+        &mut self,
+        attr: &mut JSXSpreadAttribute<'a>,
+        ctx: &mut TraverseCtx<'a, CoverageState>,
+    ) {
+        let ignored = jsx_spread_attribute_ignored(attr, &ctx.state.pragmas, self.skip_next);
+        self.ignored_prop_stack.push(ignored);
+        if ignored {
+            self.skip_next = false;
+        }
+    }
+
+    fn exit_jsx_spread_attribute(
+        &mut self,
+        _attr: &mut JSXSpreadAttribute<'a>,
+        _ctx: &mut TraverseCtx<'a, CoverageState>,
+    ) {
+        self.ignored_prop_stack.pop();
+    }
+
+    fn enter_jsx_child(
+        &mut self,
+        child: &mut JSXChild<'a>,
+        ctx: &mut TraverseCtx<'a, CoverageState>,
+    ) {
+        let ignored = jsx_child_ignored(child, &ctx.state.pragmas, self.skip_next);
+        self.ignored_prop_stack.push(ignored);
+        if ignored {
+            self.skip_next = false;
+        }
+    }
+
+    fn exit_jsx_child(
+        &mut self,
+        _child: &mut JSXChild<'a>,
+        _ctx: &mut TraverseCtx<'a, CoverageState>,
+    ) {
+        self.ignored_prop_stack.pop();
+    }
+
     fn enter_logical_expression(
         &mut self,
         expr: &mut LogicalExpression<'a>,
@@ -1329,8 +1419,13 @@ impl<'a> Traverse<'a, CoverageState> for CoverageTransform<'_, 'a> {
                     return;
                 }
 
+                let leaf_spans = collect_logical_leaf_spans(expr, &ctx.state.pragmas);
+                if leaf_spans.len() < 2 {
+                    return;
+                }
+
                 let branch_id = self.add_branch("binary-expr", expr.span);
-                for span in collect_logical_leaf_spans(expr, &ctx.state.pragmas) {
+                for span in leaf_spans {
                     self.add_branch_path(branch_id, span);
                 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -228,9 +228,9 @@ impl FileCoverage {
             statement_locs.into_iter().enumerate().map(|(i, loc)| (i.to_string(), loc)).collect();
         let fn_map: BTreeMap<String, FnEntry> =
             fn_entries.into_iter().enumerate().map(|(i, e)| (i.to_string(), e)).collect();
-        // Drop branches that never got any path locations (e.g. an `if` arm
-        // suppressed by `/* istanbul ignore if */`). Original ids are preserved
-        // so logical_branch_ids can index back into the surviving entries.
+        // Drop branches that never got any path locations (e.g. both `if` arms
+        // suppressed by pragmas). Original ids are preserved so generated
+        // counter ids still line up with the public maps.
         let branch_map: BTreeMap<String, BranchEntry> = branch_entries
             .into_iter()
             .enumerate()
@@ -250,10 +250,10 @@ impl FileCoverage {
             Some(
                 logical_branch_ids
                     .iter()
-                    .map(|&id| {
+                    .filter_map(|&id| {
                         let key = id.to_string();
-                        let len = branch_map[&key].locations.len();
-                        (key, vec![0; len])
+                        let len = branch_map.get(&key)?.locations.len();
+                        Some((key, vec![0; len]))
                     })
                     .collect(),
             )

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1752,13 +1752,13 @@ fn pragma_ignore_next_skips_ternary_branch_counter() {
     let source = "function f(x) {\n  return x.set ? { a: 1 } : /* v8 ignore next */ {};\n}";
     let result = instrument_js(source);
     assert!(result.unhandled_pragmas.is_empty());
-    assert_eq!(result.coverage_map.branch_map.len(), 1);
     assert_eq!(
-        result.coverage_map.branch_map["0"].locations.len(),
-        1,
-        "ignored ternary arm should not remain as an uncovered branch path"
+        result.coverage_map.branch_map.len(),
+        0,
+        "ternary branches with only one tracked path should be pruned"
     );
-    assert!(result.code.contains(".b[0][0]"));
+    assert_eq!(result.coverage_map.b.len(), 0);
+    assert!(!result.code.contains(".b[0][0]"));
     assert!(!result.code.contains(".b[0][1]"));
 }
 
@@ -1768,13 +1768,13 @@ fn pragma_ignore_next_skips_nested_object_spread_ternary_arm() {
     let result = instrument_js(source);
     assert!(result.unhandled_pragmas.is_empty());
     assert_eq!(result.coverage_map.fn_map.len(), 1, "the enclosing function should still count");
-    assert_eq!(result.coverage_map.branch_map.len(), 1, "the non-ignored ternary arm should count");
     assert_eq!(
-        result.coverage_map.branch_map["0"].locations.len(),
-        1,
-        "ignored object-spread ternary arm should not remain as an uncovered branch path"
+        result.coverage_map.branch_map.len(),
+        0,
+        "one-path ternary branches should be removed from the public map"
     );
-    assert!(result.code.contains(".b[0][0]"));
+    assert_eq!(result.coverage_map.b.len(), 0);
+    assert!(!result.code.contains(".b[0][0]"));
     assert!(!result.code.contains(".b[0][1]"));
 }
 
@@ -1797,14 +1797,87 @@ fn pragma_ignore_next_skips_logical_expression_leaf() {
     let source = "function f(a, b) {\n  return a && /* v8 ignore next */ b;\n}";
     let result = instrument_js(source);
     assert!(result.unhandled_pragmas.is_empty());
-    assert_eq!(result.coverage_map.branch_map.len(), 1);
     assert_eq!(
-        result.coverage_map.branch_map["0"].locations.len(),
-        1,
-        "ignored logical leaf should not remain as an uncovered branch path"
+        result.coverage_map.branch_map.len(),
+        0,
+        "logical branches with only one tracked leaf should be pruned"
     );
-    assert!(result.code.contains(".b[0][0]"));
+    assert_eq!(result.coverage_map.b.len(), 0);
+    assert!(!result.code.contains(".b[0][0]"));
     assert!(!result.code.contains(".b[0][1]"));
+}
+
+#[test]
+fn pragma_ignore_next_prunes_binary_and_conditional_rhs_stub_branches() {
+    let cases = [
+        "function f(x) { return x ?? /* v8 ignore next -- @preserve */ [] }",
+        "function f(x) { return x || /* v8 ignore next -- @preserve */ true }",
+        "function f(x) { return x && /* v8 ignore next -- @preserve */ true }",
+        "function f(x) { return x ? 1 : /* v8 ignore next -- @preserve */ 2 }",
+    ];
+
+    for source in cases {
+        let result = instrument_js(source);
+        assert!(result.unhandled_pragmas.is_empty());
+        assert_eq!(
+            result.coverage_map.branch_map.len(),
+            0,
+            "ignored rhs must not leave a one-location branch stub:\n{source}"
+        );
+        assert_eq!(result.coverage_map.b.len(), 0, "hit arrays should match branchMap:\n{source}");
+        assert!(
+            !result.code.contains(".b[0][0]"),
+            "branch counter should not be emitted:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn pragma_ignore_next_skips_jsx_attribute_value_subtree() {
+    let cases = [
+        (
+            "function f() {\n  return <Tag\n    /* v8 ignore next -- @preserve */\n    onClick={() => doSomething()}\n  />\n}",
+            1,
+            0,
+        ),
+        (
+            "function f(pass) {\n  return <Tag\n    /* v8 ignore next -- @preserve */\n    text={pass ? 'Pass' : 'Fail'}\n  />\n}",
+            1,
+            0,
+        ),
+        (
+            "function f(name) {\n  return <Tag\n    /* v8 ignore next -- @preserve */\n    name={name || 'fallback'}\n  />\n}",
+            1,
+            0,
+        ),
+    ];
+
+    for (source, expected_fns, expected_branches) in cases {
+        let result = instrument(source, "test.tsx", &InstrumentOptions::default()).unwrap();
+        assert!(result.unhandled_pragmas.is_empty());
+        assert_eq!(
+            result.coverage_map.fn_map.len(),
+            expected_fns,
+            "JSX attribute pragma should skip nested functions:\n{source}"
+        );
+        assert_eq!(
+            result.coverage_map.branch_map.len(),
+            expected_branches,
+            "JSX attribute pragma should skip nested branches:\n{source}"
+        );
+    }
+}
+
+#[test]
+fn jsx_expression_container_pragma_ignore_next_skips_next_child_subtree() {
+    let source = "function f(x) {\n  return <div>\n    {/* v8 ignore next -- @preserve */}\n    {x ? <a/> : <b/>}\n  </div>\n}";
+    let result = instrument(source, "test.tsx", &InstrumentOptions::default()).unwrap();
+    assert!(result.unhandled_pragmas.is_empty());
+    assert_eq!(
+        result.coverage_map.branch_map.len(),
+        0,
+        "JSX comment-style ignore next should skip the following JSX child"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #27.
Fixes #28.
Fixes #29.

## Summary
- prune single-path binary/conditional expression branch counters before codegen
- propagate `ignore next` through JSX attributes and JSX child expression containers
- add Rust and N-API regressions for the three reported cases

## Validation
- cargo test --workspace
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- npm --prefix napi run build:debug
- npm --prefix napi test
- node scripts/istanbul-upstream-specs.mjs
- direct N-API smoke for #27/#28/#29