### PR TITLE
feat(report): html polish layer (PR G2)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,11 +53,11 @@ Coverage suite (umbrella [#45](https://github.com/fallow-rs/oxc-coverage-instrum
   - Source-map remapping via `oxc_coverage_source_maps` so TS / JSX projects show original source
   - Embedded `base.css` (no external assets / CDN deps); dark mode via `prefers-color-scheme`
   - New CLI flag `--output-dir <dir>` for multi-file output (default `coverage/`)
-- [ ] **PR G2**: `html` polish layer
-  - Sortable index-table JS (sort by file name, statements %, branches %, functions %, lines %)
-  - Explicit dark-mode toggle button overriding `prefers-color-scheme`
-  - Prettify syntax highlighting on detail-page source
-  - Corporate-proxy hardening verification (no third-party fetches at runtime)
+- [x] **PR G2**: `html` polish layer
+  - Sortable index-table JS (click or keyboard; `aria-sort` updates; numeric `%` columns sort numerically; tri-state ascending / descending / original)
+  - Explicit auto / light / dark theme toggle, persisted to `localStorage`, overriding `prefers-color-scheme`
+  - Lightweight JS / TS syntax highlighting on detail-page source (tokenizer for keywords, builtins, strings, numbers, comments, punctuation)
+  - Corporate-proxy hardening: strict `Content-Security-Policy` `<meta>` (`default-src 'self'; connect-src 'none'; font-src 'none'; object-src 'none'; ...`) and a test that scans every emitted asset for external URLs
 
 ## Future
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -7,3 +7,7 @@ extend-exclude = [
     "tests/conformance/reference",
     "tests/snapshots",
 ]
+
+[default.extend-words]
+# Local variable for "table header cells" in the HTML reporter's JS.
+ths = "ths"

--- a/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
+++ b/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
@@ -326,9 +326,12 @@ fn report_html_format_writes_directory_tree() {
     assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
     assert!(out_dir.join("index.html").exists(), "root index.html missing");
     assert!(out_dir.join("base.css").exists(), "base.css missing");
+    assert!(out_dir.join("base.js").exists(), "base.js missing");
     assert!(out_dir.join("a.js.html").exists(), "per-file detail page missing");
     let detail = std::fs::read_to_string(out_dir.join("a.js.html")).unwrap();
     assert!(detail.contains("<title>Coverage: a.js</title>"), "got:\n{detail}");
+    assert!(detail.contains("Content-Security-Policy"), "CSP meta missing in CLI output");
+    assert!(detail.contains("base.js"), "script reference missing in CLI output");
 }
 
 #[test]

--- a/crates/oxc-coverage-reports/src/html.rs
+++ b/crates/oxc-coverage-reports/src/html.rs
@@ -1,4 +1,4 @@
-//! HTML reporter (PR G1).
+//! HTML reporter.
 //!
 //! Writes a self-contained directory of HTML pages matching the structure
 //! produced by istanbul-reports' `html` reporter: a root `index.html`, a
@@ -19,19 +19,21 @@
 //! - **No template engine**: hand-rolled string concatenation with
 //!   careful HTML-attribute and HTML-text escaping. Adding handlebars /
 //!   askama for one reporter is not worth the dependency surface.
-//! - **Offline**: all CSS is embedded as a `&'static str` constant and
-//!   copied to `<output_dir>/base.css`. PR G2 will add prettify syntax
-//!   highlighting, sortable table JS, and an explicit dark-mode toggle.
+//! - **Offline / corporate-proxy safe**: CSS and JS are embedded via
+//!   `include_str!` and copied to `<output_dir>/base.css` and
+//!   `<output_dir>/base.js`. Every page also carries a strict
+//!   `Content-Security-Policy` `<meta>` tag (`default-src 'self';
+//!   connect-src 'none'; font-src 'none'; object-src 'none'; ...`) so the
+//!   report makes zero network requests even if served from an HTTP
+//!   origin behind an inspecting proxy.
+//! - **Progressive enhancement**: without JS the report still renders
+//!   correctly; JS adds sortable index tables, an explicit
+//!   auto/light/dark toggle that overrides `prefers-color-scheme`, and
+//!   lightweight syntax highlighting on detail-page source views.
 //! - **Graceful missing-source**: if a file's source cannot be read from
 //!   disk (CI runs without the original tree, remapped path that does
 //!   not exist locally), the detail page shows the coverage statistics
 //!   alongside a `(source unavailable)` placeholder rather than failing.
-//!
-//! The emitter is intentionally not styled with vendor JS or color
-//! pickers in v1; the styling matches istanbul-reports' green / red /
-//! yellow gutter convention via the `prefers-color-scheme` CSS media
-//! query so the report is readable in both light and dark terminals
-//! without an explicit toggle button.
 
 use oxc_coverage_report::{CoverageMap, CoverageSummary, NodeKind, ReportNode, summarize};
 use oxc_coverage_source_maps::remap_coverage_map;
@@ -51,6 +53,29 @@ const DETAIL_SUFFIX: &str = ".html";
 /// Embedded stylesheet copied to `<output_dir>/base.css`.
 const BASE_CSS: &str = include_str!("html/base.css");
 
+/// Embedded enhancement script copied to `<output_dir>/base.js`.
+///
+/// Provides the sortable index tables, the auto / light / dark theme
+/// toggle, and the lightweight JS/TS syntax highlighter. Pure DOM API,
+/// never assigns `innerHTML`, never makes a network request, so the
+/// page stays compatible with the strict CSP emitted by [`render_page`].
+const BASE_JS: &str = include_str!("html/base.js");
+
+/// Strict Content-Security-Policy applied to every emitted page.
+///
+/// - `default-src 'self'`: only same-origin scripts, styles, images.
+/// - `connect-src 'none'`: no `fetch` / `XMLHttpRequest` / `WebSocket`.
+/// - `font-src 'none'`: no web-font fetches (we use system fonts only).
+/// - `object-src 'none'`: no embeds / plugins.
+/// - `base-uri 'self'`: prevents `<base>` tag tampering by injection.
+/// - `form-action 'none'`: no form submissions (we have no forms).
+///
+/// The combined effect is that opening a report in a browser, even one
+/// served from a corporate HTTP proxy, performs zero outbound requests
+/// to anything other than the report's own directory.
+const CSP_POLICY: &str = "default-src 'self'; connect-src 'none'; \
+font-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'";
+
 /// Render a complete HTML coverage report into `output_dir`.
 ///
 /// `coverage_map` may carry `inputSourceMap` entries; they are remapped
@@ -66,6 +91,7 @@ pub fn write(coverage_map: &CoverageMap, root_dir: &Path, output_dir: &Path) -> 
 
     fs::create_dir_all(output_dir)?;
     fs::write(output_dir.join("base.css"), BASE_CSS)?;
+    fs::write(output_dir.join("base.js"), BASE_JS)?;
 
     let ctx = RenderContext { root_dir };
     render_node(&root, &ctx, output_dir, 0)?;
@@ -301,11 +327,19 @@ fn render_source_unavailable(line_hits: &BTreeMap<u32, u32>) -> String {
 
 fn render_page(title: &str, depth: usize, body: &str) -> String {
     let css_href = relative_to_root(depth, "base.css");
+    let js_href = relative_to_root(depth, "base.js");
     let mut out = String::with_capacity(body.len() + 1024);
     out.push_str("<!doctype html>\n<html lang=\"en\">\n<head>\n");
     out.push_str("  <meta charset=\"utf-8\">\n");
+    out.push_str("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    let _ = writeln!(
+        out,
+        "  <meta http-equiv=\"Content-Security-Policy\" content=\"{}\">",
+        html_attr_escape(CSP_POLICY),
+    );
     let _ = writeln!(out, "  <title>Coverage: {}</title>", html_text_escape(title));
     let _ = writeln!(out, "  <link rel=\"stylesheet\" href=\"{}\">", html_attr_escape(&css_href));
+    let _ = writeln!(out, "  <script src=\"{}\" defer></script>", html_attr_escape(&js_href));
     out.push_str("</head>\n<body>\n");
     out.push_str(body);
     out.push_str("</body>\n</html>\n");
@@ -357,7 +391,7 @@ fn render_breadcrumb(node: &ReportNode, depth: usize) -> String {
         } else {
             // Build a relative href that climbs up to that ancestor's index.
             depth_remaining = depth_remaining.saturating_sub(1);
-            let href = relative_to_root_with_extra(depth_remaining, INDEX_FILE);
+            let href = relative_to_root(depth_remaining, INDEX_FILE);
             let _ = write!(
                 out,
                 " / <a href=\"{}\">{}</a>",
@@ -380,10 +414,6 @@ fn relative_to_root(depth: usize, file: &str) -> String {
     }
     out.push_str(file);
     out
-}
-
-fn relative_to_root_with_extra(depth: usize, file: &str) -> String {
-    relative_to_root(depth, file)
 }
 
 // -- Per-file analysis helpers ---------------------------------------------
@@ -591,6 +621,102 @@ mod tests {
                 found.expect("detail file present")
             });
         assert!(detail.contains("line miss"), "expected miss class; got:\n{detail}");
+    }
+
+    #[test]
+    fn writes_base_js_alongside_base_css() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let js = fs::read_to_string(dir.path().join("base.js")).unwrap();
+        // Sanity-check the three feature blocks are present in the emitted JS.
+        assert!(js.contains("Theme toggle"), "base.js missing theme toggle section");
+        assert!(js.contains("Sortable tables"), "base.js missing sortable tables section");
+        assert!(js.contains("Source prettify"), "base.js missing prettify section");
+        // The three feature areas must be wired into the boot path.
+        assert!(js.contains("buildThemeToggle"), "base.js missing theme toggle invocation");
+        assert!(js.contains("initSortable"), "base.js missing sortable init invocation");
+        assert!(js.contains("initPrettify"), "base.js missing prettify init invocation");
+    }
+
+    #[test]
+    fn every_page_carries_csp_and_script_tag() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}},"src/foo.js":{"path":"src/foo.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        for html_path in walkdir(dir.path())
+            .into_iter()
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("html"))
+        {
+            let html = fs::read_to_string(&html_path).unwrap();
+            assert!(html.contains("Content-Security-Policy"), "missing CSP meta in {html_path:?}");
+            assert!(
+                html.contains("connect-src &#39;none&#39;"),
+                "CSP lacks connect-src 'none' in {html_path:?}"
+            );
+            assert!(
+                html.contains("font-src &#39;none&#39;"),
+                "CSP lacks font-src 'none' in {html_path:?}"
+            );
+            assert!(html.contains("<script src="), "missing <script> in {html_path:?}");
+            assert!(html.contains("base.js"), "page does not reference base.js in {html_path:?}");
+            assert!(
+                html.contains(" defer></script>"),
+                "<script> not marked defer in {html_path:?}"
+            );
+            assert!(html.contains("viewport"), "missing viewport meta in {html_path:?}");
+        }
+    }
+
+    #[test]
+    fn nested_pages_use_relative_script_href() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}},"src/foo.js":{"path":"src/foo.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let nested = fs::read_to_string(dir.path().join("src").join("foo.js.html")).unwrap();
+        assert!(nested.contains("src=\"../base.js\""), "nested script href wrong: {nested}");
+        let root = fs::read_to_string(dir.path().join("a.js.html")).unwrap();
+        assert!(root.contains("src=\"base.js\""), "root script href wrong: {root}");
+    }
+
+    #[test]
+    fn emitted_assets_have_no_external_urls() {
+        // Corporate-proxy hardening: the report must not contain any
+        // absolute external URLs in HTML, CSS, or JS. Any future change
+        // that pulls in a CDN dependency must be a deliberate one and
+        // will fail this test.
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}},"src/foo.js":{"path":"src/foo.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let banned = [
+            "http://",
+            "https://",
+            "ws://",
+            "wss://",
+            "//cdn.",
+            "fonts.googleapis",
+            "fonts.gstatic",
+        ];
+        for path in walkdir(dir.path()) {
+            let Ok(text) = fs::read_to_string(&path) else { continue };
+            for needle in banned {
+                assert!(
+                    !text.contains(needle),
+                    "{path:?} contains external reference {needle:?}:\n{text}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn base_css_exposes_theme_override_and_token_classes() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let css = fs::read_to_string(dir.path().join("base.css")).unwrap();
+        assert!(css.contains(":root[data-theme=\"dark\"]"), "missing dark override");
+        assert!(css.contains(":root:not([data-theme=\"light\"])"), "missing light escape hatch");
+        assert!(css.contains(".sortable"), "missing .sortable selector");
+        assert!(css.contains("aria-sort=\"ascending\""), "missing aria-sort hook");
+        for cls in [".tok-k", ".tok-s", ".tok-c", ".tok-n", ".tok-b", ".tok-p"] {
+            assert!(css.contains(cls), "missing token class {cls}");
+        }
+        assert!(css.contains(".theme-toggle__btn"), "missing theme-toggle button class");
     }
 
     fn walkdir(dir: &Path) -> Vec<PathBuf> {

--- a/crates/oxc-coverage-reports/src/html.rs
+++ b/crates/oxc-coverage-reports/src/html.rs
@@ -587,39 +587,30 @@ mod tests {
 
     #[test]
     fn html_special_chars_are_escaped_in_titles_and_breadcrumbs() {
-        let json = r#"{"<scary>.js":{"path":"<scary>.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        // Use '&' as the HTML-special character: it exercises the escaping
+        // path (`&` -> `&amp;`) AND is a valid filename on every platform,
+        // unlike `<` or `>` which Windows path APIs reject.
+        let json = r#"{"a&b.js":{"path":"a&b.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
         let dir = write_to_temp(json);
-        let detail = fs::read_to_string(dir.path().join("<scary>.js.html")).unwrap();
-        assert!(detail.contains("&lt;scary&gt;.js"), "got:\n{detail}");
+        let detail = fs::read_to_string(dir.path().join("a&b.js.html")).unwrap();
+        assert!(detail.contains("a&amp;b.js"), "got:\n{detail}");
     }
 
     #[test]
     fn detail_row_class_marks_misses() {
         // statementMap with one statement on line 1, hit count 0 -> "miss" class
-        // on the source row.
+        // on the source row. The coverage key uses a relative path resolved
+        // against `root_dir` so the same JSON works on every platform; an
+        // absolute Windows path (`C:\\...`) would round-trip through the
+        // report tree as a non-relative folder component, which Windows path
+        // APIs reject.
         let dir = tempfile::TempDir::new().unwrap();
-        let src_path = dir.path().join("a.js");
-        fs::write(&src_path, "const x = 1;\n").unwrap();
-        let json = format!(
-            r#"{{"{path}":{{"path":"{path}","statementMap":{{"0":{{"start":{{"line":1,"column":0}},"end":{{"line":1,"column":12}}}}}},"fnMap":{{}},"branchMap":{{}},"s":{{"0":0}},"f":{{}},"b":{{}}}}}}"#,
-            path = src_path.to_string_lossy().replace('\\', "\\\\"),
-        );
-        let map = parse_coverage_map(&json).unwrap();
+        fs::write(dir.path().join("a.js"), "const x = 1;\n").unwrap();
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":12}}},"fnMap":{},"branchMap":{},"s":{"0":0},"f":{},"b":{}}}"#;
+        let map = parse_coverage_map(json).unwrap();
         let out_dir = dir.path().join("html");
-        write(&map, Path::new(""), &out_dir).unwrap();
-        let file_name = src_path.file_name().unwrap().to_string_lossy().to_string();
-        let detail =
-            fs::read_to_string(out_dir.join(format!("{file_name}.html"))).unwrap_or_else(|_| {
-                // The escape may produce nested paths; fall back to scanning.
-                let mut found = None;
-                for entry in walkdir(&out_dir) {
-                    if entry.ends_with(format!("{file_name}.html")) {
-                        found = Some(fs::read_to_string(entry).unwrap());
-                        break;
-                    }
-                }
-                found.expect("detail file present")
-            });
+        write(&map, dir.path(), &out_dir).unwrap();
+        let detail = fs::read_to_string(out_dir.join("a.js.html")).unwrap();
         assert!(detail.contains("line miss"), "expected miss class; got:\n{detail}");
     }
 

--- a/crates/oxc-coverage-reports/src/html/base.css
+++ b/crates/oxc-coverage-reports/src/html/base.css
@@ -1,12 +1,22 @@
 /* oxc-coverage-instrument HTML reporter base stylesheet.
  *
- * Hand-rolled, single-file, no external font / JS dependencies. Adapts to
- * the system color scheme via prefers-color-scheme. The PR G2 polish layer
- * will add: sortable index table JS, a dark-mode toggle, prettify syntax
- * highlighting, and an explicit high-contrast theme.
+ * Hand-rolled, single-file, no external font / JS dependencies.
+ *
+ * Theme:
+ *   - Default palette is light; `prefers-color-scheme: dark` switches the
+ *     palette automatically.
+ *   - The `data-theme="dark"` / `data-theme="light"` attribute on <html>
+ *     (set by base.js when the user clicks the toggle) overrides the
+ *     media query, so the user choice always wins.
+ *
+ * Syntax highlighting: classes `.tok-k`, `.tok-s`, `.tok-c`, `.tok-n`,
+ * `.tok-b`, `.tok-p` are applied to source spans by base.js. Without JS,
+ * the source still renders in plain monospace text.
  */
 
 :root {
+  color-scheme: light dark;
+
   --bg: #ffffff;
   --text: #1d2129;
   --muted: #66707a;
@@ -24,10 +34,23 @@
   --link: #0366d6;
   --gutter-bg: #f6f8fa;
   --code-bg: #fdfdfd;
+  --focus-ring: #0366d6;
+  --btn-bg: #ffffff;
+  --btn-bg-active: #0366d6;
+  --btn-fg-active: #ffffff;
+
+  --tok-keyword: #cf222e;
+  --tok-string: #0a3069;
+  --tok-comment: #6e7781;
+  --tok-number: #0550ae;
+  --tok-builtin: #8250df;
+  --tok-punct: #57606a;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
     --bg: #14171c;
     --text: #e6e9ef;
     --muted: #9aa2ad;
@@ -45,7 +68,51 @@
     --link: #58a6ff;
     --gutter-bg: #1a1e25;
     --code-bg: #0d1117;
+    --focus-ring: #58a6ff;
+    --btn-bg: #1c2027;
+    --btn-bg-active: #1f6feb;
+    --btn-fg-active: #ffffff;
+
+    --tok-keyword: #ff7b72;
+    --tok-string: #a5d6ff;
+    --tok-comment: #8b949e;
+    --tok-number: #79c0ff;
+    --tok-builtin: #d2a8ff;
+    --tok-punct: #8b949e;
   }
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --bg: #14171c;
+  --text: #e6e9ef;
+  --muted: #9aa2ad;
+  --border: #2a2f37;
+  --header-bg: #1c2027;
+  --hit-bg: #173527;
+  --miss-bg: #3d1a1f;
+  --partial-bg: #3a3220;
+  --pct-high: #6ee787;
+  --pct-medium: #f0b429;
+  --pct-low: #ff7b72;
+  --row-high: #1b2a23;
+  --row-medium: #2b2620;
+  --row-low: #2a1b1f;
+  --link: #58a6ff;
+  --gutter-bg: #1a1e25;
+  --code-bg: #0d1117;
+  --focus-ring: #58a6ff;
+  --btn-bg: #1c2027;
+  --btn-bg-active: #1f6feb;
+  --btn-fg-active: #ffffff;
+
+  --tok-keyword: #ff7b72;
+  --tok-string: #a5d6ff;
+  --tok-comment: #8b949e;
+  --tok-number: #79c0ff;
+  --tok-builtin: #d2a8ff;
+  --tok-punct: #8b949e;
 }
 
 * { box-sizing: border-box; }
@@ -59,11 +126,13 @@ body {
 }
 a { color: var(--link); text-decoration: none; }
 a:hover, a:focus { text-decoration: underline; }
+:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; border-radius: 2px; }
 
 header.summary {
   background: var(--header-bg);
   border-bottom: 1px solid var(--border);
   padding: 16px 24px;
+  position: relative;
 }
 header.summary h1 {
   margin: 0 0 8px 0;
@@ -103,6 +172,35 @@ ul.metrics {
 .metric.medium .pct { color: var(--pct-medium); }
 .metric.low .pct { color: var(--pct-low); }
 
+/* Theme toggle (inserted by base.js into header.summary) */
+.theme-toggle {
+  position: absolute;
+  top: 16px;
+  right: 24px;
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--btn-bg);
+}
+.theme-toggle__btn {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  font: inherit;
+  font-size: 12px;
+  padding: 6px 10px;
+  cursor: pointer;
+  border-right: 1px solid var(--border);
+}
+.theme-toggle__btn:last-child { border-right: 0; }
+.theme-toggle__btn:hover { color: var(--text); }
+.theme-toggle__btn[aria-pressed="true"] {
+  background: var(--btn-bg-active);
+  color: var(--btn-fg-active);
+}
+
 .pad1 { padding: 16px 24px; }
 
 table.coverage-summary {
@@ -125,6 +223,31 @@ table.coverage-summary td.pct.high { color: var(--pct-high); }
 table.coverage-summary td.pct.medium { color: var(--pct-medium); }
 table.coverage-summary td.pct.low { color: var(--pct-low); }
 table.coverage-summary .quiet { color: var(--muted); font-size: 11px; }
+
+/* Sortable column headers (enhanced by base.js; without JS, no .sortable class).
+ * The indicator is an inline ::after sibling glued to the label text so it
+ * stays adjacent regardless of cell alignment. Unicode triangles, no SVGs. */
+table.coverage-summary th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+table.coverage-summary th.sortable:first-child { text-align: left; }
+table.coverage-summary th.sortable::after {
+  content: " \2195"; /* ↕ both-directions, unsorted */
+  margin-left: 4px;
+  font-size: 0.85em;
+  opacity: 0.35;
+  display: inline-block;
+}
+table.coverage-summary th.sortable[aria-sort="ascending"]::after {
+  content: " \25B2"; /* ▲ */
+  opacity: 0.95;
+}
+table.coverage-summary th.sortable[aria-sort="descending"]::after {
+  content: " \25BC"; /* ▼ */
+  opacity: 0.95;
+}
+table.coverage-summary th.sortable:hover { color: var(--text); }
 
 table.source {
   width: 100%;
@@ -176,3 +299,11 @@ table.source .branch-note {
   font-size: 11px;
   color: var(--muted);
 }
+
+/* Syntax highlighting (applied by base.js prettify pass) */
+.tok-k { color: var(--tok-keyword); font-weight: 600; }
+.tok-s { color: var(--tok-string); }
+.tok-c { color: var(--tok-comment); font-style: italic; }
+.tok-n { color: var(--tok-number); }
+.tok-b { color: var(--tok-builtin); }
+.tok-p { color: var(--tok-punct); }

--- a/crates/oxc-coverage-reports/src/html/base.js
+++ b/crates/oxc-coverage-reports/src/html/base.js
@@ -1,0 +1,346 @@
+/* oxc-coverage-instrument HTML reporter, PR G2 polish layer.
+ *
+ * Self-contained, no external dependencies, no network access. Provides:
+ *   1. theme toggle (auto / light / dark, persisted to localStorage),
+ *   2. sortable index tables (click or keyboard, aria-sort updates),
+ *   3. lightweight JS / TS syntax highlighting on detail-page sources.
+ *
+ * The page is fully usable without JS: missing JS just means no sort, no
+ * explicit toggle (prefers-color-scheme still works), and no syntax
+ * highlighting. Every feature is progressive enhancement.
+ *
+ * Note: this script uses DOM methods (createElement / textContent /
+ * appendChild) exclusively. It never assigns HTML strings, so it cannot
+ * introduce XSS even if source files contain hostile characters.
+ */
+(function () {
+  'use strict';
+
+  // ---------- Theme toggle ----------------------------------------------
+  var STORAGE_KEY = 'oxc-coverage-theme';
+
+  function readStoredTheme() {
+    try { return window.localStorage.getItem(STORAGE_KEY); }
+    catch (_e) { return null; }
+  }
+
+  function writeStoredTheme(value) {
+    try {
+      if (value === null) { window.localStorage.removeItem(STORAGE_KEY); }
+      else { window.localStorage.setItem(STORAGE_KEY, value); }
+    } catch (_e) { /* private mode, ignore */ }
+  }
+
+  function applyTheme(value) {
+    var root = document.documentElement;
+    if (value === 'light' || value === 'dark') {
+      root.setAttribute('data-theme', value);
+    } else {
+      root.removeAttribute('data-theme');
+    }
+  }
+
+  // Apply stored theme immediately to avoid a flash of the wrong palette.
+  var storedTheme = readStoredTheme();
+  applyTheme(storedTheme);
+
+  function buildThemeToggle() {
+    var header = document.querySelector('header.summary');
+    if (!header) { return; }
+    var wrap = document.createElement('div');
+    wrap.className = 'theme-toggle';
+    wrap.setAttribute('role', 'group');
+    wrap.setAttribute('aria-label', 'Color theme');
+    var current = storedTheme || 'auto';
+    var options = [
+      ['auto', 'Auto'],
+      ['light', 'Light'],
+      ['dark', 'Dark']
+    ];
+    options.forEach(function (opt) {
+      var value = opt[0];
+      var label = opt[1];
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'theme-toggle__btn';
+      btn.textContent = label;
+      btn.setAttribute('data-theme-value', value);
+      btn.setAttribute('aria-pressed', String(value === current));
+      btn.addEventListener('click', function () {
+        if (value === 'auto') {
+          writeStoredTheme(null);
+          applyTheme(null);
+        } else {
+          writeStoredTheme(value);
+          applyTheme(value);
+        }
+        var buttons = wrap.querySelectorAll('button[data-theme-value]');
+        for (var i = 0; i < buttons.length; i++) {
+          var b = buttons[i];
+          b.setAttribute('aria-pressed',
+            String(b.getAttribute('data-theme-value') === value));
+        }
+      });
+      wrap.appendChild(btn);
+    });
+    header.appendChild(wrap);
+  }
+
+  // ---------- Sortable tables -------------------------------------------
+  function initSortable() {
+    var tables = document.querySelectorAll('table.coverage-summary');
+    for (var t = 0; t < tables.length; t++) {
+      enhanceTable(tables[t]);
+    }
+  }
+
+  function enhanceTable(table) {
+    var thead = table.tHead;
+    var tbody = table.tBodies[0];
+    if (!thead || !tbody) { return; }
+
+    var rows = tbody.rows;
+    for (var r = 0; r < rows.length; r++) {
+      rows[r].setAttribute('data-original-index', String(r));
+    }
+
+    var ths = thead.querySelectorAll('th');
+    for (var i = 0; i < ths.length; i++) {
+      var th = ths[i];
+      // <th> already exposes role="columnheader"; do not overwrite it.
+      // tabindex + a keydown handler give us keyboard activation without
+      // disturbing the table semantics for screen readers.
+      th.classList.add('sortable');
+      th.setAttribute('tabindex', '0');
+      th.setAttribute('aria-sort', 'none');
+      (function (idx, header) {
+        var click = function () { applySort(table, idx, header); };
+        header.addEventListener('click', click);
+        header.addEventListener('keydown', function (ev) {
+          if (ev.key === 'Enter' || ev.key === ' ' || ev.key === 'Spacebar') {
+            ev.preventDefault();
+            click();
+          }
+        });
+      }(i, th));
+    }
+  }
+
+  function applySort(table, colIdx, th) {
+    var thead = table.tHead;
+    var tbody = table.tBodies[0];
+    if (!thead || !tbody) { return; }
+    var rows = Array.prototype.slice.call(tbody.rows);
+    var direction = th.getAttribute('aria-sort');
+    var next;
+    if (direction === 'ascending') { next = 'descending'; }
+    else if (direction === 'descending') { next = 'none'; }
+    else { next = 'ascending'; }
+
+    var ths = thead.querySelectorAll('th');
+    for (var i = 0; i < ths.length; i++) {
+      ths[i].setAttribute('aria-sort', 'none');
+    }
+
+    if (next === 'none') {
+      rows.sort(function (a, b) {
+        return numericAttr(a, 'data-original-index') - numericAttr(b, 'data-original-index');
+      });
+    } else {
+      th.setAttribute('aria-sort', next);
+      var ascending = next === 'ascending';
+      rows.sort(function (a, b) {
+        var av = cellValue(a.cells[colIdx]);
+        var bv = cellValue(b.cells[colIdx]);
+        if (typeof av === 'number' && typeof bv === 'number') {
+          return ascending ? av - bv : bv - av;
+        }
+        var as = String(av).toLowerCase();
+        var bs = String(bv).toLowerCase();
+        if (as < bs) { return ascending ? -1 : 1; }
+        if (as > bs) { return ascending ? 1 : -1; }
+        return 0;
+      });
+    }
+
+    for (var k = 0; k < rows.length; k++) {
+      tbody.appendChild(rows[k]);
+    }
+  }
+
+  function numericAttr(el, name) {
+    var v = parseInt(el.getAttribute(name) || '0', 10);
+    return isNaN(v) ? 0 : v;
+  }
+
+  function cellValue(cell) {
+    if (!cell) { return ''; }
+    var text = cell.textContent || '';
+    var pctMatch = text.match(/(-?\d+(?:\.\d+)?)\s*%/);
+    if (pctMatch) { return parseFloat(pctMatch[1]); }
+    var trimmed = text.trim();
+    if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) { return parseFloat(trimmed); }
+    return trimmed;
+  }
+
+  // ---------- Source prettify -------------------------------------------
+  // Tiny tokenizer covering JS / TS / JSX surface adequate for an
+  // unminified source view. Aims for "GitHub-style readable", not a
+  // full language parser. Emits <span class="tok-*"> nodes via the DOM.
+  var KEYWORDS = (
+    'abstract,any,as,async,await,boolean,break,case,catch,class,const,' +
+    'constructor,continue,debugger,declare,default,delete,do,else,enum,' +
+    'export,extends,false,finally,for,from,function,get,if,implements,' +
+    'import,in,infer,instanceof,interface,is,keyof,let,module,namespace,' +
+    'never,new,null,number,object,of,override,package,private,protected,' +
+    'public,readonly,require,return,satisfies,set,static,string,super,' +
+    'switch,symbol,this,throw,true,try,type,typeof,undefined,unique,unknown,' +
+    'var,void,while,with,yield'
+  ).split(',');
+  var KEYWORD_SET = {};
+  for (var ki = 0; ki < KEYWORDS.length; ki++) { KEYWORD_SET[KEYWORDS[ki]] = true; }
+
+  var BUILTINS = (
+    'Array,ArrayBuffer,Boolean,Buffer,console,DataView,Date,document,Error,' +
+    'EvalError,Function,globalThis,Infinity,Intl,JSON,Map,Math,NaN,' +
+    'Number,Object,process,Promise,Proxy,RangeError,ReferenceError,Reflect,' +
+    'RegExp,Set,String,Symbol,SyntaxError,TypeError,URIError,WeakMap,WeakSet,window'
+  ).split(',');
+  var BUILTIN_SET = {};
+  for (var bi = 0; bi < BUILTINS.length; bi++) { BUILTIN_SET[BUILTINS[bi]] = true; }
+
+  function isIdentStart(ch) {
+    return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch === '_' || ch === '$';
+  }
+  function isIdentCont(ch) {
+    return isIdentStart(ch) || (ch >= '0' && ch <= '9');
+  }
+  function isDigit(ch) { return ch >= '0' && ch <= '9'; }
+  function isHexCont(ch) {
+    return isDigit(ch) || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
+      || ch === '_' || ch === '.';
+  }
+
+  function tokenize(src) {
+    var tokens = [];
+    var i = 0;
+    var n = src.length;
+    while (i < n) {
+      var ch = src.charAt(i);
+
+      // line comment
+      if (ch === '/' && src.charAt(i + 1) === '/') {
+        var j = i + 2;
+        while (j < n && src.charAt(j) !== '\n') { j++; }
+        tokens.push(['c', src.slice(i, j)]);
+        i = j;
+        continue;
+      }
+
+      // block comment
+      if (ch === '/' && src.charAt(i + 1) === '*') {
+        var k = i + 2;
+        while (k + 1 < n && !(src.charAt(k) === '*' && src.charAt(k + 1) === '/')) {
+          k++;
+        }
+        k = k + 1 < n ? k + 2 : n;
+        tokens.push(['c', src.slice(i, k)]);
+        i = k;
+        continue;
+      }
+
+      // string / template
+      if (ch === '"' || ch === '\'' || ch === '`') {
+        var quote = ch;
+        var m = i + 1;
+        while (m < n) {
+          var cc = src.charAt(m);
+          if (cc === '\\' && m + 1 < n) { m += 2; continue; }
+          if (cc === quote) { m++; break; }
+          if (cc === '\n' && quote !== '`') { break; }
+          m++;
+        }
+        tokens.push(['s', src.slice(i, m)]);
+        i = m;
+        continue;
+      }
+
+      // number (decimal / hex / float). Heuristic; good enough.
+      if (isDigit(ch) || (ch === '.' && isDigit(src.charAt(i + 1)))) {
+        var p = i + 1;
+        while (p < n && isHexCont(src.charAt(p))) { p++; }
+        if (p < n && (src.charAt(p) === 'n' || src.charAt(p) === 'e' || src.charAt(p) === 'E')) {
+          p++;
+          if (p < n && (src.charAt(p) === '+' || src.charAt(p) === '-')) { p++; }
+          while (p < n && isDigit(src.charAt(p))) { p++; }
+        }
+        tokens.push(['n', src.slice(i, p)]);
+        i = p;
+        continue;
+      }
+
+      // identifier / keyword / builtin
+      if (isIdentStart(ch)) {
+        var q = i + 1;
+        while (q < n && isIdentCont(src.charAt(q))) { q++; }
+        var word = src.slice(i, q);
+        if (KEYWORD_SET[word]) { tokens.push(['k', word]); }
+        else if (BUILTIN_SET[word]) { tokens.push(['b', word]); }
+        else { tokens.push(['i', word]); }
+        i = q;
+        continue;
+      }
+
+      // punctuation (single char is enough for highlight purposes)
+      if ('+-*/%=<>!&|^~?:,;.(){}[]'.indexOf(ch) !== -1) {
+        tokens.push(['p', ch]);
+        i++;
+        continue;
+      }
+
+      // anything else (whitespace / unicode / etc): pass through plain
+      tokens.push(['t', ch]);
+      i++;
+    }
+    return tokens;
+  }
+
+  function renderTokensInto(pre, tokens) {
+    while (pre.firstChild) { pre.removeChild(pre.firstChild); }
+    for (var i = 0; i < tokens.length; i++) {
+      var kind = tokens[i][0];
+      var text = tokens[i][1];
+      if (kind === 't' || kind === 'i') {
+        pre.appendChild(document.createTextNode(text));
+      } else {
+        var span = document.createElement('span');
+        span.className = 'tok-' + kind;
+        span.textContent = text;
+        pre.appendChild(span);
+      }
+    }
+  }
+
+  function initPrettify() {
+    var pres = document.querySelectorAll('table.source td.src pre');
+    for (var i = 0; i < pres.length; i++) {
+      var pre = pres[i];
+      var text = pre.textContent;
+      if (!text || text === '(source unavailable)') { continue; }
+      renderTokensInto(pre, tokenize(text));
+    }
+  }
+
+  // ---------- Boot ------------------------------------------------------
+  function boot() {
+    buildThemeToggle();
+    initSortable();
+    initPrettify();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+}());

--- a/crates/oxc-coverage-reports/src/lib.rs
+++ b/crates/oxc-coverage-reports/src/lib.rs
@@ -17,8 +17,10 @@
 //! - [`cobertura`]: Cobertura XML consumed by GitLab MR widget, Jenkins,
 //!   Azure DevOps, and Codecov.
 //! - [`html`]: self-contained directory of HTML pages with per-file source
-//!   gutter. Multi-file output (uses [`Format::write_to_dir`]). PR G2 will
-//!   add sortable table JS, a dark-mode toggle, and prettify highlighting.
+//!   gutter. Multi-file output (uses [`Format::write_to_dir`]). Ships
+//!   sortable index tables, an auto/light/dark theme toggle, JS/TS
+//!   syntax highlighting on detail pages, and a strict Content-Security-
+//!   Policy so the report performs zero outbound network requests.
 //!
 //! # Example
 //!

--- a/crates/oxc-coverage-reports/tests/html_smoke.rs
+++ b/crates/oxc-coverage-reports/tests/html_smoke.rs
@@ -17,33 +17,33 @@ use std::path::Path;
 #[test]
 fn renders_actual_source_with_coverage_classes() {
     let dir = tempfile::TempDir::new().unwrap();
-    let src_path = dir.path().join("module.js");
-    fs::write(&src_path, "const x = 1;\nconst y = 2;\nif (x) y;\n").unwrap();
+    // Use a relative path as the coverage key (resolved against root_dir
+    // below). An absolute Windows path (`C:\\...`) would propagate through
+    // the report tree as a non-relative folder component, which Windows
+    // path APIs reject.
+    fs::write(dir.path().join("module.js"), "const x = 1;\nconst y = 2;\nif (x) y;\n").unwrap();
 
     // Statement 0 on line 1 (hit), statement 1 on line 2 (miss), statement 2
     // on line 3 (hit). Branch 0 on line 3, only the truthy arm taken (partial).
-    let coverage = format!(
-        r#"{{"{path}":{{
-            "path":"{path}",
-            "statementMap":{{
-                "0":{{"start":{{"line":1,"column":0}},"end":{{"line":1,"column":12}}}},
-                "1":{{"start":{{"line":2,"column":0}},"end":{{"line":2,"column":12}}}},
-                "2":{{"start":{{"line":3,"column":0}},"end":{{"line":3,"column":9}}}}
-            }},
-            "fnMap":{{}},
-            "branchMap":{{
-                "0":{{"loc":{{"start":{{"line":3,"column":0}},"end":{{"line":3,"column":9}}}},"line":3,"type":"if","locations":[{{"start":{{"line":3,"column":4}},"end":{{"line":3,"column":5}}}},{{"start":{{"line":3,"column":6}},"end":{{"line":3,"column":9}}}}]}}
-            }},
-            "s":{{"0":1,"1":0,"2":1}},
-            "f":{{}},
-            "b":{{"0":[1,0]}}
-        }}}}"#,
-        path = src_path.to_string_lossy().replace('\\', "\\\\"),
-    );
+    let coverage = r#"{"module.js":{
+        "path":"module.js",
+        "statementMap":{
+            "0":{"start":{"line":1,"column":0},"end":{"line":1,"column":12}},
+            "1":{"start":{"line":2,"column":0},"end":{"line":2,"column":12}},
+            "2":{"start":{"line":3,"column":0},"end":{"line":3,"column":9}}
+        },
+        "fnMap":{},
+        "branchMap":{
+            "0":{"loc":{"start":{"line":3,"column":0},"end":{"line":3,"column":9}},"line":3,"type":"if","locations":[{"start":{"line":3,"column":4},"end":{"line":3,"column":5}},{"start":{"line":3,"column":6},"end":{"line":3,"column":9}}]}
+        },
+        "s":{"0":1,"1":0,"2":1},
+        "f":{},
+        "b":{"0":[1,0]}
+    }}"#;
 
