### PR TITLE
feat(types): extract data model into oxc_coverage_types crate (#45)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -127,6 +127,13 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      # Publish in topological order: oxc_coverage_types (no internal deps)
+      # before oxc_coverage_instrument (depends on oxc_coverage_types).
+      - name: Publish oxc_coverage_types
+        run: cargo publish -p oxc_coverage_types --allow-dirty || echo "Already published, skipping"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
       - name: Publish oxc_coverage_instrument
         run: cargo publish -p oxc_coverage_instrument --allow-dirty || echo "Already published, skipping"
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_codegen",
+ "oxc_coverage_types",
  "oxc_parser",
  "oxc_semantic",
  "oxc_sourcemap",
@@ -834,6 +835,14 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxc_coverage_instrument",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "oxc_coverage_types"
+version = "0.1.0"
+dependencies = [
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/oxc-coverage-instrument",
     "crates/oxc-coverage-instrument-cli",
     "crates/oxc-coverage-instrument-napi",
+    "crates/oxc-coverage-types",
 ]
 resolver = "3"
 

--- a/crates/oxc-coverage-instrument/Cargo.toml
+++ b/crates/oxc-coverage-instrument/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["development-tools::testing", "web-programming"]
 workspace = true
 
 [dependencies]
+# Suite data-model crate. Path + version: path for workspace builds, version
+# for `cargo publish` so the lib crate can publish standalone from crates.io.
+oxc_coverage_types = { path = "../oxc-coverage-types", version = "0.1.0" }
 oxc_allocator = "0.126"
 oxc_ast = "0.126"
 oxc_codegen = "0.126"

--- a/crates/oxc-coverage-instrument/src/coverage_builder.rs
+++ b/crates/oxc-coverage-instrument/src/coverage_builder.rs
@@ -1,0 +1,79 @@
+//! Crate-internal builder that converts the AST-traversal counter Vecs into
+//! the Istanbul-shaped `FileCoverage`.
+//!
+//! Lives on the instrument side (not in `oxc_coverage_types`) because the
+//! input shape (sequential `Vec<Location>` etc. keyed by counter id) is an
+//! implementation detail of the transform pass, not part of the public data
+//! model.
+
+use std::collections::BTreeMap;
+
+use oxc_coverage_types::{BranchEntry, FileCoverage, FnEntry, Location};
+
+/// Inputs to [`build_file_coverage`], grouped so callers thread one value
+/// instead of five.
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "crate-internal type intentionally; the explicit pub(crate) documents that this is not part of the public API even though the parent module is already private"
+)]
+pub(crate) struct CoverageMaps {
+    /// File path stored on the resulting `FileCoverage`.
+    pub(crate) path: String,
+    /// Statement spans collected during traversal, indexed by counter id.
+    pub(crate) statement_locs: Vec<Location>,
+    /// Function metadata (name, decl span, body span) indexed by counter id.
+    pub(crate) fn_entries: Vec<FnEntry>,
+    /// Branch metadata indexed by counter id; entries with empty `locations`
+    /// are dropped during map construction.
+    pub(crate) branch_entries: Vec<BranchEntry>,
+    /// Counter ids of branches that should also be tracked in the truthy
+    /// (`bT`) map; only populated when `report_logic` is on.
+    pub(crate) logical_branch_ids: Vec<usize>,
+}
+
+/// Convert sequential id-indexed Vecs collected during AST traversal into the
+/// Istanbul-shaped `FileCoverage`. The Vecs are converted once into the
+/// `BTreeMap<String, _>` here so the hot traversal path avoids per-add String
+/// allocations and tree rebalancing.
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "crate-internal function intentionally; the explicit pub(crate) documents that this is not part of the public API even though the parent module is already private"
+)]
+pub(crate) fn build_file_coverage(maps: CoverageMaps) -> FileCoverage {
+    let CoverageMaps { path, statement_locs, fn_entries, branch_entries, logical_branch_ids } =
+        maps;
+    let statement_map: BTreeMap<String, Location> =
+        statement_locs.into_iter().enumerate().map(|(i, loc)| (i.to_string(), loc)).collect();
+    let fn_map: BTreeMap<String, FnEntry> =
+        fn_entries.into_iter().enumerate().map(|(i, e)| (i.to_string(), e)).collect();
+    // Drop branches that never got any path locations (e.g. both `if` arms
+    // suppressed by pragmas). Original ids are preserved so generated
+    // counter ids still line up with the public maps.
+    let branch_map: BTreeMap<String, BranchEntry> = branch_entries
+        .into_iter()
+        .enumerate()
+        .filter(|(_, entry)| !entry.locations.is_empty())
+        .map(|(i, entry)| (i.to_string(), entry))
+        .collect();
+
+    let s = statement_map.keys().map(|k| (k.clone(), 0)).collect();
+    let f = fn_map.keys().map(|k| (k.clone(), 0)).collect();
+    let b =
+        branch_map.iter().map(|(k, entry)| (k.clone(), vec![0; entry.locations.len()])).collect();
+    let b_t = if logical_branch_ids.is_empty() {
+        None
+    } else {
+        Some(
+            logical_branch_ids
+                .iter()
+                .filter_map(|&id| {
+                    let key = id.to_string();
+                    let len = branch_map.get(&key)?.locations.len();
+                    Some((key, vec![0; len]))
+                })
+                .collect(),
+        )
+    };
+
+    FileCoverage { path, statement_map, fn_map, branch_map, s, f, b, b_t, input_source_map: None }
+}

