### PR TITLE
feat(v8): extract V8 range intersection into oxc_coverage_v8 crate (#45)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -130,7 +130,8 @@ jobs:
       # Publish in topological order:
       #   oxc_coverage_types          (no internal deps)
       #   oxc_coverage_source_maps    (depends on types)
-      #   oxc_coverage_instrument     (depends on both)
+      #   oxc_coverage_v8             (depends on types)
+      #   oxc_coverage_instrument     (depends on all three)
       - name: Publish oxc_coverage_types
         run: cargo publish -p oxc_coverage_types --allow-dirty || echo "Already published, skipping"
         env:
@@ -138,6 +139,11 @@ jobs:
 
       - name: Publish oxc_coverage_source_maps
         run: cargo publish -p oxc_coverage_source_maps --allow-dirty || echo "Already published, skipping"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish oxc_coverage_v8
+        run: cargo publish -p oxc_coverage_v8 --allow-dirty || echo "Already published, skipping"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,7 @@ dependencies = [
  "oxc_codegen",
  "oxc_coverage_source_maps",
  "oxc_coverage_types",
+ "oxc_coverage_v8",
  "oxc_parser",
  "oxc_semantic",
  "oxc_sourcemap",
@@ -853,6 +854,15 @@ dependencies = [
 name = "oxc_coverage_types"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "oxc_coverage_v8"
+version = "0.1.0"
+dependencies = [
+ "oxc_coverage_types",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/oxc-coverage-instrument-napi",
     "crates/oxc-coverage-source-maps",
     "crates/oxc-coverage-types",
+    "crates/oxc-coverage-v8",
 ]
 resolver = "3"
 

--- a/crates/oxc-coverage-instrument/Cargo.toml
+++ b/crates/oxc-coverage-instrument/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 # `cargo publish` so the lib crate can publish standalone from crates.io.
 oxc_coverage_types = { path = "../oxc-coverage-types", version = "0.1.0" }
 oxc_coverage_source_maps = { path = "../oxc-coverage-source-maps", version = "0.1.0" }
+oxc_coverage_v8 = { path = "../oxc-coverage-v8", version = "0.1.0" }
 oxc_allocator = "0.126"
 oxc_ast = "0.126"
 oxc_codegen = "0.126"

--- a/crates/oxc-coverage-instrument/src/v8_to_istanbul.rs
+++ b/crates/oxc-coverage-instrument/src/v8_to_istanbul.rs
@@ -1,63 +1,22 @@
 //! Convert V8 byte-range coverage into Istanbul `FileCoverage`.
 //!
-//! V8's inspector protocol reports coverage as `[startOffset, endOffset, count]`
-//! ranges grouped by function. Istanbul reporters consume per-statement,
-//! per-function, and per-branch hit counts keyed by (line, column). The bridge
-//! is to walk the same AST that `instrument()` walks, recover each location's
-//! byte range, and intersect with the V8 ranges to assign counts.
+//! Thin orchestrator that combines this crate's AST-traversal pass
+//! ([`crate::instrument::collect_for_v8_to_istanbul`]) with
+//! `oxc_coverage_v8::apply_v8_coverage` for the V8-range intersection and
+//! `oxc_coverage_v8`'s source-map extraction helpers for the inline /
+//! external `//# sourceMappingURL=` trailer.
 //!
-//! v2 covers statement, function, and branch counts from `isBlockCoverage`
-//! output. Inline `//# sourceMappingURL=` comments are extracted and attached
-//! to the result as `inputSourceMap`, so feeding the output through
-//! [`crate::remap_coverage`] resolves coverage positions back to
-//! original sources in one chained step.
-//!
-//! ## CJS wrapper offset
-//!
-//! Node wraps every CommonJS module in `(function(exports,require,module,...){`
-//! before V8 sees it. V8 byte offsets are relative to that wrapped source. Pass
-//! the wrapper length (62 by default on stock Node CJS) so this module can
-//! shift offsets back into the user's source. ESM modules and bare `eval`
-//! sources have a wrapper length of zero.
+//! For the user-facing description of the V8-to-Istanbul mapping, the CJS
+//! wrapper offset semantics, and the per-arm `body_byte_span` resolution, see
+//! the `oxc_coverage_v8` crate documentation.
 
-use serde::{Deserialize, Serialize};
+pub use oxc_coverage_v8::{V8CoverageRange, V8FunctionCoverage};
 
 use crate::instrument::collect_for_v8_to_istanbul;
-use oxc_coverage_types::{FileCoverage, Location};
-
-/// A function's coverage data as reported by the V8 inspector.
-///
-/// Serializes to / from the same JSON shape as
-/// [`node:inspector`'s `Profiler.FunctionCoverage`](https://nodejs.org/api/inspector.html)
-/// so callers can hand the V8 inspector's output straight through.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct V8FunctionCoverage {
-    /// Function name as reported by V8 (may be empty for anonymous functions
-    /// or the implicit top-level module function).
-    #[serde(rename = "functionName")]
-    pub function_name: String,
-    /// One or more byte ranges. With `is_block_coverage = false` there is
-    /// exactly one range (the whole function); with `is_block_coverage = true`
-    /// the outermost range covers the function and inner ranges cover blocks.
-    pub ranges: Vec<V8CoverageRange>,
-    /// When true, `ranges` includes block-level subdivisions. When false, the
-    /// only count is at function granularity.
-    #[serde(rename = "isBlockCoverage")]
-    pub is_block_coverage: bool,
-}
-
-/// A single V8 coverage range.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct V8CoverageRange {
-    /// Byte offset of the range start (inclusive) in the V8-visible source.
-    #[serde(rename = "startOffset")]
-    pub start_offset: u32,
-    /// Byte offset of the range end (exclusive).
-    #[serde(rename = "endOffset")]
-    pub end_offset: u32,
-    /// Hit count. Zero means the range was reachable but never executed.
-    pub count: u32,
-}
+use oxc_coverage_types::FileCoverage;
+use oxc_coverage_v8::{
+    apply_v8_coverage, extract_external_source_mapping_url, extract_inline_source_map,
+};
 
 /// Errors produced by the V8-to-Istanbul conversion.
 #[derive(Debug)]
@@ -150,45 +109,13 @@ where
     let collected = collect_for_v8_to_istanbul(source, filename)
         .map_err(|e| V8ToIstanbulError::Parse(e.to_string()))?;
     let mut file_coverage = collected.coverage_map;
-    let arm_body_byte_spans = collected.arm_body_byte_spans;
-    let line_offsets = compute_line_offsets(source);
-    let ranges: Vec<V8CoverageRange> =
-        functions.iter().flat_map(|f| f.ranges.iter().copied()).collect();
-
-    for (id, loc) in &file_coverage.statement_map {
-        let count = count_for_location(source, loc, &line_offsets, &ranges, wrapper_length);
-        if let Some(slot) = file_coverage.s.get_mut(id) {
-            *slot = count;
-        }
-    }
-    for (id, fn_entry) in &file_coverage.fn_map {
-        let count =
-            count_for_location(source, &fn_entry.loc, &line_offsets, &ranges, wrapper_length);
-        if let Some(slot) = file_coverage.f.get_mut(id) {
-            *slot = count;
-        }
-    }
-    for (id, branch_entry) in &file_coverage.branch_map {
-        let body_spans = arm_body_byte_spans.get(id);
-        let arm_counts: Vec<u32> = branch_entry
-            .locations
-            .iter()
-            .enumerate()
-            .map(|(arm_idx, loc)| {
-                arm_count_for_arm(
-                    source,
-                    loc,
-                    body_spans.and_then(|spans| spans.get(arm_idx).copied()),
-                    &line_offsets,
-                    &ranges,
-                    wrapper_length,
-                )
-            })
-            .collect();
-        if let Some(slot) = file_coverage.b.get_mut(id) {
-            *slot = arm_counts;
-        }
-    }
+    apply_v8_coverage(
+        &mut file_coverage,
+        source,
+        functions,
+        wrapper_length,
+        &collected.arm_body_byte_spans,
+    );
 
     if file_coverage.input_source_map.is_none() {
         if let Some(inline_map) = extract_inline_source_map(source) {
@@ -201,271 +128,4 @@ where
     }
 
     Ok(file_coverage)
-}
-
-/// Pull a trailing `//# sourceMappingURL=<url>` comment from the tail of
-/// `source` and return the URL when it is NOT a `data:` URI. Returns `None`
-/// when no trailer is present or when the trailer is an inline data URL (the
-/// inline form is handled by [`extract_inline_source_map`]).
-fn extract_external_source_mapping_url(source: &str) -> Option<&str> {
-    const NEEDLE: &str = "//# sourceMappingURL=";
-    let idx = source.rfind(NEEDLE)?;
-    let after = &source[idx + NEEDLE.len()..];
-    let url = after.lines().next()?.trim();
-    if url.is_empty() || url.starts_with("data:") {
-        return None;
-    }
-    Some(url)
-}
-
-/// Pull an inline `//# sourceMappingURL=data:application/json;base64,...`
-/// comment from the tail of `source` and decode the embedded source map.
-///
-/// Only the data-URL form (the dominant case for ESM bundles emitted by Vite,
-/// esbuild, swc, and tsc) is supported. External URLs are handled via the
-/// loader-accepting [`v8_to_istanbul_with_loader`] API.
-fn extract_inline_source_map(source: &str) -> Option<serde_json::Value> {
-    const NEEDLE: &str = "//# sourceMappingURL=data:application/json";
-    let idx = source.rfind(NEEDLE)?;
-    let line = source[idx..].lines().next()?;
-
-    let comma = line.find(',')?;
-    let payload = &line[comma + 1..];
-    let is_base64 = line[..comma].contains(";base64");
-    let json = if is_base64 {
-        let bytes = decode_base64(payload).ok()?;
-        String::from_utf8(bytes).ok()?
-    } else {
-        urlencoding_decode(payload).ok()?
-    };
-    serde_json::from_str(&json).ok()
-}
-
-/// Tiny base64 decoder (standard alphabet, no padding required).
-/// Kept in-crate to avoid pulling a base64 dep just for this one site.
-fn decode_base64(input: &str) -> Result<Vec<u8>, ()> {
-    fn value(c: u8) -> Result<u8, ()> {
-        // Accepts both the standard (RFC 4648 §4) and URL-safe (RFC 4648 §5)
-        // alphabets so esbuild-emitted inline maps (which use the URL-safe
-        // alphabet in some output modes) decode without a silent miss.
-        match c {
-            b'A'..=b'Z' => Ok(c - b'A'),
-            b'a'..=b'z' => Ok(c - b'a' + 26),
-            b'0'..=b'9' => Ok(c - b'0' + 52),
-            b'+' | b'-' => Ok(62),
-            b'/' | b'_' => Ok(63),
-            _ => Err(()),
-        }
-    }
-    let trimmed: Vec<u8> =
-        input.bytes().filter(|b| *b != b'=' && !b.is_ascii_whitespace()).collect();
-    let mut out = Vec::with_capacity(trimmed.len() * 3 / 4);
-    for chunk in trimmed.chunks(4) {
-        let n0 = value(chunk[0])?;
-        let n1 = value(chunk[1])?;
-        out.push((n0 << 2) | (n1 >> 4));
-        if let Some(&c2) = chunk.get(2) {
-            let n2 = value(c2)?;
-            out.push((n1 << 4) | (n2 >> 2));
-            if let Some(&c3) = chunk.get(3) {
-                let n3 = value(c3)?;
-                out.push((n2 << 6) | n3);
-            }
-        }
-    }
-    Ok(out)
-}
-
-/// Decode percent-encoded URL payload for non-base64 inline source maps.
-fn urlencoding_decode(input: &str) -> Result<String, ()> {
-    let mut out = Vec::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            let hi = (bytes[i + 1] as char).to_digit(16).ok_or(())? as u8;
-            let lo = (bytes[i + 2] as char).to_digit(16).ok_or(())? as u8;
-            out.push((hi << 4) | lo);
-            i += 3;
-        } else {
-            out.push(bytes[i]);
-            i += 1;
-        }
-    }
-    String::from_utf8(out).map_err(|_| ())
-}
-
-/// Precompute byte offsets for the start of each line in `source`.
-/// `line_offsets[N]` is the byte offset of the (0-based) Nth line's first
-/// character. `line_offsets.len()` equals the line count plus one (sentinel
-/// at the end of the source so the last line's range is also bounded).
-fn compute_line_offsets(source: &str) -> Vec<u32> {
-    let mut offsets = vec![0u32];
-    for (i, b) in source.bytes().enumerate() {
-        if b == b'\n' {
-            let next = u32::try_from(i + 1).unwrap_or(u32::MAX);
-            offsets.push(next);
-        }
-    }
-    let end = u32::try_from(source.len()).unwrap_or(u32::MAX);
-    offsets.push(end);
-    offsets
-}
-
-/// Byte offset of an Istanbul `(line, column)` inside `source`.
-///
-/// Istanbul columns are UTF-16 code units (Babel + `istanbul-lib-instrument`
-/// convention). srcmap is byte-based. For ASCII the two collapse, but for
-/// non-ASCII source the byte position must be computed by walking the line
-/// and consuming `col_utf16` UTF-16 code units. The walk is bounded by the
-/// `line_offsets` sentinel so a column past end-of-line clamps to end-of-line.
-fn position_to_byte_offset(
-    source: &str,
-    line_1based: u32,
-    col_utf16: u32,
-    line_offsets: &[u32],
-) -> u32 {
-    if line_1based == 0 {
-        return 0;
-    }
-    let line_idx = (line_1based - 1) as usize;
-    if line_idx >= line_offsets.len() - 1 {
-        return *line_offsets.last().unwrap_or(&0);
-    }
-    let line_start = line_offsets[line_idx] as usize;
-    let line_end = line_offsets[line_idx + 1] as usize;
-    let line_bytes = source.get(line_start..line_end).unwrap_or("");
-
-    let mut utf16_remaining = col_utf16;
-    let mut byte_in_line = 0usize;
-    for ch in line_bytes.chars() {
-        if utf16_remaining == 0 {
-            break;
-        }
-        let units = ch.len_utf16() as u32;
-        if units > utf16_remaining {
-            break;
-        }
-        utf16_remaining -= units;
-        byte_in_line += ch.len_utf8();
-    }
-
-    u32::try_from(line_start + byte_in_line).unwrap_or(u32::MAX)
-}
-
-fn count_for_location(
-    source: &str,
-    loc: &Location,
-    line_offsets: &[u32],
-    ranges: &[V8CoverageRange],
-    wrapper_length: u32,
-) -> u32 {
-    let start = position_to_byte_offset(source, loc.start.line, loc.start.column, line_offsets)
-        + wrapper_length;
-    let end = position_to_byte_offset(source, loc.end.line, loc.end.column, line_offsets)
-        + wrapper_length;
-    smallest_containing_range_count(start, end, ranges)
-}
-
-/// Resolve the V8 hit count for a branch arm.
-///
-/// Unlike statements and functions (which can correctly use a containing
-/// scope's count, because being inside an executed function implies the
-/// statement was reachable), branch arms need *arm-level* resolution. V8
-/// block coverage only emits subdivision ranges for `BlockStatement` nodes,
-/// so non-block branch shapes (ternaries, logical-expr right-hand operands,
-/// `default-arg` expressions, switch cases without `{ ... }`) have no V8
-/// range tight to the arm body. Falling back to the enclosing function /
-/// module count there over-reports execution and trips CI coverage
-/// thresholds. The honest answer is 0 ("V8 did not give us per-arm data for
-/// this branch shape").
-///
-/// The 4-byte tolerance covers the typical newline + 2-space indent gap
-/// between istanbul's reported arm location and V8's `BlockStatement` range.
-/// Longer gaps (`else /* comment */ {`) intentionally return 0 because the
-/// match is then ambiguous; under-reporting is preferable to over-reporting.
-///
-/// When multiple V8 ranges fall within tolerance of the same arm (nested
-/// blocks whose `{` characters happen to be close together), the *tightest*
-/// match wins: minimum sum of start-distance + end-distance, ties broken by
-/// the narrower range. V8 emits ranges outermost-first, so a naive
-/// first-match would prefer the enclosing block over the actual arm.
-///
-/// When `body_byte_span` is `Some`, the resolver uses that byte range
-/// directly instead of computing one from `arm_loc`. This is the if-arm 0
-/// path: istanbul's whole-IfStatement convention puts `locations[0]` at the
-/// outer `if (...) ... else ...` span, which V8 does not match; the
-/// collected consequent-body span does match V8's block range and yields
-/// "number of times the predicate evaluated truthy".
-fn arm_count_for_arm(
-    source: &str,
-    arm_loc: &Location,
-    body_byte_span: Option<(u32, u32)>,
-    line_offsets: &[u32],
-    ranges: &[V8CoverageRange],
-    wrapper_length: u32,
-) -> u32 {
-    const TOLERANCE: u32 = 4;
-
-    let (arm_start, arm_end) = match body_byte_span {
-        Some((start, end)) if !(start == 0 && end == 0) => {
-            (start + wrapper_length, end + wrapper_length)
-        }
-        _ => (
-            position_to_byte_offset(source, arm_loc.start.line, arm_loc.start.column, line_offsets)
-                + wrapper_length,
-            position_to_byte_offset(source, arm_loc.end.line, arm_loc.end.column, line_offsets)
-                + wrapper_length,
-        ),
-    };
-
-    let mut best: Option<(V8CoverageRange, u32)> = None;
-    for r in ranges {
-        let dist_start = r.start_offset.abs_diff(arm_start);
-        let dist_end = r.end_offset.abs_diff(arm_end);
-        if dist_start > TOLERANCE || dist_end > TOLERANCE {
-            continue;
-        }
-        let distance = dist_start + dist_end;
-        match best {
-            None => best = Some((*r, distance)),
-            Some((prev, prev_distance)) => {
-                let prev_width = prev.end_offset.saturating_sub(prev.start_offset);
-                let this_width = r.end_offset.saturating_sub(r.start_offset);
-                if distance < prev_distance
-                    || (distance == prev_distance && this_width < prev_width)
-                {
-                    best = Some((*r, distance));
-                }
-            }
-        }
-    }
-    best.map_or(0, |(r, _)| r.count)
-}
-
-/// Pick the count of the smallest V8 range that fully contains `[start, end)`.
-/// Smaller ranges represent inner blocks (with their own counts under
-/// `isBlockCoverage`) and override the outer function-level count.
-///
-/// Both V8 ranges and the statement byte span use the half-open convention
-/// (`endOffset` / `end` are exclusive). The containment predicate is therefore
-/// `r.start <= start && r.end >= end`: a range whose exclusive end is equal
-/// to the statement's exclusive end is the smallest possible exact container.
-fn smallest_containing_range_count(start: u32, end: u32, ranges: &[V8CoverageRange]) -> u32 {
-    let mut best: Option<V8CoverageRange> = None;
-    for r in ranges {
-        if r.start_offset <= start && r.end_offset >= end {
-            let width = r.end_offset.saturating_sub(r.start_offset);
-            match best {
-                None => best = Some(*r),
-                Some(prev) => {
-                    let prev_width = prev.end_offset.saturating_sub(prev.start_offset);
-                    if width < prev_width {
-                        best = Some(*r);
-                    }
-                }
-            }
-        }
-    }
-    best.map_or(0, |r| r.count)
 }

