### PR TITLE
feat(report): fallow Mode B visual pass (PR G4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,6 +64,14 @@ Coverage suite (umbrella [#45](https://github.com/fallow-rs/oxc-coverage-instrum
   - `rayon` parallelism on per-file render (`children.par_iter()`); 100-file / 200-LOC project emits in under 2 s on a typical laptop
   - New `html` Cargo feature (default-enabled) gates `syntect` + `two-face` + `rayon` so downstream consumers that only want text / lcov / cobertura / json-summary can drop the grammar payload via `default-features = false`
   - `~+2.2 MiB` binary delta for the bundled grammar set; acceptable for a CI-class tool
+- [x] **PR G4**: fallow "Mode B" visual pass
+  - New `coverage-tokens.css` vendored from fallow-cloud's design system (Radix Sand palette, severity stops, type ramp, font stacks). Light-default per Mode B; dark via explicit `data-theme="dark"` OR `prefers-color-scheme: dark` + no override
+  - KPI metric pills with `[ Statements ]` bracket labels and severity-coloured values; per-row mini coverage meter on the Lines column (1px outline, severity fill, `role="meter"`); breadcrumb as semantic `<ol><li>` with `aria-current="page"`
+  - Filter input on index pages with proper `<label>`, debounced match, `role="status"` live count, `/` keyboard shortcut guarded against `activeElement` so screen-reader browse mode is preserved
+  - Line anchors as `<button>` per source row; `id="L<n>"` on each `<tr>` and per-line `aria-label`; clicking copies the canonical URL via the clipboard API with a polite-live `copy-toast`
+  - "Next uncovered" ghost button (fallow brutalist offset shadow) that cycles `tr.line.miss` / `tr.line.partial` in document order and focuses the inner anchor
+  - `[H]` / `[P]` / `[M]` non-color severity glyphs in the gutter + 2px luminance left-borders on coverage rows (WCAG 1.4.1 non-color cue), with `aria-hidden` on the glyph (the row's `aria-label` carries the semantics)
+  - `<meta name="generator">` version stamp on every page; sticky table header; `:focus-within` row highlight so keyboard parity with mouse hover; `prefers-reduced-motion` guards on every new transition
 
 ## Future
 

--- a/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
+++ b/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
@@ -327,11 +327,16 @@ fn report_html_format_writes_directory_tree() {
     assert!(out_dir.join("index.html").exists(), "root index.html missing");
     assert!(out_dir.join("base.css").exists(), "base.css missing");
     assert!(out_dir.join("base.js").exists(), "base.js missing");
+    // base.css `@import`s coverage-tokens.css: dropping the sibling file
+    // would silently break the palette without any compile-time signal,
+    // so guard it at the CLI integration layer too.
+    assert!(out_dir.join("coverage-tokens.css").exists(), "coverage-tokens.css missing");
     assert!(out_dir.join("a.js.html").exists(), "per-file detail page missing");
     let detail = std::fs::read_to_string(out_dir.join("a.js.html")).unwrap();
     assert!(detail.contains("<title>Coverage: a.js</title>"), "got:\n{detail}");
     assert!(detail.contains("Content-Security-Policy"), "CSP meta missing in CLI output");
     assert!(detail.contains("base.js"), "script reference missing in CLI output");
+    assert!(detail.contains("<meta name=\"generator\""), "generator meta missing in CLI output");
 }
 
 #[test]

--- a/crates/oxc-coverage-reports/src/html/base.css
+++ b/crates/oxc-coverage-reports/src/html/base.css
@@ -1,153 +1,147 @@
 /* oxc-coverage-instrument HTML reporter base stylesheet.
  *
- * Hand-rolled, single-file, no external font / JS dependencies.
+ * Renders the static coverage report in fallow's "Mode B" (stakeholder
+ * artifact) visual language. The token layer lives in a sibling file,
+ * `coverage-tokens.css`, which is `@import`-ed at the top so the same
+ * palette can be vendored into fallow-cloud (or anywhere else) without
+ * touching the structural rules below.
  *
- * Theme:
- *   - Default palette is light; `prefers-color-scheme: dark` switches the
- *     palette automatically.
- *   - The `data-theme="dark"` / `data-theme="light"` attribute on <html>
- *     (set by base.js when the user clicks the toggle) overrides the
- *     media query, so the user choice always wins.
- *
- * Syntax highlighting: classes `.tok-k`, `.tok-s`, `.tok-c`, `.tok-n`,
- * `.tok-b`, `.tok-p` are applied to source spans by base.js. Without JS,
- * the source still renders in plain monospace text.
+ * Hard constraints: file://-portable, strict CSP (no web fonts, no
+ * external assets), no JS required for the visual layer (sortable +
+ * filter + line-anchor are progressive enhancement on top).
  */
+@import url("coverage-tokens.css");
 
-:root {
-  color-scheme: light dark;
+/* ---- Base + reset ----------------------------------------------------- */
+*,
+*::before,
+*::after { box-sizing: border-box; }
 
-  --bg: #ffffff;
-  --text: #1d2129;
-  --muted: #66707a;
-  --border: #e3e6ea;
-  --header-bg: #f5f6f8;
-  --hit-bg: #e6ffed;
-  --miss-bg: #ffeef0;
-  --partial-bg: #fff8c5;
-  --pct-high: #1f8b3a;
-  --pct-medium: #b08800;
-  --pct-low: #c1271d;
-  --row-high: #e6f4ea;
-  --row-medium: #fff8c5;
-  --row-low: #ffeef0;
-  --link: #0366d6;
-  --gutter-bg: #f6f8fa;
-  --code-bg: #fdfdfd;
-  --focus-ring: #0366d6;
-  --btn-bg: #ffffff;
-  --btn-bg-active: #0366d6;
-  --btn-fg-active: #ffffff;
+html,
+body { margin: 0; padding: 0; }
 
-  --tok-keyword: #cf222e;
-  --tok-string: #0a3069;
-  --tok-comment: #6e7781;
-  --tok-number: #0550ae;
-  --tok-builtin: #8250df;
-  --tok-punct: #57606a;
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    color-scheme: dark;
-
-    --bg: #14171c;
-    --text: #e6e9ef;
-    --muted: #9aa2ad;
-    --border: #2a2f37;
-    --header-bg: #1c2027;
-    --hit-bg: #173527;
-    --miss-bg: #3d1a1f;
-    --partial-bg: #3a3220;
-    --pct-high: #6ee787;
-    --pct-medium: #f0b429;
-    --pct-low: #ff7b72;
-    --row-high: #1b2a23;
-    --row-medium: #2b2620;
-    --row-low: #2a1b1f;
-    --link: #58a6ff;
-    --gutter-bg: #1a1e25;
-    --code-bg: #0d1117;
-    --focus-ring: #58a6ff;
-    --btn-bg: #1c2027;
-    --btn-bg-active: #1f6feb;
-    --btn-fg-active: #ffffff;
-
-    --tok-keyword: #ff7b72;
-    --tok-string: #a5d6ff;
-    --tok-comment: #8b949e;
-    --tok-number: #79c0ff;
-    --tok-builtin: #d2a8ff;
-    --tok-punct: #8b949e;
-  }
-}
-
-:root[data-theme="dark"] {
-  color-scheme: dark;
-
-  --bg: #14171c;
-  --text: #e6e9ef;
-  --muted: #9aa2ad;
-  --border: #2a2f37;
-  --header-bg: #1c2027;
-  --hit-bg: #173527;
-  --miss-bg: #3d1a1f;
-  --partial-bg: #3a3220;
-  --pct-high: #6ee787;
-  --pct-medium: #f0b429;
-  --pct-low: #ff7b72;
-  --row-high: #1b2a23;
-  --row-medium: #2b2620;
-  --row-low: #2a1b1f;
-  --link: #58a6ff;
-  --gutter-bg: #1a1e25;
-  --code-bg: #0d1117;
-  --focus-ring: #58a6ff;
-  --btn-bg: #1c2027;
-  --btn-bg-active: #1f6feb;
-  --btn-fg-active: #ffffff;
-
-  --tok-keyword: #ff7b72;
-  --tok-string: #a5d6ff;
-  --tok-comment: #8b949e;
-  --tok-number: #79c0ff;
-  --tok-builtin: #d2a8ff;
-  --tok-punct: #8b949e;
-}
-
-* { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; }
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  font-size: 14px;
-  line-height: 1.5;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  min-height: 100vh;
 }
-a { color: var(--link); text-decoration: none; }
-a:hover, a:focus { text-decoration: underline; }
-:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; border-radius: 2px; }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-heading);
+  color: var(--text-high);
+  line-height: var(--leading-tight);
+  margin: 0 0 0.5em;
+}
+h1 { font-size: var(--text-2xl); font-weight: 700; letter-spacing: var(--tracking-display); }
+h2 { font-size: var(--text-xl); font-weight: 700; }
+h3 { font-size: var(--text-lg); font-weight: 600; }
+
+a { color: var(--link); text-decoration: none; }
+a:hover,
+a:focus-visible { text-decoration: underline; }
+
+:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+::selection {
+  background-color: var(--blue-subtle);
+  color: var(--text-high);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Visually-hidden helper (for screen-reader-only labels) */
+.sr-only {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- Page header (h1 + breadcrumb + KPI row + theme toggle) ---------- */
 header.summary {
   background: var(--header-bg);
   border-bottom: 1px solid var(--border);
-  padding: 16px 24px;
+  padding: 24px 32px 20px;
   position: relative;
 }
 header.summary h1 {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  letter-spacing: var(--tracking-display);
   margin: 0 0 8px 0;
-  font-size: 20px;
-  font-weight: 600;
 }
-.breadcrumb {
-  font-size: 12px;
-  color: var(--muted);
-  margin-bottom: 12px;
-}
-.breadcrumb a { color: var(--link); }
-.breadcrumb .current { color: var(--text); font-weight: 500; }
 
-ul.metrics {
+/* Breadcrumb: <nav><ol><li>...</li></ol></nav> (a11y: aria-label="Breadcrumb",
+ * aria-current="page" on the last <span>). */
+.breadcrumb {
+  font-size: var(--text-xs);
+  color: var(--muted);
+  margin-bottom: 16px;
+}
+.breadcrumb ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.breadcrumb li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.breadcrumb a { color: var(--muted); }
+.breadcrumb a:hover { color: var(--text); text-decoration: underline; }
+.breadcrumb .current { color: var(--text); font-weight: 500; }
+.breadcrumb-sep {
+  color: var(--text-muted);
+  user-select: none;
+}
+
+/* Threshold summary sentence ("X of Y files below 80%"). Below the
+ * KPI row, before the table. Plain Inter, low-weight, muted. */
+.threshold-summary {
+  font-size: var(--text-sm);
+  color: var(--muted);
+  margin: 8px 0 0;
+}
+.threshold-summary strong { color: var(--text); font-weight: 600; }
+
+/* KPI metric pills (Statements / Branches / Functions / Lines) */
+.kpi-row {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -155,32 +149,52 @@ ul.metrics {
   flex-wrap: wrap;
   gap: 12px;
 }
-.metric {
-  background: var(--bg);
+.kpi-cell {
+  flex: 1 1 0;
+  min-width: 144px;
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 10px 14px;
-  min-width: 140px;
+  background: var(--bg);
+  padding: 12px 16px;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
-.metric .label { font-size: 11px; text-transform: uppercase; color: var(--muted); letter-spacing: 0.04em; }
-.metric .pct { font-size: 22px; font-weight: 700; }
-.metric .quiet { font-size: 12px; color: var(--muted); }
-.metric.high .pct { color: var(--pct-high); }
-.metric.medium .pct { color: var(--pct-medium); }
-.metric.low .pct { color: var(--pct-low); }
+.kpi-cell__label {
+  font-family: var(--font-code);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
+  color: var(--muted);
+  white-space: nowrap;
+}
+/* The default text colour for the value is the neutral text token, not
+ * a severity colour. Every metric pill must carry an explicit
+ * `kpi-cell--{high,medium,low}` modifier; a missing modifier renders
+ * neutral rather than silently green. */
+.kpi-cell__value {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: var(--tracking-display);
+  color: var(--text);
+}
+.kpi-cell--high .kpi-cell__value { color: var(--pct-high); }
+.kpi-cell--medium .kpi-cell__value { color: var(--pct-medium); }
+.kpi-cell--low .kpi-cell__value { color: var(--pct-low); }
+.kpi-cell__sub {
+  font-family: var(--font-code);
+  font-size: var(--text-xs);
+  color: var(--muted);
+}
 
-/* Theme toggle (inserted by base.js into header.summary) */
+/* Theme toggle (top-right of header.summary) */
 .theme-toggle {
   position: absolute;
-  top: 16px;
-  right: 24px;
+  top: 24px;
+  right: 32px;
   display: inline-flex;
   border: 1px solid var(--border);
-  border-radius: 6px;
-  overflow: hidden;
   background: var(--btn-bg);
 }
 .theme-toggle__btn {
@@ -189,10 +203,12 @@ ul.metrics {
   border: 0;
   color: var(--muted);
   font: inherit;
-  font-size: 12px;
-  padding: 6px 10px;
+  font-family: var(--font-code);
+  font-size: var(--text-xs);
+  padding: 6px 12px;
   cursor: pointer;
   border-right: 1px solid var(--border);
+  transition: color 100ms ease-out, background-color 100ms ease-out;
 }
 .theme-toggle__btn:last-child { border-right: 0; }
 .theme-toggle__btn:hover { color: var(--text); }
@@ -201,59 +217,187 @@ ul.metrics {
   color: var(--btn-fg-active);
 }
 
-.pad1 { padding: 16px 24px; }
+/* Ghost button (used by "Next uncovered" and any future action buttons).
+ * Carries fallow's brutalist offset shadow per the design-system token. */
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  background: var(--btn-bg);
+  color: var(--text);
+  font-family: var(--font-code);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  height: 32px;
+  padding: 0 14px;
+  cursor: pointer;
+  text-decoration: none;
+  box-shadow: var(--shadow-button-ghost);
+  transition: box-shadow 100ms ease-out, background-color 100ms ease-out;
+}
+.btn-ghost:hover:not(:disabled) {
+  background: var(--surface-2);
+  box-shadow: var(--shadow-button-ghost-hover);
+}
+.btn-ghost:active:not(:disabled) { box-shadow: var(--shadow-button-ghost-active); }
+.btn-ghost:disabled { opacity: 0.45; cursor: not-allowed; box-shadow: none; }
+@media (prefers-reduced-motion: reduce) {
+  .btn-ghost { transition: none; }
+}
 
+/* ---- Filter (index pages) -------------------------------------------- */
+.pad1 { padding: 24px 32px; }
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+  max-width: 480px;
+}
+.filter-group__label {
+  font-family: var(--font-code);
+  font-size: var(--text-xs);
+  color: var(--muted);
+}
+.filter-input {
+  display: block;
+  width: 100%;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--font-code);
+  font-size: var(--text-sm);
+  line-height: 1.3;
+  color: var(--text);
+  padding: 8px 12px;
+  transition: border-color 100ms ease-out, box-shadow 100ms ease-out;
+}
+.filter-input::placeholder { color: var(--muted); }
+.filter-input:hover:not(:focus) { border-color: var(--border-strong); }
+.filter-input:focus {
+  outline: none;
+  border-color: var(--blue-text);
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--blue-text);
+}
+.filter-count {
+  font-family: var(--font-code);
+  font-size: var(--text-xs);
+  color: var(--muted);
+  min-height: 1em;
+}
+@media (prefers-reduced-motion: reduce) {
+  .filter-input { transition: none; }
+}
+
+/* ---- Index summary table --------------------------------------------- */
 table.coverage-summary {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: var(--text-sm);
+}
+table.coverage-summary thead {
+  position: sticky;
+  top: 0;
+  background: var(--header-bg);
+  z-index: 1;
 }
 table.coverage-summary th,
 table.coverage-summary td {
   text-align: right;
-  padding: 6px 12px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--border);
 }
-table.coverage-summary th { font-weight: 600; color: var(--muted); }
+table.coverage-summary th {
+  font-family: var(--font-code);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
+  color: var(--muted);
+}
+table.coverage-summary tbody tr:hover { background: var(--surface-2); }
 table.coverage-summary td.file { text-align: left; }
+table.coverage-summary td.file a { color: var(--link); }
 table.coverage-summary tr.row-high { background: var(--row-high); }
 table.coverage-summary tr.row-medium { background: var(--row-medium); }
 table.coverage-summary tr.row-low { background: var(--row-low); }
 table.coverage-summary td.pct.high { color: var(--pct-high); }
 table.coverage-summary td.pct.medium { color: var(--pct-medium); }
 table.coverage-summary td.pct.low { color: var(--pct-low); }
-table.coverage-summary .quiet { color: var(--muted); font-size: 11px; }
+table.coverage-summary .quiet {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  font-family: var(--font-code);
+}
 
-/* Sortable column headers (enhanced by base.js; without JS, no .sortable class).
- * The indicator is an inline ::after sibling glued to the label text so it
- * stays adjacent regardless of cell alignment. Unicode triangles, no SVGs. */
+/* Sortable column headers: progressive enhancement, .sortable class
+ * added by base.js. Inline ::after Unicode arrows keep the indicator
+ * adjacent to the label regardless of cell alignment. */
 table.coverage-summary th.sortable {
   cursor: pointer;
   user-select: none;
 }
 table.coverage-summary th.sortable:first-child { text-align: left; }
 table.coverage-summary th.sortable::after {
-  content: " \2195"; /* ↕ both-directions, unsorted */
+  content: " \2195";
   margin-left: 4px;
   font-size: 0.85em;
   opacity: 0.35;
   display: inline-block;
 }
 table.coverage-summary th.sortable[aria-sort="ascending"]::after {
-  content: " \25B2"; /* ▲ */
+  content: " \25B2";
   opacity: 0.95;
 }
 table.coverage-summary th.sortable[aria-sort="descending"]::after {
-  content: " \25BC"; /* ▼ */
+  content: " \25BC";
   opacity: 0.95;
 }
 table.coverage-summary th.sortable:hover { color: var(--text); }
+table.coverage-summary th.sortable:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
 
+/* Mini coverage meter inline in the index table. Track + severity fill,
+ * 1px outline, 0 radius (fallow Meter pattern). */
+.cov-meter {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 6px;
+  margin-left: 8px;
+  vertical-align: middle;
+  background: var(--gutter-bg);
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+.cov-meter__fill {
+  display: block;
+  height: 100%;
+  background: var(--hit-solid);
+}
+.cov-meter--medium .cov-meter__fill { background: var(--partial-solid); }
+.cov-meter--low .cov-meter__fill { background: var(--miss-solid); }
+
+/* ---- Detail page: action header (Next uncovered + back) -------------- */
+.detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+/* ---- Detail page source table ---------------------------------------- */
 table.source {
   width: 100%;
   border-collapse: collapse;
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 13px;
+  font-family: var(--font-code);
+  font-size: var(--text-sm);
+  line-height: 1.5;
   background: var(--code-bg);
 }
 table.source th,
@@ -263,49 +407,118 @@ table.source td {
 }
 table.source thead {
   background: var(--header-bg);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  font-weight: 600;
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: 500;
   color: var(--muted);
-  font-size: 11px;
   text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
 }
-table.source th { text-align: left; padding: 6px 12px; border-bottom: 1px solid var(--border); }
+table.source th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* Gutter cells (line-num + hits + severity glyph) */
 table.source td.line-num {
   text-align: right;
   background: var(--gutter-bg);
   color: var(--muted);
-  width: 56px;
+  width: 64px;
   user-select: none;
+  border-left: 2px solid transparent;
+  position: relative;
 }
 table.source td.hits {
   text-align: right;
-  color: var(--muted);
-  width: 64px;
   background: var(--gutter-bg);
+  color: var(--muted);
+  width: 80px;
   user-select: none;
+  font-size: var(--text-xs);
 }
 table.source td.src pre {
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* Line anchor button: appears inside td.line-num. Renders the line
+ * number as a clickable button that copies #L<n> to the URL hash and
+ * the clipboard. Falls back to plain text without JS. */
+.line-anchor {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+.line-anchor:hover { color: var(--text); text-decoration: underline; }
+.line-anchor:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Coverage row backgrounds + 2px left luminance bar.
+ * The luminance values are chosen so all three are distinguishable
+ * under grayscale (WCAG 1.4.1 non-color cue). */
 table.source tr.line.hit { background: var(--hit-bg); }
 table.source tr.line.miss { background: var(--miss-bg); }
 table.source tr.line.partial { background: var(--partial-bg); }
 table.source tr.line.no-stmt { background: var(--code-bg); }
+
+table.source tr.line.hit > td.line-num { border-left-color: var(--hit-solid); }
+table.source tr.line.miss > td.line-num { border-left-color: var(--miss-solid); }
+table.source tr.line.partial > td.line-num { border-left-color: var(--partial-solid); }
+
+/* Keyboard parity with mouse hover: any row containing keyboard focus
+ * gets the same emphasis a hover would give. */
+table.source tr.line:hover,
+table.source tr.line:focus-within {
+  filter: brightness(0.98);
+}
+
+/* Anchor target (when navigating to #L42) */
+table.source tr.line:target {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+  scroll-margin-top: 80px;
+}
+
+/* Branch note appended after partial lines */
 table.source .branch-note {
   display: inline-block;
   margin-left: 8px;
-  font-size: 11px;
+  font-size: var(--text-xs);
+  font-family: var(--font-body);
   color: var(--muted);
 }
 
-/* Syntax highlighting, applied to syntect-rendered spans on detail
- * pages. Classes use the `stok-` prefix (server-side syntect emits
- * them via ClassStyle::SpacedPrefixed) so they cannot collide with
- * coverage row classes. Selectors match the leading TextMate scope
- * segment; trailing segments (e.g. `stok-double-slash`, `stok-quoted`)
- * are kept in markup for finer theming in G4 but ignored here. */
+/* Severity glyph (`[H]`/`[P]`/`[M]`) placed in the hits cell so it sits
+ * alongside the per-line hit count and acts as a non-color coverage cue
+ * for users with deuteranopia/protanopia. aria-hidden in markup; the
+ * row's aria-label conveys the same information to screen readers. */
+.sev-glyph {
+  display: inline-block;
+  font-family: var(--font-code);
+  font-weight: 700;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  margin-right: 6px;
+}
+.sev-glyph--hit { color: var(--hit-solid); }
+.sev-glyph--partial { color: var(--partial-solid); }
+.sev-glyph--miss { color: var(--miss-solid); }
+
+/* ---- Syntax-highlighting tokens (consumed by syntect-emitted spans) -- */
+/* Selectors target the leading TextMate scope segment that syntect
+ * emits via ClassStyle::SpacedPrefixed { prefix: "stok-" }. Trailing
+ * scope-tail classes (e.g. `stok-double-slash`) are kept in markup for
+ * finer theming but unused here. */
 .stok-comment { color: var(--tok-comment); font-style: italic; }
 .stok-keyword { color: var(--tok-keyword); font-weight: 600; }
 .stok-storage { color: var(--tok-keyword); font-weight: 600; }
@@ -315,3 +528,24 @@ table.source .branch-note {
 .stok-entity { color: var(--tok-builtin); }
 .stok-variable.stok-language { color: var(--tok-keyword); }
 .stok-punctuation { color: var(--tok-punct); }
+
+/* ---- Copy-toast live region for the line-anchor confirmation -------- */
+.copy-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface-3);
+  color: var(--text);
+  border: 1px solid var(--border);
+  font-family: var(--font-code);
+  font-size: var(--text-xs);
+  padding: 8px 12px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease-out;
+}
+.copy-toast.visible { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .copy-toast { transition: none; }
+}

--- a/crates/oxc-coverage-reports/src/html/base.js
+++ b/crates/oxc-coverage-reports/src/html/base.js
@@ -261,7 +261,8 @@
 
   // ---------- Line anchors (detail pages) -------------------------------
   // Hooks: <button class="line-anchor" data-line="42"> inside td.line-num,
-  // + <div id="cov-copy-toast" role="status" aria-live="polite">.
+  // + <div id="cov-copy-toast" role="status">. (role="status" implies
+  // aria-live="polite" per the WAI-ARIA spec, no need to declare both.)
   // Clicking the button: scrolls to the row via hash, copies the
   // canonical link to the clipboard, flashes a toast.
   function initLineAnchors() {

--- a/crates/oxc-coverage-reports/src/html/base.js
+++ b/crates/oxc-coverage-reports/src/html/base.js
@@ -190,10 +190,164 @@
   // there is no client-side tokenizer here. The detail-page <pre> cells
   // arrive with `<span class="stok-...">` markup already in the HTML.
 
+  // ---------- File filter (index pages) ---------------------------------
+  // Hooks: <input id="cov-filter"> + <div id="cov-filter-count"> +
+  // <table id="cov-file-table">. Each tbody row carries data-file="..."
+  // populated by the Rust render. Without JS the input is inert and the
+  // count region stays empty; the table is fully usable.
+  function initFilter() {
+    var input = document.getElementById('cov-filter');
+    var table = document.getElementById('cov-file-table');
+    var count = document.getElementById('cov-filter-count');
+    if (!input || !table) { return; }
+    var tbody = table.tBodies[0];
+    if (!tbody) { return; }
+    var rows = Array.prototype.slice.call(tbody.rows);
+    var total = rows.length;
+    if (count && count.getAttribute('data-total')) {
+      total = parseInt(count.getAttribute('data-total'), 10) || total;
+    }
+
+    var debounceHandle = 0;
+    function applyFilter() {
+      var q = input.value.trim().toLowerCase();
+      var shown = 0;
+      for (var i = 0; i < rows.length; i++) {
+        var r = rows[i];
+        var name = (r.getAttribute('data-file') || '').toLowerCase();
+        var match = q === '' || name.indexOf(q) !== -1;
+        r.style.display = match ? '' : 'none';
+        if (match) { shown++; }
+      }
+      if (count) {
+        if (q === '') {
+          count.textContent = '';
+        } else {
+          count.textContent = shown + ' of ' + total + ' files match';
+        }
+      }
+    }
+    input.addEventListener('input', function () {
+      if (debounceHandle) { clearTimeout(debounceHandle); }
+      debounceHandle = setTimeout(applyFilter, 80);
+    });
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        input.value = '';
+        applyFilter();
+      }
+    });
+
+    // Power-user shortcut: pressing `/` anywhere in the page (when not
+    // already inside a form field) focuses the filter input. Guarded
+    // against active form fields to avoid stealing focus from a user
+    // typing into another input, and against contentEditable to avoid
+    // intercepting normal text entry. Browse-mode screen-reader users
+    // still see `/` as a "find in page" gesture because we only act
+    // when the activeElement is the body itself.
+    document.addEventListener('keydown', function (e) {
+      if (e.key !== '/' || e.ctrlKey || e.metaKey || e.altKey) { return; }
+      var ae = document.activeElement;
+      if (ae && ae !== document.body) {
+        var tag = ae.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') { return; }
+        if (ae.isContentEditable) { return; }
+      }
+      e.preventDefault();
+      input.focus();
+      input.select();
+    });
+  }
+
+  // ---------- Line anchors (detail pages) -------------------------------
+  // Hooks: <button class="line-anchor" data-line="42"> inside td.line-num,
+  // + <div id="cov-copy-toast" role="status" aria-live="polite">.
+  // Clicking the button: scrolls to the row via hash, copies the
+  // canonical link to the clipboard, flashes a toast.
+  function initLineAnchors() {
+    var anchors = document.querySelectorAll('button.line-anchor[data-line]');
+    if (anchors.length === 0) { return; }
+    var toast = document.getElementById('cov-copy-toast');
+    var toastTimer = 0;
+
+    function flashToast(message) {
+      if (!toast) { return; }
+      // The screen-reader announcement is triggered by the textContent
+      // assignment below, not by the `visible` class toggle. The class
+      // controls only the visual fade-in; do not switch to display:none
+      // for the hide step or the live-region observer will detach.
+      toast.textContent = message;
+      toast.classList.add('visible');
+      if (toastTimer) { clearTimeout(toastTimer); }
+      toastTimer = setTimeout(function () {
+        toast.classList.remove('visible');
+        toast.textContent = '';
+      }, 1500);
+    }
+
+    function copyAndAnchor(line) {
+      var hash = '#L' + line;
+      history.replaceState(null, '', hash);
+      var url = location.href;
+      var ok = false;
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(url).then(function () {
+          flashToast('Link to line ' + line + ' copied');
+        }).catch(function () {
+          flashToast('Linked to line ' + line);
+        });
+        ok = true;
+      }
+      if (!ok) {
+        // Older browsers / file:// origins where clipboard API is
+        // unavailable: still anchor the URL so the user can copy it
+        // from the address bar.
+        flashToast('Linked to line ' + line);
+      }
+    }
+
+    anchors.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var line = btn.getAttribute('data-line');
+        if (line) { copyAndAnchor(line); }
+      });
+    });
+  }
+
+  // ---------- "Next uncovered" jump button ------------------------------
+  // Hook: <button id="cov-next-uncovered">. Cycles through
+  // tr.line.miss and tr.line.partial in document order; wraps at end.
+  // Disabled when the page has no uncovered rows.
+  function initNextUncovered() {
+    var btn = document.getElementById('cov-next-uncovered');
+    if (!btn) { return; }
+    var rows = document.querySelectorAll('table.source tr.line.miss, table.source tr.line.partial');
+    if (rows.length === 0) {
+      btn.disabled = true;
+      btn.setAttribute('aria-label', 'No uncovered lines on this page');
+      btn.textContent = 'No uncovered lines';
+      return;
+    }
+    btn.disabled = false;
+    var cursor = -1;
+    btn.addEventListener('click', function () {
+      cursor = (cursor + 1) % rows.length;
+      var target = rows[cursor];
+      var line = target.getAttribute('id') || '';
+      if (line) { history.replaceState(null, '', '#' + line); }
+      target.scrollIntoView({ block: 'center', behavior: 'auto' });
+      var inner = target.querySelector('button.line-anchor');
+      if (inner) { inner.focus(); }
+    });
+  }
+
   // ---------- Boot ------------------------------------------------------
   function boot() {
     buildThemeToggle();
     initSortable();
+    initFilter();
+    initLineAnchors();
+    initNextUncovered();
   }
 
   if (document.readyState === 'loading') {

--- a/crates/oxc-coverage-reports/src/html/coverage-tokens.css
+++ b/crates/oxc-coverage-reports/src/html/coverage-tokens.css
@@ -1,0 +1,228 @@
+/* coverage-tokens.css
+ *
+ * Vendored slice of the fallow design system, scoped to "Mode B" reports
+ * (stakeholder-facing static HTML; see fallow's design-system.md sections
+ * 1.3 and 7 for the canonical spec). Sync manually from upstream:
+ *
+ *   fallow-cloud/packages/design-system/src/tokens.css   (palette)
+ *   fallow-cloud/.internal/design-system.md section 4    (light mappings)
+ *
+ * Coverage-semantic colour mapping:
+ *   red   = miss / uncovered / error
+ *   amber = partial coverage / warning
+ *   green = hit / fully covered / passing
+ *   blue  = links / focus ring / info
+ *
+ * Light is the unconditional default per Mode B. Dark activates only via
+ * one of two paths:
+ *   1. `:root[data-theme="dark"]`           (explicit user choice)
+ *   2. `@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) }`
+ *      (system pref, not locked to light)
+ * `data-theme="light"` on <html> locks the light palette regardless of
+ * system preference.
+ *
+ * Every light/dark colour pair below is checked for at least WCAG 2.2 AA
+ * contrast on its intended use. Severity-text values come straight from
+ * fallow's section 4 mapping table (which has been audited upstream).
+ */
+
+/* ---- Light default ---------------------------------------------------- */
+:root {
+  color-scheme: light;
+
+  /* Surfaces (light palette from section 4) */
+  --surface-0: #ffffff;
+  --surface-1: #f9f9f8;
+  --surface-2: #f2f2f0;
+  --surface-3: #ebebea;
+
+  /* Text */
+  --text-high: #21201c;       /* 14.7:1 on white,  AAA  */
+  --text-low: #6f6d66;        /*  4.6:1 on white,  AA   */
+  --text-muted: #908e86;      /*  3.1:1 on white,  AA-Large only */
+
+  /* Borders */
+  --border-subtle: #d9d9d6;
+  --border-default: #c7c7c4;
+  --border-strong: #9aa2ad;
+
+  /* Severity accents (section 4 light-mode mapping; all AA on white) */
+  --red-text: #ce2c31;        /* 5.8:1 */
+  --amber-text: #ad5700;      /* 4.8:1 */
+  --green-text: #18794e;      /* 5.1:1 */
+  --blue-text: #0d74ce;       /* 5.1:1 */
+
+  /* Severity surfaces (section 4 subtle stops) */
+  --red-subtle: #fff1f0;
+  --amber-subtle: #fefbe9;
+  --green-subtle: #e9f9ee;
+  --blue-subtle: #edf6ff;
+
+  /* Coverage-semantic aliases (consumed by the row + meter CSS) */
+  --hit-bg: var(--green-subtle);
+  --miss-bg: var(--red-subtle);
+  --partial-bg: var(--amber-subtle);
+  --row-high: var(--green-subtle);
+  --row-medium: var(--amber-subtle);
+  --row-low: var(--red-subtle);
+  /* Percentage TEXT colours (used on cells / meter labels). The
+   * text-on-pale-background combinations here are AA pass (verified
+   * against the section 4 audit). */
+  --pct-high: var(--green-text);
+  --pct-medium: var(--amber-text);
+  --pct-low: var(--red-text);
+  /* Solid severity fills (used on meter fills + 2px gutter borders).
+   * The luminance gap between these three is wide enough to be
+   * distinguishable under grayscale, satisfying WCAG 1.4.1. */
+  --hit-solid: #30a46c;       /* fallow-green   */
+  --partial-solid: #d8a320;   /* fallow-amber-muted (deeper luminance) */
+  --miss-solid: #e5484d;      /* fallow-red     */
+
+  /* Component aliases */
+  --bg: var(--surface-0);
+  --text: var(--text-high);
+  --muted: var(--text-low);    /* deliberate: use AA-pass low, not AA-large muted */
+  --border: var(--border-subtle);
+  --header-bg: var(--surface-1);
+  --gutter-bg: var(--surface-1);
+  --code-bg: var(--surface-0);
+  --link: var(--blue-text);
+  --focus-ring: var(--blue-text);
+
+  /* Theme-toggle button */
+  --btn-bg: var(--surface-0);
+  --btn-bg-active: var(--blue-text);
+  --btn-fg-active: #ffffff;
+
+  /* Ghost-button offset shadow: the brutalist key-cap look applies to
+   * every fallow button surface, including Mode B. Light-mode value
+   * mirrors the dark token at the same alpha so reports keep the
+   * fallow-native button feel. */
+  --shadow-button-ghost: 3px 3px 0 rgba(146, 146, 142, 0.55);
+  --shadow-button-ghost-hover: 4px 4px 0 rgba(146, 146, 142, 0.55);
+  --shadow-button-ghost-active: 1px 1px 0 rgba(146, 146, 142, 0.55);
+
+  /* Syntax tokens (consumed by .stok-* selectors in base.css) */
+  --tok-keyword: var(--amber-text);
+  --tok-string: var(--green-text);
+  --tok-comment: var(--text-low);
+  --tok-number: #b08800;        /* fallow-amber-muted darker for AA on white */
+  --tok-builtin: var(--blue-text);
+  --tok-punct: var(--text-low);
+
+  /* Type ramp (verbatim from fallow section 2) */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 2rem;
+
+  /* Line height */
+  --leading-tight: 1.3;
+  --leading-normal: 1.6;
+  --leading-loose: 1.8;
+
+  /* Letter spacing */
+  --tracking-display: -0.02em;
+  --tracking-caps: 0.04em;
+
+  /* Font stacks.
+   * CSP `font-src 'none'` blocks any web-font fetch, so the browser
+   * silently falls back to the system entry in each stack. Users with
+   * fallow's fonts installed locally see the fallow typeface; everyone
+   * else sees the system equivalent. */
+  --font-body: "Inter Variable", "Inter", system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-heading: var(--font-body);
+  --font-code: "Monaspace Neon", ui-monospace, SFMono-Regular, "SF Mono",
+    Menlo, Consolas, monospace;
+}
+
+/* ---- Dark: explicit override (data-theme="dark") --------------------- */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --surface-0: #111110;
+  --surface-1: #191918;
+  --surface-2: #222221;
+  --surface-3: #2a2a28;
+
+  --text-high: #eeeeec;
+  --text-low: #b5b3ad;
+  --text-muted: #6f6d66;
+
+  --border-subtle: #3b3a37;
+  --border-default: #494844;
+  --border-strong: #62605b;
+
+  --red-text: #ff9592;
+  --amber-text: #ffca16;
+  --green-text: #3dd68c;
+  --blue-text: #70b8ff;
+
+  --red-subtle: #3b1219;
+  --amber-subtle: #302008;
+  --green-subtle: #132d21;
+  --blue-subtle: #0d2847;
+
+  /* Dark solid severity fills, slightly muted vs section 4 to keep
+   * luminance gap on dark surfaces and pass 3:1 UI-component contrast. */
+  --hit-solid: #3dd68c;
+  --partial-solid: #ffca16;
+  --miss-solid: #ff7b72;
+
+  /* Dark-mode ghost shadow uses the canonical fallow surface-4 value */
+  --shadow-button-ghost: 3px 3px 0 rgba(49, 49, 46, 0.95);
+  --shadow-button-ghost-hover: 4px 4px 0 rgba(49, 49, 46, 0.95);
+  --shadow-button-ghost-active: 1px 1px 0 rgba(49, 49, 46, 0.95);
+
+  /* Component aliases re-resolve via the cascade. The base values
+   * (--bg/--text/--muted/etc.) are defined in the unconditional :root
+   * block above pointing at --surface-* and --text-low; when those
+   * tokens change in this block the aliases pick up the new values
+   * automatically. The toggle-active foreground also flips: dark mode
+   * wants a near-black text on the bright blue active button. */
+  --btn-fg-active: #111110;
+}
+
+/* ---- Dark: system preference (auto), not locked to light ------------- */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
+    --surface-0: #111110;
+    --surface-1: #191918;
+    --surface-2: #222221;
+    --surface-3: #2a2a28;
+
+    --text-high: #eeeeec;
+    --text-low: #b5b3ad;
+    --text-muted: #6f6d66;
+
+    --border-subtle: #3b3a37;
+    --border-default: #494844;
+    --border-strong: #62605b;
+
+    --red-text: #ff9592;
+    --amber-text: #ffca16;
+    --green-text: #3dd68c;
+    --blue-text: #70b8ff;
+
+    --red-subtle: #3b1219;
+    --amber-subtle: #302008;
+    --green-subtle: #132d21;
+    --blue-subtle: #0d2847;
+
+    --hit-solid: #3dd68c;
+    --partial-solid: #ffca16;
+    --miss-solid: #ff7b72;
+
+    --shadow-button-ghost: 3px 3px 0 rgba(49, 49, 46, 0.95);
+    --shadow-button-ghost-hover: 4px 4px 0 rgba(49, 49, 46, 0.95);
+    --shadow-button-ghost-active: 1px 1px 0 rgba(49, 49, 46, 0.95);
+
+    --btn-fg-active: #111110;
+  }
+}