--- a/crates/oxc-coverage-instrument/src/instrument.rs
+++ b/crates/oxc-coverage-instrument/src/instrument.rs
@@ -12,12 +12,13 @@ use oxc_traverse::traverse_mut;
 
 use std::collections::BTreeMap;
 
+use crate::coverage_builder::{CoverageMaps, build_file_coverage};
 use crate::pragma::PragmaMap;
 use crate::transform::{
     CoverageState, CoverageTransform, PreambleInputs, TransformInit, djb31_hex,
     generate_cov_fn_name, generate_preamble_source,
 };
-use crate::types::{CoverageMaps, FileCoverage, UnhandledPragma};
+use oxc_coverage_types::{FileCoverage, UnhandledPragma};
 
 /// Options for the `instrument` function.
 #[derive(Debug, Clone)]
@@ -204,7 +205,7 @@ fn empty_coverage_result(
     source: &str,
     unhandled_pragmas: Vec<UnhandledPragma>,
 ) -> InstrumentResult {
-    let coverage_map = FileCoverage::from_maps(CoverageMaps {
+    let coverage_map = build_file_coverage(CoverageMaps {
         path: filename.to_string(),
         statement_locs: Vec::new(),
         fn_entries: Vec::new(),
@@ -226,7 +227,7 @@ fn build_coverage_map(
     transform: CoverageTransform<'_, '_>,
     input_source_map: Option<&str>,
 ) -> FileCoverage {
-    let mut coverage_map = FileCoverage::from_maps(CoverageMaps {
+    let mut coverage_map = build_file_coverage(CoverageMaps {
         path: filename.to_string(),
         statement_locs: transform.statement_map,
         fn_entries: transform.fn_map,
@@ -276,7 +277,7 @@ pub(crate) fn collect_for_v8_to_istanbul(
 
     let (pragmas, _unhandled_pragmas) = PragmaMap::from_program(&parsed.program, source);
     if pragmas.ignore_file {
-        let coverage_map = FileCoverage::from_maps(CoverageMaps {
+        let coverage_map = build_file_coverage(CoverageMaps {
             path: filename.to_string(),
             statement_locs: Vec::new(),
             fn_entries: Vec::new(),

--- a/crates/oxc-coverage-instrument/src/lib.rs
+++ b/crates/oxc-coverage-instrument/src/lib.rs
@@ -28,20 +28,20 @@
 //! Function names are derived from the same Oxc parser used by other Oxc-based
 //! tools, so they match consistently across the ecosystem.
 
+mod coverage_builder;
 mod instrument;
 mod pragma;
 mod source_maps;
 mod transform;
-mod types;
 mod v8_to_istanbul;
 
 pub use instrument::{InstrumentError, InstrumentOptions, InstrumentResult, instrument};
+pub use oxc_coverage_types::{
+    BranchEntry, FileCoverage, FnEntry, Location, Position, UnhandledPragma, parse_coverage_map,
+};
 pub use source_maps::{
     SourceMapStore, remap_coverage, remap_coverage_map, remap_coverage_map_with_loader,
     remap_coverage_with_loader,
-};
-pub use types::{
-    BranchEntry, FileCoverage, FnEntry, Location, Position, UnhandledPragma, parse_coverage_map,
 };
 pub use v8_to_istanbul::{
     V8CoverageRange, V8FunctionCoverage, V8ToIstanbulError, v8_to_istanbul,

--- a/crates/oxc-coverage-instrument/src/pragma.rs
+++ b/crates/oxc-coverage-instrument/src/pragma.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 
 use oxc_ast::ast::{Comment, Program};
 
-use crate::types::UnhandledPragma;
+use oxc_coverage_types::UnhandledPragma;
 
 /// Type of coverage ignore directive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/oxc-coverage-instrument/src/source_maps.rs
+++ b/crates/oxc-coverage-instrument/src/source_maps.rs
@@ -28,7 +28,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::types::{BranchEntry, FileCoverage, FnEntry, Location, Position};
+use oxc_coverage_types::{BranchEntry, FileCoverage, FnEntry, Location, Position};
 
 /// Remap a single `FileCoverage` through its embedded `inputSourceMap`.
 ///

--- a/crates/oxc-coverage-instrument/src/transform.rs
+++ b/crates/oxc-coverage-instrument/src/transform.rs
@@ -17,7 +17,7 @@ use oxc_syntax::operator::{LogicalOperator, UpdateOperator};
 use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::pragma::{IgnoreType, PragmaMap};
-use crate::types::{BranchEntry, FileCoverage, FnEntry, Location, Position};
+use oxc_coverage_types::{BranchEntry, FileCoverage, FnEntry, Location, Position};
 
 /// State carried through the traverse for coverage instrumentation.
 pub struct CoverageState {

--- a/crates/oxc-coverage-instrument/src/v8_to_istanbul.rs
+++ b/crates/oxc-coverage-instrument/src/v8_to_istanbul.rs
@@ -23,7 +23,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::instrument::collect_for_v8_to_istanbul;
-use crate::types::{FileCoverage, Location};
+use oxc_coverage_types::{FileCoverage, Location};
 
 /// A function's coverage data as reported by the V8 inspector.
 ///

--- a/crates/oxc-coverage-types/Cargo.toml
+++ b/crates/oxc-coverage-types/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "oxc_coverage_types"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+description = "Istanbul-compatible coverage data types (FileCoverage, CoverageMap, etc.) for the oxc-coverage suite"
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+categories = ["development-tools::testing", "data-structures"]
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/oxc-coverage-types/src/lib.rs
+++ b/crates/oxc-coverage-types/src/lib.rs
@@ -3,6 +3,20 @@
 //! First-party serde types derived from Istanbul's JSON schema
 //! (`@istanbuljs/schema`). Produces `coverage-final.json` compatible
 //! output that Jest, Vitest, c8, nyc, and Codecov all consume.
+//!
+//! This crate is the data-model layer of the `oxc-coverage` suite. The
+//! instrumenter, source-map remapper, V8-to-Istanbul converter, and any future
+//! reporter all share these types.
+//!
+//! # Example
+//!
+//! ```
+//! use oxc_coverage_types::{FileCoverage, parse_coverage_map};
+//!
+//! let json = r#"{"file.js": {"path": "file.js", "statementMap": {}, "fnMap": {}, "branchMap": {}, "s": {}, "f": {}, "b": {}}}"#;
+//! let map = parse_coverage_map(json).unwrap();
+//! assert!(map.contains_key("file.js"));
+//! ```
 
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
@@ -59,9 +73,9 @@ pub struct FileCoverage {
         deserialize_with = "deserialize_optional_null_as_zero_vec_map"
     )]
     pub b_t: Option<BTreeMap<String, Vec<u32>>>,
-    /// Input source map from a prior transformation (e.g., TypeScript → JS).
+    /// Input source map from a prior transformation (e.g., TypeScript to JS).
     /// Stored so downstream tools can chain back to the original source.
-    /// Only present when `InstrumentOptions::input_source_map` was provided.
+    /// Only present when the instrumenter received an `inputSourceMap`.
     #[serde(rename = "inputSourceMap", skip_serializing_if = "Option::is_none")]
     pub input_source_map: Option<serde_json::Value>,
 }
@@ -206,13 +220,13 @@ where
 
 /// Parse a `coverage-final.json` string into a map of file paths to coverage data.
 ///
-/// This is the inverse of instrumentation, it reads existing coverage data
+/// This is the inverse of instrumentation: it reads existing coverage data
 /// produced by any Istanbul-compatible tool (Jest, Vitest, c8, nyc, etc.).
 ///
 /// # Example
 ///
 /// ```
-/// use oxc_coverage_instrument::parse_coverage_map;
+/// use oxc_coverage_types::parse_coverage_map;
 ///
 /// let json = r#"{"file.js": {"path": "file.js", "statementMap": {}, "fnMap": {}, "branchMap": {}, "s": {}, "f": {}, "b": {}}}"#;
 /// let map = parse_coverage_map(json).unwrap();
@@ -230,66 +244,4 @@ impl FileCoverage {
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }
-
-    /// Create a new `FileCoverage` with empty hit counts from sequential
-    /// id-indexed Vecs collected during AST traversal. The Vecs are converted
-    /// once into the Istanbul-shaped `BTreeMap<String, _>` here so the hot
-    /// traversal path avoids per-add String allocations and tree rebalancing.
-    pub(crate) fn from_maps(maps: CoverageMaps) -> Self {
-        let CoverageMaps { path, statement_locs, fn_entries, branch_entries, logical_branch_ids } =
-            maps;
-        let statement_map: BTreeMap<String, Location> =
-            statement_locs.into_iter().enumerate().map(|(i, loc)| (i.to_string(), loc)).collect();
-        let fn_map: BTreeMap<String, FnEntry> =
-            fn_entries.into_iter().enumerate().map(|(i, e)| (i.to_string(), e)).collect();
-        // Drop branches that never got any path locations (e.g. both `if` arms
-        // suppressed by pragmas). Original ids are preserved so generated
-        // counter ids still line up with the public maps.
-        let branch_map: BTreeMap<String, BranchEntry> = branch_entries
-            .into_iter()
-            .enumerate()
-            .filter(|(_, entry)| !entry.locations.is_empty())
-            .map(|(i, entry)| (i.to_string(), entry))
-            .collect();
-
-        let s = statement_map.keys().map(|k| (k.clone(), 0)).collect();
-        let f = fn_map.keys().map(|k| (k.clone(), 0)).collect();
-        let b = branch_map
-            .iter()
-            .map(|(k, entry)| (k.clone(), vec![0; entry.locations.len()]))
-            .collect();
-        let b_t = if logical_branch_ids.is_empty() {
-            None
-        } else {
-            Some(
-                logical_branch_ids
-                    .iter()
-                    .filter_map(|&id| {
-                        let key = id.to_string();
-                        let len = branch_map.get(&key)?.locations.len();
-                        Some((key, vec![0; len]))
-                    })
-                    .collect(),
-            )
-        };
-
-        Self { path, statement_map, fn_map, branch_map, s, f, b, b_t, input_source_map: None }
-    }
-}
-
-/// Inputs to [`FileCoverage::from_maps`], grouped so callers thread one value
-/// instead of five.
-pub struct CoverageMaps {
-    /// File path stored on the resulting `FileCoverage`.
-    pub path: String,
-    /// Statement spans collected during traversal, indexed by counter id.
-    pub statement_locs: Vec<Location>,
-    /// Function metadata (name, decl span, body span) indexed by counter id.
-    pub fn_entries: Vec<FnEntry>,
-    /// Branch metadata indexed by counter id; entries with empty `locations`
-    /// are dropped during map construction.
-    pub branch_entries: Vec<BranchEntry>,
-    /// Counter ids of branches that should also be tracked in the truthy
-    /// (`bT`) map; only populated when `report_logic` is on.
-    pub logical_branch_ids: Vec<usize>,
 }


### PR DESCRIPTION
## Summary

PR B of issue #45's umbrella plan. Extracts the Istanbul-compatible coverage data model into a separate publishable crate (\`oxc_coverage_types\`) so non-instrument consumers (future reporters, source-map remappers, V8 converters in this suite + downstream Rust JS tools) can depend on the types without pulling in the instrumenter.

## What changed

**New crate: \`oxc_coverage_types\` v0.1.0**
- \`UnhandledPragma\`, \`FileCoverage\`, \`Location\`, \`Position\`, \`FnEntry\`, \`BranchEntry\`, \`parse_coverage_map\`
- Private serde null-tolerant deserializer helpers
- Pure data model, zero internal deps (just \`serde\` + \`serde_json\`)

**\`oxc_coverage_instrument\` changes**
- Depends on \`oxc_coverage_types\` via path + version specifier (\`path = "../oxc-coverage-types", version = "0.1.0"\`)
- Re-exports the same public types at the crate root via \`pub use oxc_coverage_types::{...}\`, preserving the existing public API surface byte-for-byte (no breaking change for downstream Rust consumers)
- \`CoverageMaps\` + the \`from_maps\` builder (private, crate-internal) move to a new \`coverage_builder.rs\` module on the instrument side; their input shape (\`Vec<Location>\` keyed by counter id) is a transform-pass implementation detail, not part of the data model. \`FileCoverage::from_maps\` becomes the free function \`coverage_builder::build_file_coverage\`.
- Internal callsites switch from \`use crate::types::...\` to \`use oxc_coverage_types::...\`

**Release workflow (\`release-npm.yml\`)**
- Publish \`oxc_coverage_types\` first, then \`oxc_coverage_instrument\` (topological order so the lib's crates.io publish can resolve \`oxc_coverage_types\` from the registry).

## Naming caveat

\`oxc_coverage_types\` is a **working name**. The naming refresh in #45 prefers a neutral name for the data-model crate (candidates: \`istanbul_coverage\`, \`istanbul_data\`) to avoid an implied affiliation that would discourage non-Oxc consumers from adopting it. Final naming is held pending a coordination conversation with OJ Kwon on whether \`istanbul-oxide\` can become the shared crate.

This PR uses \`oxc_coverage_types\` because:
1. It keeps the safe \`oxc_\` prefix under fallow-rs ownership
2. The \`_types\` suffix honestly scopes it (just the data model, not the full impl \`istanbul-oxide\` covers)
3. It can be renamed later by deprecating this crate and re-exporting from the renamed one; preemptively claiming the \`istanbul-*\` namespace without coordination would be the worse failure mode

## Test plan

Verified locally on macOS:

- [x] \`cargo check --workspace\` (clean)
- [x] \`cargo test --workspace --all-targets\` (no failures; 16 test result: ok lines)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` (clean)
- [x] \`cargo fmt --all --check\` (clean)
- [x] \`cargo doc --workspace --no-deps --document-private-items\` with \`RUSTDOCFLAGS=-D warnings\` (clean)
- [x] \`cargo deny check\` (clean)
- [x] \`typos\` (clean)
- [x] \`cargo publish -p oxc_coverage_types --dry-run\` (5 files, 15.3 KiB, packages and compiles cleanly inside the sandboxed tarball dir)
- [x] napi build --release + \`node test.mjs\` (16/16 pass)
- [x] \`node scripts/istanbul-upstream-specs.mjs\` (8/8 upstream istanbul spec cases pass)
- [x] \`node scripts/istanbul-diff.mjs\` (27/27 conformance fixtures byte-match istanbul-lib-instrument)
- [x] \`node scripts/real-world-parity.mjs\` (5/5 libs match: react, lodash, vue, d3, three)

Note: \`cargo publish -p oxc_coverage_instrument --dry-run\` fails locally because \`oxc_coverage_types\` is not yet on crates.io. This resolves itself in CI on the next tag push: the release workflow publishes \`oxc_coverage_types\` first, then \`oxc_coverage_instrument\` which can then resolve the dependency from the registry.

## Out of scope

- PR C (\`oxc_coverage_source_maps\` extraction) lands separately per the umbrella plan
- PR D (\`oxc_coverage_v8\` extraction) lands separately
- Final data-model crate name decision (pending OJ Kwon coordination)

Refs #45