### PR TITLE
feat(source-maps): extract remap into oxc_coverage_source_maps crate (#45)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -127,10 +127,17 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      # Publish in topological order: oxc_coverage_types (no internal deps)
-      # before oxc_coverage_instrument (depends on oxc_coverage_types).
+      # Publish in topological order:
+      #   oxc_coverage_types          (no internal deps)
+      #   oxc_coverage_source_maps    (depends on types)
+      #   oxc_coverage_instrument     (depends on both)
       - name: Publish oxc_coverage_types
         run: cargo publish -p oxc_coverage_types --allow-dirty || echo "Already published, skipping"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish oxc_coverage_source_maps
+        run: cargo publish -p oxc_coverage_source_maps --allow-dirty || echo "Already published, skipping"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_codegen",
+ "oxc_coverage_source_maps",
  "oxc_coverage_types",
  "oxc_parser",
  "oxc_semantic",
@@ -837,6 +838,15 @@ dependencies = [
  "oxc_coverage_instrument",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "oxc_coverage_source_maps"
+version = "0.1.0"
+dependencies = [
+ "oxc_coverage_types",
+ "serde_json",
+ "srcmap-sourcemap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/oxc-coverage-instrument",
     "crates/oxc-coverage-instrument-cli",
     "crates/oxc-coverage-instrument-napi",
+    "crates/oxc-coverage-source-maps",
     "crates/oxc-coverage-types",
 ]
 resolver = "3"

--- a/crates/oxc-coverage-instrument/Cargo.toml
+++ b/crates/oxc-coverage-instrument/Cargo.toml
@@ -15,9 +15,10 @@ categories = ["development-tools::testing", "web-programming"]
 workspace = true
 
 [dependencies]
-# Suite data-model crate. Path + version: path for workspace builds, version
-# for `cargo publish` so the lib crate can publish standalone from crates.io.
+# Suite crates. Path + version: path for workspace builds, version for
+# `cargo publish` so the lib crate can publish standalone from crates.io.
 oxc_coverage_types = { path = "../oxc-coverage-types", version = "0.1.0" }
+oxc_coverage_source_maps = { path = "../oxc-coverage-source-maps", version = "0.1.0" }
 oxc_allocator = "0.126"
 oxc_ast = "0.126"
 oxc_codegen = "0.126"

--- a/crates/oxc-coverage-instrument/src/lib.rs
+++ b/crates/oxc-coverage-instrument/src/lib.rs
@@ -31,17 +31,16 @@
 mod coverage_builder;
 mod instrument;
 mod pragma;
-mod source_maps;
 mod transform;
 mod v8_to_istanbul;
 
 pub use instrument::{InstrumentError, InstrumentOptions, InstrumentResult, instrument};
-pub use oxc_coverage_types::{
-    BranchEntry, FileCoverage, FnEntry, Location, Position, UnhandledPragma, parse_coverage_map,
-};
-pub use source_maps::{
+pub use oxc_coverage_source_maps::{
     SourceMapStore, remap_coverage, remap_coverage_map, remap_coverage_map_with_loader,
     remap_coverage_with_loader,
+};
+pub use oxc_coverage_types::{
+    BranchEntry, FileCoverage, FnEntry, Location, Position, UnhandledPragma, parse_coverage_map,
 };
 pub use v8_to_istanbul::{
     V8CoverageRange, V8FunctionCoverage, V8ToIstanbulError, v8_to_istanbul,

--- a/crates/oxc-coverage-instrument/src/v8_to_istanbul.rs
+++ b/crates/oxc-coverage-instrument/src/v8_to_istanbul.rs
@@ -9,7 +9,7 @@
 //! v2 covers statement, function, and branch counts from `isBlockCoverage`
 //! output. Inline `//# sourceMappingURL=` comments are extracted and attached
 //! to the result as `inputSourceMap`, so feeding the output through
-//! [`crate::source_maps::remap_coverage`] resolves coverage positions back to
+//! [`crate::remap_coverage`] resolves coverage positions back to
 //! original sources in one chained step.
 //!
 //! ## CJS wrapper offset
@@ -85,7 +85,7 @@ impl std::error::Error for V8ToIstanbulError {}
 /// V8 range containing the corresponding location. When the source carries an
 /// inline `//# sourceMappingURL=data:application/json;base64,...` comment, the
 /// embedded map is decoded and attached as `inputSourceMap` so the result
-/// chains cleanly into [`crate::source_maps::remap_coverage`].
+/// chains cleanly into [`crate::remap_coverage`].
 ///
 /// To resolve an external `//# sourceMappingURL=foo.js.map` reference rather
 /// than the inline data-URL form, use [`v8_to_istanbul_with_loader`] and
@@ -106,7 +106,7 @@ pub fn v8_to_istanbul(
 /// inline `data:application/json` URL, the loader is called with the URL as
 /// reported by the trailer (e.g. `foo.js.map`, `https://cdn.example/x.js.map`).
 /// Returning `Some(json)` attaches the parsed map as `inputSourceMap` on the
-/// result so a subsequent [`crate::source_maps::remap_coverage`] resolves
+/// result so a subsequent [`crate::remap_coverage`] resolves
 /// positions back to the original source in one chained call. Returning
 /// `None` leaves `inputSourceMap` unset.
 ///

--- a/crates/oxc-coverage-source-maps/Cargo.toml
+++ b/crates/oxc-coverage-source-maps/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "oxc_coverage_source_maps"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+description = "Istanbul-compatible source-map remap for FileCoverage (port of istanbul-lib-source-maps)"
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+categories = ["development-tools::testing", "web-programming"]
+
+[lints]
+workspace = true
+
+[dependencies]
+oxc_coverage_types = { path = "../oxc-coverage-types", version = "0.1.0" }
+serde_json = "1"
+# Exact-pinned (pre-1.0): bump together with the rest of the srcmap suite.
+srcmap-sourcemap = "=0.3.6"

--- a/crates/oxc-coverage-source-maps/src/lib.rs
+++ b/crates/oxc-coverage-source-maps/src/lib.rs
@@ -5,13 +5,13 @@
 //! emitted via `tsc` and then instrumented). Downstream coverage reporters
 //! (nyc, `@vitest/coverage-istanbul`, monocart) call into
 //! `istanbul-lib-source-maps` to walk that source map and rewrite every
-//! coverage position back to the original source. This module covers both
+//! coverage position back to the original source. This crate covers both
 //! upstream usage modes:
 //!
 //! - **Mode A (remap-at-report-time)**: [`remap_coverage`] /
-//!   [`remap_coverage_map`] walk a single FileCoverage (or every entry of a
+//!   [`remap_coverage_map`] walk a single `FileCoverage` (or every entry of a
 //!   coverage-final.json shaped map) through the embedded `inputSourceMap`.
-//!   When the input map is not embedded on the FileCoverage,
+//!   When the input map is not embedded on the `FileCoverage`,
 //!   [`remap_coverage_with_loader`] / [`remap_coverage_map_with_loader`]
 //!   accept a caller-supplied loader that reads the map JSON from disk or
 //!   another source, matching `istanbul-lib-source-maps`'s `sourceStore`
@@ -136,20 +136,22 @@ fn apply_source_map(
 /// Example usage:
 ///
 /// ```
-/// use oxc_coverage_instrument::{SourceMapStore, instrument, InstrumentOptions};
+/// use oxc_coverage_source_maps::SourceMapStore;
+/// use oxc_coverage_types::FileCoverage;
 ///
 /// let mut store = SourceMapStore::new();
 /// let input_sm = r#"{"version":3,"sources":["src/app.ts"],"mappings":"AAAA","names":[]}"#;
-/// let opts = InstrumentOptions {
-///     input_source_map: Some(input_sm.to_string()),
-///     ..InstrumentOptions::default()
-/// };
-/// let result = instrument("const x = 1;", "intermediate.js", &opts).unwrap();
 /// store.add_map("intermediate.js", serde_json::from_str(input_sm).unwrap());
 ///
-/// // Later, when the runner finalizes its coverage map:
+/// // Minimal FileCoverage to demonstrate the remap; the instrumenter produces
+/// // this shape in real usage. Constructed inline here so the doctest does
+/// // not reverse-depend on the instrumenter.
+/// let fc = FileCoverage::from_json(
+///     r#"{"path":"intermediate.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}"#,
+/// ).unwrap();
+///
 /// let remapped = store
-///     .transform_coverage(&result.coverage_map)
+///     .transform_coverage(&fc)
 ///     .expect("store has a map for the file");
 /// assert_eq!(remapped.path, "src/app.ts");
 /// ```


### PR DESCRIPTION
## Summary

PR C of issue #45's umbrella plan. Lifts the Istanbul-compatible source-map remap module out of the instrument crate into a publishable \`oxc_coverage_source_maps\` crate so future Rust JS coverage tooling can depend on the remap surface without pulling in the instrumenter.

## What changed

**New crate: \`oxc_coverage_source_maps\` v0.1.0**
- \`remap_coverage\`, \`remap_coverage_map\` (Mode A: remap-at-report-time)
- \`remap_coverage_with_loader\`, \`remap_coverage_map_with_loader\` (nyc-style disk-read fallback when the \`inputSourceMap\` is not embedded)
- \`SourceMapStore\` (Mode B: continuous remap during collection, Jest \`transform\` path)
- Depends on \`oxc_coverage_types\` + \`srcmap-sourcemap\`. Zero Oxc deps, so it composes with any Rust-side coverage producer.

**\`oxc_coverage_instrument\` changes**
- Depends on \`oxc_coverage_source_maps\` via path + version specifier
- Re-exports the same public API at the crate root via \`pub use oxc_coverage_source_maps::{...}\`, preserving \`SourceMapStore\`, \`remap_coverage\`, \`remap_coverage_map\`, \`remap_coverage_with_loader\`, \`remap_coverage_map_with_loader\` byte-for-byte (no breaking change for downstream Rust consumers like \`oxc_coverage_instrument_napi\`)
- Delete \`src/source_maps.rs\` (replaced by the new crate)
- Fix the three intra-doc-links in \`v8_to_istanbul.rs\` that referenced \`crate::source_maps::remap_coverage\` to point at the lib-root \`crate::remap_coverage\` re-export

**Release workflow (\`release-npm.yml\`)** — publish in topological order:
1. \`oxc_coverage_types\` (no internal deps)
2. \`oxc_coverage_source_maps\` (depends on types)
3. \`oxc_coverage_instrument\` (depends on both)

**SourceMapStore doctest rewritten**: the previous version used \`instrument()\` and \`InstrumentOptions\` to produce a real \`FileCoverage\`, which would force \`oxc_coverage_source_maps\` to reverse-depend on the instrumenter (cycle). The new doctest uses \`FileCoverage::from_json\` with a minimal JSON payload, demonstrating the same Mode B path without the reverse dep.

## Test plan

Verified locally on macOS:

- [x] \`cargo check --workspace\` (clean)
- [x] \`cargo test --workspace --all-targets\` (no failures; 17 test result: ok lines)
- [x] \`cargo test --workspace --doc\` (clean: instrument 3, source_maps 1, types 2)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` (clean)
- [x] \`cargo fmt --all --check\` (clean)
- [x] \`cargo doc --workspace --no-deps --document-private-items\` with \`RUSTDOCFLAGS=-D warnings\` (clean)
- [x] \`cargo deny check\` (clean)
- [x] \`typos\` (clean)
- [x] napi build --release + \`node test.mjs\` (16/16 pass)
- [x] \`node scripts/istanbul-upstream-specs.mjs\` (8/8 pass)
- [x] \`node scripts/istanbul-diff.mjs\` (27/27 conformance fixtures byte-match istanbul-lib-instrument)
- [x] \`node scripts/real-world-parity.mjs\` (5/5 libs match)

\`cargo publish -p oxc_coverage_source_maps --dry-run\` fails locally because \`oxc_coverage_types\` is not yet on crates.io. Resolves in CI on the next tag push via the topological publish order.

## Suite status after merge

| Crate | Status |
|:--|:--|
| \`oxc_coverage_instrument\` | shipping, now depends on types + source-maps |
| \`oxc_coverage_types\` | PR B (merged), ready for first publish |
| \`oxc_coverage_source_maps\` | this PR, ready for first publish |
| \`oxc_coverage_v8\` | PR D, not started |
| \`oxc_coverage_report\` / \`oxc_coverage_reports\` | PR E+, not started |

## Out of scope

- PR D (\`oxc_coverage_v8\` extraction) lands separately
- Reports + report data model (PR E+) land separately
- Final data-model crate name decision (still pending OJ Kwon coordination)

Refs #45