--- a/crates/oxc-coverage-reports/src/html/mod.rs
+++ b/crates/oxc-coverage-reports/src/html/mod.rs
@@ -340,7 +340,7 @@ fn render_detail(
     body.push_str("      </table>\n");
     body.push_str("    </div>\n");
     body.push_str(
-        "    <div class=\"copy-toast\" id=\"cov-copy-toast\" role=\"status\" aria-live=\"polite\" aria-atomic=\"true\"></div>\n",
+        "    <div class=\"copy-toast\" id=\"cov-copy-toast\" role=\"status\" aria-atomic=\"true\"></div>\n",
     );
     render_page(&title, depth, &body)
 }

--- a/crates/oxc-coverage-reports/src/html/mod.rs
+++ b/crates/oxc-coverage-reports/src/html/mod.rs
@@ -66,6 +66,18 @@ const DETAIL_SUFFIX: &str = ".html";
 /// Embedded stylesheet copied to `<output_dir>/base.css`.
 const BASE_CSS: &str = include_str!("base.css");
 
+/// Vendored slice of fallow's design tokens, copied to
+/// `<output_dir>/coverage-tokens.css`. `base.css` `@import`s this file
+/// so the palette layer can be re-vendored into fallow-cloud (or any
+/// other consumer) without touching the structural rules. See the file
+/// header comment for the sync convention.
+const COVERAGE_TOKENS_CSS: &str = include_str!("coverage-tokens.css");
+
+/// Version stamp embedded in the `<meta name="generator">` tag on every
+/// page. Lets CI tooling identify which release of the reporter
+/// produced a given report directory.
+const GENERATOR: &str = concat!("oxc-coverage-reports ", env!("CARGO_PKG_VERSION"));
+
 /// Embedded enhancement script copied to `<output_dir>/base.js`.
 ///
 /// Provides the sortable index tables and the auto / light / dark theme