--- a/crates/oxc-coverage-v8/Cargo.toml
+++ b/crates/oxc-coverage-v8/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "oxc_coverage_v8"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+description = "V8 inspector coverage to Istanbul FileCoverage conversion (port of v8-to-istanbul)"
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+categories = ["development-tools::testing", "web-programming"]
+
+[lints]
+workspace = true
+
+[dependencies]
+oxc_coverage_types = { path = "../oxc-coverage-types", version = "0.1.0" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/oxc-coverage-v8/src/lib.rs
+++ b/crates/oxc-coverage-v8/src/lib.rs
@@ -108,32 +108,25 @@ pub fn apply_v8_coverage(
             *slot = count;
         }
     }
-    let branch_updates: Vec<(String, Vec<u32>)> = file_coverage
-        .branch_map
-        .iter()
-        .map(|(id, branch_entry)| {
-            let body_spans = arm_body_byte_spans.get(id);
-            let arm_counts: Vec<u32> = branch_entry
-                .locations
-                .iter()
-                .enumerate()
-                .map(|(arm_idx, loc)| {
-                    arm_count_for_arm(
-                        source,
-                        loc,
-                        body_spans.and_then(|spans| spans.get(arm_idx).copied()),
-                        &line_offsets,
-                        &ranges,
-                        wrapper_length,
-                    )
-                })
-                .collect();
-            (id.clone(), arm_counts)
-        })
-        .collect();
-    for (id, counts) in branch_updates {
-        if let Some(slot) = file_coverage.b.get_mut(&id) {
-            *slot = counts;
+    for (id, branch_entry) in &file_coverage.branch_map {
+        let body_spans = arm_body_byte_spans.get(id);
+        let arm_counts: Vec<u32> = branch_entry
+            .locations
+            .iter()
+            .enumerate()
+            .map(|(arm_idx, loc)| {
+                arm_count_for_arm(
+                    source,
+                    loc,
+                    body_spans.and_then(|spans| spans.get(arm_idx).copied()),
+                    &line_offsets,
+                    &ranges,
+                    wrapper_length,
+                )
+            })
+            .collect();
+        if let Some(slot) = file_coverage.b.get_mut(id) {
+            *slot = arm_counts;
         }
     }
 }

--- a/crates/oxc-coverage-v8/src/lib.rs
+++ b/crates/oxc-coverage-v8/src/lib.rs
@@ -1,0 +1,408 @@
+//! V8 inspector coverage to Istanbul `FileCoverage` conversion.
+//!
+//! V8's inspector protocol reports coverage as `[startOffset, endOffset, count]`
+//! ranges grouped by function. Istanbul reporters consume per-statement,
+//! per-function, and per-branch hit counts keyed by (line, column). This crate
+//! takes a pre-built `FileCoverage` (typically produced by an AST-traversal
+//! pass in an instrumenter) and fills in its hit-count vectors from V8 ranges.
+//!
+//! ## Position semantics
+//!
+//! Istanbul's `Position` is 1-based line + 0-based UTF-16 column. V8 ranges are
+//! byte offsets into the V8-visible source. This crate walks each location's
+//! UTF-16 column into a byte offset, then intersects against the V8 ranges.
+//!
+//! ## CJS wrapper offset
+//!
+//! Node wraps every CommonJS module in `(function(exports,require,module,...){`
+//! before V8 sees it. V8 byte offsets are relative to that wrapped source. Pass
+//! the wrapper length (62 by default on stock Node CJS) so this crate can shift
+//! offsets back into the user's source. ESM modules and bare `eval` sources
+//! have a wrapper length of zero.
+//!
+//! ## Companion helpers for inline / external source maps
+//!
+//! V8 coverage data does not carry source-map information; the source itself
+//! does, via a `//# sourceMappingURL=` trailer. [`extract_inline_source_map`]
+//! decodes the inline `data:application/json` form and
+//! [`extract_external_source_mapping_url`] reports the trailer URL when it is
+//! not a data URL. Callers can attach the result as `FileCoverage.input_source_map`
+//! and chain through `oxc_coverage_source_maps::remap_coverage` to resolve
+//! positions back to the original source.
+
+use std::collections::BTreeMap;
+
+use oxc_coverage_types::{FileCoverage, Location};
+use serde::{Deserialize, Serialize};
+
+/// A function's coverage data as reported by the V8 inspector.
+///
+/// Serializes to / from the same JSON shape as
+/// [`node:inspector`'s `Profiler.FunctionCoverage`](https://nodejs.org/api/inspector.html)
+/// so callers can hand the V8 inspector's output straight through.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct V8FunctionCoverage {
+    /// Function name as reported by V8 (may be empty for anonymous functions
+    /// or the implicit top-level module function).
+    #[serde(rename = "functionName")]
+    pub function_name: String,
+    /// One or more byte ranges. With `is_block_coverage = false` there is
+    /// exactly one range (the whole function); with `is_block_coverage = true`
+    /// the outermost range covers the function and inner ranges cover blocks.
+    pub ranges: Vec<V8CoverageRange>,
+    /// When true, `ranges` includes block-level subdivisions. When false, the
+    /// only count is at function granularity.
+    #[serde(rename = "isBlockCoverage")]
+    pub is_block_coverage: bool,
+}
+
+/// A single V8 coverage range.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct V8CoverageRange {
+    /// Byte offset of the range start (inclusive) in the V8-visible source.
+    #[serde(rename = "startOffset")]
+    pub start_offset: u32,
+    /// Byte offset of the range end (exclusive).
+    #[serde(rename = "endOffset")]
+    pub end_offset: u32,
+    /// Hit count. Zero means the range was reachable but never executed.
+    pub count: u32,
+}
+
+/// Apply V8 coverage ranges to a pre-built `FileCoverage` by filling in its
+/// statement, function, and branch hit-count vectors.
+///
+/// The caller is responsible for constructing `file_coverage` (typically via
+/// an instrumenter's AST-traversal pass) and supplying `arm_body_byte_spans`
+/// for branches. `arm_body_byte_spans["<branch_id>"][<arm_idx>]` is the
+/// `(start, end)` byte range of the arm body when known, or `(0, 0)` when the
+/// body span is synthetic / unknown (e.g. a synthesized else-arm). See the
+/// `arm_count_for_arm` documentation for how this side-table resolves the
+/// if-arm 0 case that istanbul's whole-IfStatement convention puts at
+/// `locations[0]`.
+///
+/// `wrapper_length` accounts for Node's CJS module wrapper prefix
+/// (`(function(exports,require,module,__filename,__dirname){`). Pass 0 for
+/// ESM.
+pub fn apply_v8_coverage(
+    file_coverage: &mut FileCoverage,
+    source: &str,
+    functions: &[V8FunctionCoverage],
+    wrapper_length: u32,
+    arm_body_byte_spans: &BTreeMap<String, Vec<(u32, u32)>>,
+) {
+    let line_offsets = compute_line_offsets(source);
+    let ranges: Vec<V8CoverageRange> =
+        functions.iter().flat_map(|f| f.ranges.iter().copied()).collect();
+
+    for (id, loc) in &file_coverage.statement_map {
+        let count = count_for_location(source, loc, &line_offsets, &ranges, wrapper_length);
+        if let Some(slot) = file_coverage.s.get_mut(id) {
+            *slot = count;
+        }
+    }
+    for (id, fn_entry) in &file_coverage.fn_map {
+        let count =
+            count_for_location(source, &fn_entry.loc, &line_offsets, &ranges, wrapper_length);
+        if let Some(slot) = file_coverage.f.get_mut(id) {
+            *slot = count;
+        }
+    }
+    let branch_updates: Vec<(String, Vec<u32>)> = file_coverage
+        .branch_map
+        .iter()
+        .map(|(id, branch_entry)| {
+            let body_spans = arm_body_byte_spans.get(id);
+            let arm_counts: Vec<u32> = branch_entry
+                .locations
+                .iter()
+                .enumerate()
+                .map(|(arm_idx, loc)| {
+                    arm_count_for_arm(
+                        source,
+                        loc,
+                        body_spans.and_then(|spans| spans.get(arm_idx).copied()),
+                        &line_offsets,
+                        &ranges,
+                        wrapper_length,
+                    )
+                })
+                .collect();
+            (id.clone(), arm_counts)
+        })
+        .collect();
+    for (id, counts) in branch_updates {
+        if let Some(slot) = file_coverage.b.get_mut(&id) {
+            *slot = counts;
+        }
+    }
+}
+
+/// Pull a trailing `//# sourceMappingURL=<url>` comment from the tail of
+/// `source` and return the URL when it is NOT a `data:` URI. Returns `None`
+/// when no trailer is present or when the trailer is an inline data URL (the
+/// inline form is handled by [`extract_inline_source_map`]).
+#[must_use]
+pub fn extract_external_source_mapping_url(source: &str) -> Option<&str> {
+    const NEEDLE: &str = "//# sourceMappingURL=";
+    let idx = source.rfind(NEEDLE)?;
+    let after = &source[idx + NEEDLE.len()..];
+    let url = after.lines().next()?.trim();
+    if url.is_empty() || url.starts_with("data:") {
+        return None;
+    }
+    Some(url)
+}
+
+/// Pull an inline `//# sourceMappingURL=data:application/json;base64,...`
+/// comment from the tail of `source` and decode the embedded source map.
+///
+/// Only the data-URL form (the dominant case for ESM bundles emitted by Vite,
+/// esbuild, swc, and tsc) is supported here. External URLs are handled via
+/// [`extract_external_source_mapping_url`] + a caller-supplied loader.
+#[must_use]
+pub fn extract_inline_source_map(source: &str) -> Option<serde_json::Value> {
+    const NEEDLE: &str = "//# sourceMappingURL=data:application/json";
+    let idx = source.rfind(NEEDLE)?;
+    let line = source[idx..].lines().next()?;
+
+    let comma = line.find(',')?;
+    let payload = &line[comma + 1..];
+    let is_base64 = line[..comma].contains(";base64");
+    let json = if is_base64 {
+        let bytes = decode_base64(payload).ok()?;
+        String::from_utf8(bytes).ok()?
+    } else {
+        urlencoding_decode(payload).ok()?
+    };
+    serde_json::from_str(&json).ok()
+}
+
+/// Tiny base64 decoder (standard + URL-safe alphabets, no padding required).
+/// Kept in-crate to avoid pulling a base64 dep just for this one site.
+fn decode_base64(input: &str) -> Result<Vec<u8>, ()> {
+    fn value(c: u8) -> Result<u8, ()> {
+        // Accepts both the standard (RFC 4648 §4) and URL-safe (RFC 4648 §5)
+        // alphabets so esbuild-emitted inline maps (which use the URL-safe
+        // alphabet in some output modes) decode without a silent miss.
+        match c {
+            b'A'..=b'Z' => Ok(c - b'A'),
+            b'a'..=b'z' => Ok(c - b'a' + 26),
+            b'0'..=b'9' => Ok(c - b'0' + 52),
+            b'+' | b'-' => Ok(62),
+            b'/' | b'_' => Ok(63),
+            _ => Err(()),
+        }
+    }
+    let trimmed: Vec<u8> =
+        input.bytes().filter(|b| *b != b'=' && !b.is_ascii_whitespace()).collect();
+    let mut out = Vec::with_capacity(trimmed.len() * 3 / 4);
+    for chunk in trimmed.chunks(4) {
+        let n0 = value(chunk[0])?;
+        let n1 = value(chunk[1])?;
+        out.push((n0 << 2) | (n1 >> 4));
+        if let Some(&c2) = chunk.get(2) {
+            let n2 = value(c2)?;
+            out.push((n1 << 4) | (n2 >> 2));
+            if let Some(&c3) = chunk.get(3) {
+                let n3 = value(c3)?;
+                out.push((n2 << 6) | n3);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Decode percent-encoded URL payload for non-base64 inline source maps.
+fn urlencoding_decode(input: &str) -> Result<String, ()> {
+    let mut out = Vec::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16).ok_or(())? as u8;
+            let lo = (bytes[i + 2] as char).to_digit(16).ok_or(())? as u8;
+            out.push((hi << 4) | lo);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).map_err(|_| ())
+}
+
+/// Precompute byte offsets for the start of each line in `source`.
+/// `line_offsets[N]` is the byte offset of the (0-based) Nth line's first
+/// character. `line_offsets.len()` equals the line count plus one (sentinel
+/// at the end of the source so the last line's range is also bounded).
+fn compute_line_offsets(source: &str) -> Vec<u32> {
+    let mut offsets = vec![0u32];
+    for (i, b) in source.bytes().enumerate() {
+        if b == b'\n' {
+            let next = u32::try_from(i + 1).unwrap_or(u32::MAX);
+            offsets.push(next);
+        }
+    }
+    let end = u32::try_from(source.len()).unwrap_or(u32::MAX);
+    offsets.push(end);
+    offsets
+}
+
+/// Byte offset of an Istanbul `(line, column)` inside `source`.
+///
+/// Istanbul columns are UTF-16 code units (Babel + `istanbul-lib-instrument`
+/// convention). srcmap is byte-based. For ASCII the two collapse, but for
+/// non-ASCII source the byte position must be computed by walking the line
+/// and consuming `col_utf16` UTF-16 code units. The walk is bounded by the
+/// `line_offsets` sentinel so a column past end-of-line clamps to end-of-line.
+fn position_to_byte_offset(
+    source: &str,
+    line_1based: u32,
+    col_utf16: u32,
+    line_offsets: &[u32],
+) -> u32 {
+    if line_1based == 0 {
+        return 0;
+    }
+    let line_idx = (line_1based - 1) as usize;
+    if line_idx >= line_offsets.len() - 1 {
+        return *line_offsets.last().unwrap_or(&0);
+    }
+    let line_start = line_offsets[line_idx] as usize;
+    let line_end = line_offsets[line_idx + 1] as usize;
+    let line_bytes = source.get(line_start..line_end).unwrap_or("");
+
+    let mut utf16_remaining = col_utf16;
+    let mut byte_in_line = 0usize;
+    for ch in line_bytes.chars() {
+        if utf16_remaining == 0 {
+            break;
+        }
+        let units = ch.len_utf16() as u32;
+        if units > utf16_remaining {
+            break;
+        }
+        utf16_remaining -= units;
+        byte_in_line += ch.len_utf8();
+    }
+
+    u32::try_from(line_start + byte_in_line).unwrap_or(u32::MAX)
+}
+
+fn count_for_location(
+    source: &str,
+    loc: &Location,
+    line_offsets: &[u32],
+    ranges: &[V8CoverageRange],
+    wrapper_length: u32,
+) -> u32 {
+    let start = position_to_byte_offset(source, loc.start.line, loc.start.column, line_offsets)
+        + wrapper_length;
+    let end = position_to_byte_offset(source, loc.end.line, loc.end.column, line_offsets)
+        + wrapper_length;
+    smallest_containing_range_count(start, end, ranges)
+}
+
+/// Resolve the V8 hit count for a branch arm.
+///
+/// Unlike statements and functions (which can correctly use a containing
+/// scope's count, because being inside an executed function implies the
+/// statement was reachable), branch arms need *arm-level* resolution. V8
+/// block coverage only emits subdivision ranges for `BlockStatement` nodes,
+/// so non-block branch shapes (ternaries, logical-expr right-hand operands,
+/// `default-arg` expressions, switch cases without `{ ... }`) have no V8
+/// range tight to the arm body. Falling back to the enclosing function /
+/// module count there over-reports execution and trips CI coverage
+/// thresholds. The honest answer is 0 ("V8 did not give us per-arm data for
+/// this branch shape").
+///
+/// The 4-byte tolerance covers the typical newline + 2-space indent gap
+/// between istanbul's reported arm location and V8's `BlockStatement` range.
+/// Longer gaps (`else /* comment */ {`) intentionally return 0 because the
+/// match is then ambiguous; under-reporting is preferable to over-reporting.
+///
+/// When multiple V8 ranges fall within tolerance of the same arm (nested
+/// blocks whose `{` characters happen to be close together), the *tightest*
+/// match wins: minimum sum of start-distance + end-distance, ties broken by
+/// the narrower range. V8 emits ranges outermost-first, so a naive
+/// first-match would prefer the enclosing block over the actual arm.
+///
+/// When `body_byte_span` is `Some`, the resolver uses that byte range
+/// directly instead of computing one from `arm_loc`. This is the if-arm 0
+/// path: istanbul's whole-IfStatement convention puts `locations[0]` at the
+/// outer `if (...) ... else ...` span, which V8 does not match; the
+/// collected consequent-body span does match V8's block range and yields
+/// "number of times the predicate evaluated truthy".
+fn arm_count_for_arm(
+    source: &str,
+    arm_loc: &Location,
+    body_byte_span: Option<(u32, u32)>,
+    line_offsets: &[u32],
+    ranges: &[V8CoverageRange],
+    wrapper_length: u32,
+) -> u32 {
+    const TOLERANCE: u32 = 4;
+
+    let (arm_start, arm_end) = match body_byte_span {
+        Some((start, end)) if !(start == 0 && end == 0) => {
+            (start + wrapper_length, end + wrapper_length)
+        }
+        _ => (
+            position_to_byte_offset(source, arm_loc.start.line, arm_loc.start.column, line_offsets)
+                + wrapper_length,
+            position_to_byte_offset(source, arm_loc.end.line, arm_loc.end.column, line_offsets)
+                + wrapper_length,
+        ),
+    };
+
+    let mut best: Option<(V8CoverageRange, u32)> = None;
+    for r in ranges {
+        let dist_start = r.start_offset.abs_diff(arm_start);
+        let dist_end = r.end_offset.abs_diff(arm_end);
+        if dist_start > TOLERANCE || dist_end > TOLERANCE {
+            continue;
+        }
+        let distance = dist_start + dist_end;
+        match best {
+            None => best = Some((*r, distance)),
+            Some((prev, prev_distance)) => {
+                let prev_width = prev.end_offset.saturating_sub(prev.start_offset);
+                let this_width = r.end_offset.saturating_sub(r.start_offset);
+                if distance < prev_distance
+                    || (distance == prev_distance && this_width < prev_width)
+                {
+                    best = Some((*r, distance));
+                }
+            }
+        }
+    }
+    best.map_or(0, |(r, _)| r.count)
+}
+
+/// Pick the count of the smallest V8 range that fully contains `[start, end)`.
+/// Smaller ranges represent inner blocks (with their own counts under
+/// `isBlockCoverage`) and override the outer function-level count.
+///
+/// Both V8 ranges and the statement byte span use the half-open convention
+/// (`endOffset` / `end` are exclusive). The containment predicate is therefore
+/// `r.start <= start && r.end >= end`: a range whose exclusive end is equal
+/// to the statement's exclusive end is the smallest possible exact container.
+fn smallest_containing_range_count(start: u32, end: u32, ranges: &[V8CoverageRange]) -> u32 {
+    let mut best: Option<V8CoverageRange> = None;
+    for r in ranges {
+        if r.start_offset <= start && r.end_offset >= end {
+            let width = r.end_offset.saturating_sub(r.start_offset);
+            match best {
+                None => best = Some(*r),
+                Some(prev) => {
+                    let prev_width = prev.end_offset.saturating_sub(prev.start_offset);
+                    if width < prev_width {
+                        best = Some(*r);
+                    }
+                }
+            }
+        }
+    }
+    best.map_or(0, |r| r.count)
+}


### PR DESCRIPTION
## Summary

PR D of issue #45's umbrella plan. Lifts the V8-coverage-to-Istanbul range intersection logic into its own publishable crate so any Rust JS-coverage tool that produces a \`FileCoverage\` can fill its hit counts from V8 inspector ranges without depending on the Oxc instrumenter.

## What changed

**New crate: \`oxc_coverage_v8\` v0.1.0**
- Types: \`V8FunctionCoverage\`, \`V8CoverageRange\` (serde-compatible with \`node:inspector\` \`Profiler.FunctionCoverage\` so callers can hand the V8 inspector output through directly)
- \`apply_v8_coverage(file_coverage, source, functions, wrapper_length, arm_body_byte_spans)\`: mutates a pre-built \`FileCoverage\` by filling in statement / function / branch hit counts. Infallible.
- \`extract_inline_source_map(source) -> Option<serde_json::Value>\`: decodes inline \`//# sourceMappingURL=data:application/json[;base64],...\` trailers (standard + URL-safe base64; percent-encoded fallback).
- \`extract_external_source_mapping_url(source) -> Option<&str>\`: returns the trailer URL when it is NOT a data URL.
- Depends on \`oxc_coverage_types\` only; zero Oxc / parser deps.

**\`oxc_coverage_instrument\` changes**
- \`v8_to_istanbul.rs\` slims from 472 to 130 lines: keeps the user-facing \`v8_to_istanbul\` / \`v8_to_istanbul_with_loader\` orchestrators and the \`V8ToIstanbulError\` enum. The orchestrators call \`crate::instrument::collect_for_v8_to_istanbul\` to build the FileCoverage + \`arm_body_byte_spans\` side-table, then delegate to \`oxc_coverage_v8::apply_v8_coverage\` for the V8-range intersection, then handle inline / external \`sourceMappingURL\` extraction via the new crate's helpers.
- Re-exports \`V8CoverageRange\` and \`V8FunctionCoverage\` from \`oxc_coverage_v8\` to preserve the existing crate-root public API surface byte-for-byte.

## Why split this way

The AST-traversal step \`collect_for_v8_to_istanbul\` is the instrumenter's responsibility and lives in the instrument crate. Moving the public \`v8_to_istanbul\` function into \`oxc_coverage_v8\` would require that crate to reverse-depend on the instrumenter (cycle). The split at \`apply_v8_coverage\` matches what npm's \`v8-to-istanbul\` actually does internally: parse the source on the caller side, then apply V8 ranges. The new crate is useful standalone for any Rust tool that already has its own coverage-map producer.

**Release workflow (\`release-npm.yml\`)** — topological order:
1. \`oxc_coverage_types\`
2. \`oxc_coverage_source_maps\` + \`oxc_coverage_v8\` (both depend on types)
3. \`oxc_coverage_instrument\` (depends on all three)

## Test plan

Verified locally on macOS:

- [x] \`cargo check --workspace\` (clean)
- [x] \`cargo test --workspace --all-targets\` (no failures; 18 \`test result: ok\` lines)
- [x] \`cargo test --workspace --doc\` (clean: instrument 3, source_maps 1, types 2, v8 0)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` (clean)
- [x] \`cargo fmt --all --check\` (clean)
- [x] \`cargo doc --workspace --no-deps --document-private-items\` with \`RUSTDOCFLAGS=-D warnings\` (clean)
- [x] \`cargo deny check\` (clean)
- [x] \`typos\` (clean)
- [x] napi build --release + \`node test.mjs\` (16/16 pass)
- [x] \`node scripts/istanbul-upstream-specs.mjs\` (8/8 pass)
- [x] \`node scripts/istanbul-diff.mjs\` (27/27 fixtures match)
- [x] \`node scripts/real-world-parity.mjs\` (5/5 libs match)

\`cargo publish -p oxc_coverage_v8 --dry-run\` fails locally because \`oxc_coverage_types\` is not yet on crates.io. Resolves in CI on the next tag push via the topological publish order.

## Suite status after merge

| Crate | Status |
|:--|:--|
| \`oxc_coverage_instrument\` | shipping, depends on types + source_maps + v8 |
| \`oxc_coverage_types\` | ready for first publish |
| \`oxc_coverage_source_maps\` | ready for first publish |
| \`oxc_coverage_v8\` | ready for first publish |
| \`oxc_coverage_report\` / \`oxc_coverage_reports\` | PR E+, not started |

## Out of scope

- Reports + report data model (PR E+) land separately
- Final data-model crate name decision (still pending OJ Kwon coordination)

Refs #45