-    let map = parse_coverage_map(&coverage).unwrap();
+    let map = parse_coverage_map(coverage).unwrap();
     let out_dir = dir.path().join("html");
-    html::write(&map, Path::new(""), &out_dir).unwrap();
+    html::write(&map, dir.path(), &out_dir).unwrap();
 
     let detail_file = walk_for_filename(&out_dir, "module.js.html").expect("detail page exists");
     let detail = fs::read_to_string(&detail_file).unwrap();


### PR DESCRIPTION
## Summary

- Sortable index tables, Auto/Light/Dark theme toggle, lightweight JS/TS syntax highlighting on detail pages, and corporate-proxy hardening on the `html` reporter. Completes the PR G2 row under v0.5.x in `ROADMAP.md`.
- Vanilla DOM-only `base.js` (no deps, no `innerHTML`). `<th>` keeps its native `columnheader` role; sort is keyboard-activatable via `tabindex` + Enter/Space and updates `aria-sort`. Tri-state sort: ascending / descending / original-order. Numeric `%` columns sort numerically.
- Strict `Content-Security-Policy` `<meta>` tag on every emitted page (`default-src 'self'; connect-src 'none'; font-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'`) plus a Rust test that scans every emitted asset for `http://`, `https://`, `ws://`, `wss://`, and common CDN hostnames. The report makes zero outbound requests when opened from a `file://` URL or an HTTP origin behind an inspecting proxy.

## Notes

- No new runtime dependencies. `base.js` is plain vanilla JS in one IIFE; `base.css` adds `:root[data-theme]` overrides and `.tok-*` token color variables (GitHub-toned, with separate light + dark palettes).
- Two nice-to-haves deferred to a follow-up: deduplicating the dark-mode CSS palette between the `@media (prefers-color-scheme: dark)` block and the `[data-theme="dark"]` block, and a regex-literal heuristic in the tokenizer.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (existing tests plus new unit and CLI coverage for base.js, CSP, no-external-URL, theme-override CSS, syntax-token classes)
- [x] `cargo doc` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo deny check`
- [x] Manual visual sweep of generated report (root index light/dark/sorted, folder index, file detail with hit/miss/partial lines, system prefers-color-scheme=dark with Auto theme)

Refs #45.