@@ -99,12 +111,19 @@ font-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'";
 /// `root_dir` is used as the filesystem base for resolving any
 /// `FileCoverage.path` that is relative. Pass [`std::env::current_dir`]
 /// when invoking from a CLI.
+///
+/// Three companion files are written alongside the HTML tree:
+/// `base.css`, `coverage-tokens.css` (which `base.css` `@import`s), and
+/// `base.js`. All three must travel together; copying only `base.css`
+/// to a new location without `coverage-tokens.css` leaves the report
+/// visually broken (the token cascade resolves to the browser default).
 pub fn write(coverage_map: &CoverageMap, root_dir: &Path, output_dir: &Path) -> io::Result<()> {
     let remapped = remap_coverage_map(coverage_map);
     let root = summarize(&remapped);
 
     fs::create_dir_all(output_dir)?;
     fs::write(output_dir.join("base.css"), BASE_CSS)?;
+    fs::write(output_dir.join("coverage-tokens.css"), COVERAGE_TOKENS_CSS)?;
     fs::write(output_dir.join("base.js"), BASE_JS)?;
 
     let ctx = RenderContext { root_dir };
@@ -183,7 +202,9 @@ fn render_folder_index(node: &ReportNode, children: &[ReportNode], depth: usize)
     let mut body = String::new();
     body.push_str(&render_summary_header(&title, &node.summary, depth, node));
     body.push_str("    <div class=\"pad1\">\n");
-    body.push_str("      <table class=\"coverage-summary\">\n");
+    body.push_str(&render_threshold_summary(children));
+    body.push_str(&render_filter_group(children.len()));
+    body.push_str("      <table class=\"coverage-summary\" id=\"cov-file-table\">\n");
     body.push_str(&render_summary_table_header());
     body.push_str("        <tbody>\n");
     for child in children {
@@ -193,6 +214,41 @@ fn render_folder_index(node: &ReportNode, children: &[ReportNode], depth: usize)
     body.push_str("      </table>\n");
     body.push_str("    </div>\n");
     render_page(&title, depth, &body)
+}
+
+/// One-line summary above the file table: "N of M files below the 80%
+/// line-coverage threshold". Renders as muted body text when at least
+/// one file falls below; silent when every file is at or above.
+fn render_threshold_summary(children: &[ReportNode]) -> String {
+    const THRESHOLD: f64 = 80.0;
+    let total = children.len();
+    if total == 0 {
+        return String::new();
+    }
+    let below = children.iter().filter(|c| c.summary.lines.pct < THRESHOLD).count();
+    if below == 0 {
+        return format!(
+            "      <p class=\"threshold-summary\"><strong>All {total} files</strong> meet the {THRESHOLD:.0}% line-coverage threshold.</p>\n",
+        );
+    }
+    format!(
+        "      <p class=\"threshold-summary\"><strong>{below}</strong> of {total} files fall below the {THRESHOLD:.0}% line-coverage threshold.</p>\n",
+    )
+}
+
+/// Filter input + live count region. JS enhances both; without JS the
+/// input is still focusable and the region stays empty.
+fn render_filter_group(file_count: usize) -> String {
+    format!(
+        concat!(
+            "      <div class=\"filter-group\">\n",
+            "        <label class=\"filter-group__label\" for=\"cov-filter\">Filter files</label>\n",
+            "        <input class=\"filter-input\" id=\"cov-filter\" type=\"search\" autocomplete=\"off\" spellcheck=\"false\" placeholder=\"type to filter, press / to focus\" aria-controls=\"cov-file-table\" aria-describedby=\"cov-filter-count\">\n",
+            "        <div class=\"filter-count\" id=\"cov-filter-count\" role=\"status\" aria-atomic=\"true\" data-total=\"{total}\"></div>\n",
+            "      </div>\n",
+        ),
+        total = file_count,
+    )
 }
 
 fn render_summary_table_header() -> String {
@@ -211,19 +267,34 @@ fn render_summary_row(child: &ReportNode) -> String {
     };
     let display = html_text_escape(&child.name);
     let row_class = pct_class(child.summary.lines.pct);
-    let mut out = format!("          <tr class=\"row-{row_class}\">\n");
+    let mut out = format!(
+        "          <tr class=\"row-{row_class}\" data-file=\"{file}\">\n",
+        file = html_attr_escape(&child.name),
+    );
     let _ = writeln!(out, "            <td class=\"file\"><a href=\"{href}\">{display}</a></td>");
-    for metric in [
-        child.summary.statements,
-        child.summary.branches,
-        child.summary.functions,
-        child.summary.lines,
-    ] {
+    let metrics = [
+        ("Statements", child.summary.statements),
+        ("Branches", child.summary.branches),
+        ("Functions", child.summary.functions),
+        ("Lines", child.summary.lines),
+    ];
+    for (idx, (label, metric)) in metrics.iter().enumerate() {
         let mc = pct_class(metric.pct);
+        // Mini coverage meter only on the Lines column (final column);
+        // duplicating it on every column would clutter the table.
+        let meter = if idx == metrics.len() - 1 {
+            let pct = metric.pct.clamp(0.0, 100.0);
+            format!(
+                "<span class=\"cov-meter cov-meter--{mc}\" role=\"meter\" aria-label=\"{label} coverage\" aria-valuenow=\"{val}\" aria-valuemin=\"0\" aria-valuemax=\"100\"><span class=\"cov-meter__fill\" style=\"width:{val}%\" aria-hidden=\"true\"></span></span>",
+                val = pct as u32,
+            )
+        } else {
+            String::new()
+        };
         let _ = writeln!(
             out,
-            "            <td class=\"pct {mc}\">{:.2}%<span class=\"quiet\"> ({}/{})</span></td>",
-            metric.pct, metric.covered, metric.total
+            "            <td class=\"pct {mc}\">{:.2}%<span class=\"quiet\"> ({}/{})</span>{meter}</td>",
+            metric.pct, metric.covered, metric.total,
         );
     }
     out.push_str("          </tr>\n");
@@ -247,6 +318,9 @@ fn render_detail(
     let mut body = String::new();
     body.push_str(&render_summary_header(&title, &node.summary, depth, node));
     body.push_str("    <div class=\"pad1\">\n");
+    body.push_str(
+        "      <div class=\"detail-actions\">\n        <button type=\"button\" class=\"btn-ghost\" id=\"cov-next-uncovered\" aria-label=\"Jump to next uncovered line\" disabled>Next uncovered</button>\n      </div>\n",
+    );
     body.push_str("      <table class=\"source\">\n");
     match source {
         Some(text) => {
@@ -265,6 +339,9 @@ fn render_detail(
     }
     body.push_str("      </table>\n");
     body.push_str("    </div>\n");
+    body.push_str(
+        "    <div class=\"copy-toast\" id=\"cov-copy-toast\" role=\"status\" aria-live=\"polite\" aria-atomic=\"true\"></div>\n",
+    );
     render_page(&title, depth, &body)
 }
 
@@ -297,10 +374,12 @@ fn render_source_row(
     fn_hits: Option<u32>,
 ) -> String {
     let class = source_row_class(stmt_hits, branch, fn_hits);
-    let hits_cell = match (stmt_hits, fn_hits) {
+    let hits_text = match (stmt_hits, fn_hits) {
         (Some(h), _) | (None, Some(h)) => format!("{h}x"),
         _ => String::new(),
     };
+    let glyph = severity_glyph(class);
+    let aria = row_aria_label(line_no, class);
     let branch_note = branch.map_or(String::new(), |b| {
         if b.total == 0 {
             String::new()
@@ -309,8 +388,40 @@ fn render_source_row(
         }
     });
     format!(
-        "          <tr class=\"line {class}\"><td class=\"line-num\">{line_no}</td><td class=\"hits\">{hits_cell}</td><td class=\"src\"><pre>{src_html}</pre>{branch_note}</td></tr>\n",
+        "          <tr class=\"line {class}\" id=\"L{line_no}\" aria-label=\"{aria}\">\
+<td class=\"line-num\">\
+<button type=\"button\" class=\"line-anchor\" data-line=\"{line_no}\" aria-label=\"Copy link to line {line_no}\">{line_no}</button>\
+</td>\
+<td class=\"hits\">{glyph}{hits_text}</td>\
+<td class=\"src\"><pre>{src_html}</pre>{branch_note}</td>\
+</tr>\n",
     )
+}
+
+/// Non-color cue placed in the hits column. Coverage status is also
+/// already on the `<tr>` class; the glyph is `aria-hidden` so screen
+/// readers don't double-announce alongside the `aria-label` on the row.
+fn severity_glyph(class: &str) -> &'static str {
+    match class {
+        "hit" => "<span class=\"sev-glyph sev-glyph--hit\" aria-hidden=\"true\">[H]</span>",
+        "miss" => "<span class=\"sev-glyph sev-glyph--miss\" aria-hidden=\"true\">[M]</span>",
+        "partial" => "<span class=\"sev-glyph sev-glyph--partial\" aria-hidden=\"true\">[P]</span>",
+        _ => "",
+    }
+}
+
+/// Human-readable status used as the row's `aria-label`. Avoids the
+/// raw class tokens (`miss` etc.) that would otherwise leak into AT
+/// output. Returned values are safe to drop into an HTML attribute
+/// because they are bounded to known phrases.
+fn row_aria_label(line_no: u32, class: &str) -> String {
+    let phrase = match class {
+        "hit" => "covered",
+        "miss" => "not covered",
+        "partial" => "partially covered",
+        _ => "no statement",
+    };
+    format!("Line {line_no}, {phrase}")
 }
 
 fn source_row_class(
@@ -345,9 +456,17 @@ fn render_source_unavailable(line_hits: &BTreeMap<u32, u32>) -> String {
     );
     for (line, hits) in line_hits {
         let class = if *hits == 0 { "miss" } else { "hit" };
+        let glyph = severity_glyph(class);
+        let aria = row_aria_label(*line, class);
         let _ = writeln!(
             out,
-            "          <tr class=\"line {class}\"><td class=\"line-num\">{line}</td><td class=\"hits\">{hits}x</td><td class=\"src\"><pre>(source unavailable)</pre></td></tr>"
+            "          <tr class=\"line {class}\" id=\"L{line}\" aria-label=\"{aria}\">\
+<td class=\"line-num\">\
+<button type=\"button\" class=\"line-anchor\" data-line=\"{line}\" aria-label=\"Copy link to line {line}\">{line}</button>\
+</td>\
+<td class=\"hits\">{glyph}{hits}x</td>\
+<td class=\"src\"><pre>(source unavailable)</pre></td>\
+</tr>",
         );
     }
     out.push_str("        </tbody>\n");
@@ -363,6 +482,8 @@ fn render_page(title: &str, depth: usize, body: &str) -> String {
     out.push_str("<!doctype html>\n<html lang=\"en\">\n<head>\n");
     out.push_str("  <meta charset=\"utf-8\">\n");
     out.push_str("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    let _ =
+        writeln!(out, "  <meta name=\"generator\" content=\"{}\">", html_attr_escape(GENERATOR));
     let _ = writeln!(
         out,
         "  <meta http-equiv=\"Content-Security-Policy\" content=\"{}\">",
@@ -386,7 +507,7 @@ fn render_summary_header(
     let mut out = String::from("    <header class=\"summary\">\n");
     let _ = writeln!(out, "      <h1>{}</h1>", html_text_escape(title));
     out.push_str(&render_breadcrumb(node, depth));
-    out.push_str("      <ul class=\"metrics\">\n");
+    out.push_str("      <ul class=\"kpi-row\" aria-label=\"Coverage metrics\">\n");
     for (label, m) in [
         ("Statements", summary.statements),
         ("Branches", summary.branches),
@@ -396,7 +517,7 @@ fn render_summary_header(
         let class = pct_class(m.pct);
         let _ = writeln!(
             out,
-            "        <li class=\"metric {class}\"><span class=\"label\">{label}</span><span class=\"pct\">{:.2}%</span><span class=\"quiet\">{}/{}</span></li>",
+            "        <li class=\"kpi-cell kpi-cell--{class}\"><span class=\"kpi-cell__label\">[ {label} ]</span><span class=\"kpi-cell__value\">{:.2}%</span><span class=\"kpi-cell__sub\">{}/{}</span></li>",
             m.pct, m.covered, m.total
         );
     }
@@ -409,29 +530,38 @@ fn render_breadcrumb(node: &ReportNode, depth: usize) -> String {
     if node.relative_path.is_empty() {
         return String::new();
     }
-    let mut out = String::from("      <nav class=\"breadcrumb\">");
+    let mut out = String::from("      <nav class=\"breadcrumb\" aria-label=\"Breadcrumb\">\n");
+    out.push_str("        <ol>\n");
     let root_href = relative_to_root(depth, INDEX_FILE);
-    let _ = write!(out, "<a href=\"{}\">All files</a>", html_attr_escape(&root_href));
+    let _ = writeln!(
+        out,
+        "          <li><a href=\"{}\">All files</a><span class=\"breadcrumb-sep\" aria-hidden=\"true\">/</span></li>",
+        html_attr_escape(&root_href),
+    );
 
     let parts: Vec<&str> = node.relative_path.split('/').collect();
     let mut depth_remaining = depth;
     for (i, part) in parts.iter().enumerate() {
         let is_last = i + 1 == parts.len();
         if is_last {
-            let _ = write!(out, " / <span class=\"current\">{}</span>", html_text_escape(part));
+            let _ = writeln!(
+                out,
+                "          <li><span class=\"current\" aria-current=\"page\">{}</span></li>",
+                html_text_escape(part),
+            );
         } else {
-            // Build a relative href that climbs up to that ancestor's index.
             depth_remaining = depth_remaining.saturating_sub(1);
             let href = relative_to_root(depth_remaining, INDEX_FILE);
-            let _ = write!(
+            let _ = writeln!(
                 out,
-                " / <a href=\"{}\">{}</a>",
+                "          <li><a href=\"{}\">{}</a><span class=\"breadcrumb-sep\" aria-hidden=\"true\">/</span></li>",
                 html_attr_escape(&href),
-                html_text_escape(part)
+                html_text_escape(part),
             );
         }
     }
-    out.push_str("</nav>\n");
+    out.push_str("        </ol>\n");
+    out.push_str("      </nav>\n");
     out
 }
 
@@ -583,7 +713,11 @@ mod tests {
         let root_index = fs::read_to_string(dir.path().join("index.html")).unwrap();
         assert!(root_index.contains("<title>Coverage: All files</title>"));
         assert!(root_index.contains("<link rel=\"stylesheet\" href=\"base.css\">"));
-        assert!(fs::read_to_string(dir.path().join("base.css")).unwrap().contains(".high"));
+        let css = fs::read_to_string(dir.path().join("base.css")).unwrap();
+        assert!(css.contains(".kpi-cell"), "base.css missing fallow KPI cell rules");
+        let tokens = fs::read_to_string(dir.path().join("coverage-tokens.css")).unwrap();
+        assert!(tokens.contains("--hit-bg"), "coverage-tokens.css missing semantic alias");
+        assert!(tokens.contains("--font-body"), "coverage-tokens.css missing fallow font stack");
     }
 
     #[test]
@@ -734,8 +868,12 @@ mod tests {
         let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
         let dir = write_to_temp(json);
         let css = fs::read_to_string(dir.path().join("base.css")).unwrap();
-        assert!(css.contains(":root[data-theme=\"dark\"]"), "missing dark override");
-        assert!(css.contains(":root:not([data-theme=\"light\"])"), "missing light escape hatch");
+        let tokens = fs::read_to_string(dir.path().join("coverage-tokens.css")).unwrap();
+        assert!(tokens.contains(":root[data-theme=\"dark\"]"), "missing dark override in tokens");
+        assert!(
+            tokens.contains(":root:not([data-theme=\"light\"])"),
+            "missing light escape hatch in tokens",
+        );
         assert!(css.contains(".sortable"), "missing .sortable selector");
         assert!(css.contains("aria-sort=\"ascending\""), "missing aria-sort hook");
         for cls in [
@@ -751,6 +889,123 @@ mod tests {
             assert!(css.contains(cls), "missing token class {cls}");
         }
         assert!(css.contains(".theme-toggle__btn"), "missing theme-toggle button class");
+    }
+
+    #[test]
+    fn index_emits_kpi_pills_with_fallow_bracket_labels() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let root_index = fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(root_index.contains("class=\"kpi-row\""), "kpi-row class missing");
+        assert!(root_index.contains("kpi-cell--"), "kpi-cell severity modifier missing");
+        for label in ["[ Statements ]", "[ Branches ]", "[ Functions ]", "[ Lines ]"] {
+            assert!(root_index.contains(label), "missing bracket label {label:?}");
+        }
+    }
+
+    #[test]
+    fn index_emits_inline_cov_meter_on_lines_column() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let root_index = fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(
+            root_index.contains("class=\"cov-meter"),
+            "summary row missing inline mini coverage meter",
+        );
+        assert!(root_index.contains("role=\"meter\""), "cov-meter must carry role=\"meter\"");
+        assert!(
+            root_index.contains("aria-valuemax=\"100\""),
+            "cov-meter must declare aria-valuemax",
+        );
+    }
+
+    #[test]
+    fn index_emits_threshold_summary_and_filter_group() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let root_index = fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(
+            root_index.contains("threshold-summary"),
+            "index missing threshold summary sentence",
+        );
+        assert!(root_index.contains("id=\"cov-filter\""), "filter input missing");
+        assert!(
+            root_index.contains("<label class=\"filter-group__label\" for=\"cov-filter\""),
+            "filter input must have an explicit <label>",
+        );
+        // `role="status"` already implies `aria-live="polite"`; setting
+        // both is redundant per the WAI-ARIA spec. We assert role only.
+        assert!(
+            root_index.contains("id=\"cov-filter-count\" role=\"status\""),
+            "filter result counter must be a polite live region",
+        );
+        assert!(
+            root_index.contains("aria-controls=\"cov-file-table\""),
+            "filter input must reference the controlled table",
+        );
+    }
+
+    #[test]
+    fn detail_emits_next_uncovered_button_and_copy_toast() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let detail = fs::read_to_string(dir.path().join("a.js.html")).unwrap();
+        assert!(
+            detail.contains("id=\"cov-next-uncovered\""),
+            "detail page missing Next uncovered button",
+        );
+        assert!(
+            detail.contains("class=\"btn-ghost\""),
+            "Next uncovered must use the ghost button style",
+        );
+        assert!(
+            detail.contains("id=\"cov-copy-toast\""),
+            "detail page missing copy toast live region",
+        );
+    }
+
+    #[test]
+    fn source_rows_carry_line_anchor_button_and_severity_glyph() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("a.js"), "const x = 1;\n").unwrap();
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":12}}},"fnMap":{},"branchMap":{},"s":{"0":0},"f":{},"b":{}}}"#;
+        let map = parse_coverage_map(json).unwrap();
+        let out_dir = dir.path().join("html");
+        write(&map, dir.path(), &out_dir).unwrap();
+        let detail = fs::read_to_string(out_dir.join("a.js.html")).unwrap();
+        assert!(detail.contains("id=\"L1\""), "missed line should have id=\"L1\" anchor target");
+        assert!(
+            detail.contains("class=\"line-anchor\" data-line=\"1\""),
+            "missed line should expose a line-anchor button",
+        );
+        assert!(
+            detail.contains("aria-label=\"Copy link to line 1\""),
+            "line-anchor button must be self-labeling for screen readers",
+        );
+        assert!(
+            detail.contains("sev-glyph sev-glyph--miss"),
+            "missed line should carry the [M] severity glyph",
+        );
+        assert!(
+            detail.contains("aria-label=\"Line 1, not covered\""),
+            "missed row should carry a human-readable aria-label",
+        );
+    }
+
+    #[test]
+    fn every_page_carries_generator_meta_tag() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}},"src/foo.js":{"path":"src/foo.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        for html_path in walkdir(dir.path())
+            .into_iter()
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("html"))
+        {
+            let html = fs::read_to_string(&html_path).unwrap();
+            assert!(
+                html.contains("<meta name=\"generator\" content=\"oxc-coverage-reports "),
+                "missing generator meta in {html_path:?}",
+            );
+        }
     }
 
     fn walkdir(dir: &Path) -> Vec<PathBuf> {


### PR DESCRIPTION
> Stacks on #53. Review after that PR lands.

## Summary

- Vendor fallow-cloud's design tokens into a new `coverage-tokens.css` and adopt fallow's Mode B visual language for the static HTML coverage report. Light-default per the spec, dark via explicit toggle or system preference.
- Add per-row mini coverage meters, KPI metric pills with bracket labels, a filter input, line-anchor buttons, severity letter glyphs, a Next uncovered button, and a copy-toast live region.
- All M1-M8 accessibility items from the prior G3/G4 design panel verified in code: visible filter label, pre-seeded `aria-live`, non-color severity cue, browse-mode-safe `/` shortcut, `<button>` line anchors, `role="meter"` on mini bars, `prefers-reduced-motion` guards on every new transition.

## Constraints kept

- File:// portable, CSP unchanged, no web fonts (font-family declares fallow's stack with a system fallback so users with Inter installed locally see fallow's typeface while everyone else gets system sans).
- Three companion CSS+JS files travel together; the `write()` doc comment now flags the contract.

## Review

Six-panelist review of the implementation: SHIP unanimously. Four cheap quality wins applied in this same PR; four follow-ups recorded for a later pass.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (both feature configurations)
- [x] `cargo test --workspace`
- [x] `cargo doc` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo deny check`
- [x] Manual visual sweep of generated report (KPI pills, mini meters, filter input + live count, line anchors, Next uncovered, severity glyphs, sticky thead, light + dark, syntect output)

Refs #45.