### PR TITLE
feat(report): configurable line-coverage threshold (PR G5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +71,30 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -196,6 +232,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "dragonbox_ecma"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +356,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +377,22 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -564,6 +645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +667,16 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "napi"
@@ -661,6 +758,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -869,9 +972,12 @@ dependencies = [
  "oxc_coverage_report",
  "oxc_coverage_source_maps",
  "oxc_coverage_types",
+ "rayon",
  "serde",
  "serde_json",
+ "syntect",
  "tempfile",
+ "two-face",
 ]
 
 [[package]]
@@ -1155,6 +1261,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1324,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1373,6 +1507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1603,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1668,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1706,17 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "two-face"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b285c51f8a6ade109ed4566d33ac4fb289fb5d6cf87ed70908a5eaf65e948e34"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
 ]
 
 [[package]]
@@ -1813,6 +2016,15 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,6 +58,12 @@ Coverage suite (umbrella [#45](https://github.com/fallow-rs/oxc-coverage-instrum
   - Explicit auto / light / dark theme toggle, persisted to `localStorage`, overriding `prefers-color-scheme`
   - Lightweight JS / TS syntax highlighting on detail-page source (tokenizer for keywords, builtins, strings, numbers, comments, punctuation)
   - Corporate-proxy hardening: strict `Content-Security-Policy` `<meta>` (`default-src 'self'; connect-src 'none'; font-src 'none'; object-src 'none'; ...`) and a test that scans every emitted asset for external URLs
+- [x] **PR G3**: server-side syntax highlighting via `syntect`
+  - Replace the hand-rolled client tokenizer with `syntect` 5.x + `two-face` (TS / TSX / JSX / Rust / Python / many more), pure-Rust `fancy-regex` backend so Windows cross-compile stays clean
+  - Class-based output (`ClassStyle::SpacedPrefixed { prefix: "stok-" }`) so token colours stay theme-able from CSS and forward-compatible with fallow's existing `--fallow-syntax-token-*` variables
+  - `rayon` parallelism on per-file render (`children.par_iter()`); 100-file / 200-LOC project emits in under 2 s on a typical laptop
+  - New `html` Cargo feature (default-enabled) gates `syntect` + `two-face` + `rayon` so downstream consumers that only want text / lcov / cobertura / json-summary can drop the grammar payload via `default-features = false`
+  - `~+2.2 MiB` binary delta for the bundled grammar set; acceptable for a CI-class tool
 
 ## Future
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,6 +64,11 @@ Coverage suite (umbrella [#45](https://github.com/fallow-rs/oxc-coverage-instrum
   - `rayon` parallelism on per-file render (`children.par_iter()`); 100-file / 200-LOC project emits in under 2 s on a typical laptop
   - New `html` Cargo feature (default-enabled) gates `syntect` + `two-face` + `rayon` so downstream consumers that only want text / lcov / cobertura / json-summary can drop the grammar payload via `default-features = false`
   - `~+2.2 MiB` binary delta for the bundled grammar set; acceptable for a CI-class tool
+- [x] **PR G5**: configurable line-coverage threshold
+  - New `HtmlOptions { high_threshold: f64 }` struct with `Default` (80.0, matching Istanbul's traditional cutoff). Constructed via struct-update syntax so future fields are additive without breaking callers
+  - New `html::write_with_options()` companion to `html::write()`; new `Format::write_to_dir_with_options()` companion to `Format::write_to_dir()`. The original entry points keep their signatures for backward compat and dispatch through `HtmlOptions::default()`
+  - Threshold drives both the index page's "N of M files fall below the X% line-coverage threshold" sentence AND the high/medium/low colour bucketing on every metric pill, row, and inline coverage meter, so the visual story stays consistent. Medium / low boundary stays fixed at 50%
+  - CLI `--threshold <pct>` flag on `report` subcommand; validates `0 <= x <= 100` at parse time with a friendly error message
 - [x] **PR G4**: fallow "Mode B" visual pass
   - New `coverage-tokens.css` vendored from fallow-cloud's design system (Radix Sand palette, severity stops, type ramp, font stacks). Light-default per Mode B; dark via explicit `data-theme="dark"` OR `prefers-color-scheme: dark` + no override
   - KPI metric pills with `[ Statements ]` bracket labels and severity-coloured values; per-row mini coverage meter on the Lines column (1px outline, severity fill, `role="meter"`); breadcrumb as semantic `<ol><li>` with `aria-current="page"`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,6 +64,14 @@ Coverage suite (umbrella [#45](https://github.com/fallow-rs/oxc-coverage-instrum
   - `rayon` parallelism on per-file render (`children.par_iter()`); 100-file / 200-LOC project emits in under 2 s on a typical laptop
   - New `html` Cargo feature (default-enabled) gates `syntect` + `two-face` + `rayon` so downstream consumers that only want text / lcov / cobertura / json-summary can drop the grammar payload via `default-features = false`
   - `~+2.2 MiB` binary delta for the bundled grammar set; acceptable for a CI-class tool
+- [x] **PR G4**: fallow "Mode B" visual pass
+  - New `coverage-tokens.css` vendored from fallow-cloud's design system (Radix Sand palette, severity stops, type ramp, font stacks). Light-default per Mode B; dark via explicit `data-theme="dark"` OR `prefers-color-scheme: dark` + no override
+  - KPI metric pills with `[ Statements ]` bracket labels and severity-coloured values; per-row mini coverage meter on the Lines column (1px outline, severity fill, `role="meter"`); breadcrumb as semantic `<ol><li>` with `aria-current="page"`
+  - Filter input on index pages with proper `<label>`, debounced match, `role="status"` live count, `/` keyboard shortcut guarded against `activeElement` so screen-reader browse mode is preserved
+  - Line anchors as `<button>` per source row; `id="L<n>"` on each `<tr>` and per-line `aria-label`; clicking copies the canonical URL via the clipboard API with a polite-live `copy-toast`
+  - "Next uncovered" ghost button (fallow brutalist offset shadow) that cycles `tr.line.miss` / `tr.line.partial` in document order and focuses the inner anchor
+  - `[H]` / `[P]` / `[M]` non-color severity glyphs in the gutter + 2px luminance left-borders on coverage rows (WCAG 1.4.1 non-color cue), with `aria-hidden` on the glyph (the row's `aria-label` carries the semantics)
+  - `<meta name="generator">` version stamp on every page; sticky table header; `:focus-within` row highlight so keyboard parity with mouse hover; `prefers-reduced-motion` guards on every new transition
 
 ## Future
 

--- a/crates/oxc-coverage-instrument-cli/src/main.rs
+++ b/crates/oxc-coverage-instrument-cli/src/main.rs
@@ -47,6 +47,11 @@ struct ReportArgs {
     /// when rendering the html source view. Defaults to the current working
     /// directory.
     root_dir: PathBuf,
+    /// `--threshold` (html only). Percentage cutoff for the high / medium
+    /// coverage bucket and the "below X% threshold" sentence on the
+    /// index page. Defaults to 80 if not supplied. Validated to be in
+    /// `[0, 100]` at parse time.
+    html_threshold: f64,
 }
 
 fn main() -> ExitCode {
@@ -119,6 +124,7 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
     let mut output_dir: Option<PathBuf> = None;
     let mut coverage_file: Option<String> = None;
     let mut root_dir: Option<PathBuf> = None;
+    let mut html_threshold: f64 = 80.0;
 
     let mut i = 0;
     while i < args.len() {
@@ -137,6 +143,22 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
                 output_dir = Some(PathBuf::from(take_value(args, &mut i, "--output-dir")?));
             }
             "--root" => root_dir = Some(PathBuf::from(take_value(args, &mut i, "--root")?)),
+            "--threshold" => {
+                let value = take_value(args, &mut i, "--threshold")?;
+                let parsed = value.parse::<f64>().map_err(|_| {
+                    eprintln!(
+                        "error: --threshold must be a number between 0 and 100, got '{value}'"
+                    );
+                    ExitCode::FAILURE
+                })?;
+                if !(0.0..=100.0).contains(&parsed) {
+                    eprintln!(
+                        "error: --threshold {parsed} is outside [0, 100]; pick a percentage in that range"
+                    );
+                    return Err(ExitCode::FAILURE);
+                }
+                html_threshold = parsed;
+            }
             "--help" | "-h" => {
                 print_report_usage();
                 return Err(ExitCode::SUCCESS);
@@ -199,7 +221,7 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
         })
     });
 
-    Ok(ReportArgs { coverage_file, output_file, output_dir, format, root_dir })
+    Ok(ReportArgs { coverage_file, output_file, output_dir, format, root_dir, html_threshold })
 }
 
 fn format_name(format: Format) -> &'static str {
@@ -273,7 +295,11 @@ fn run_report(args: &ReportArgs) -> ExitCode {
             eprintln!("error: --format html requires --output-dir <dir>");
             return ExitCode::FAILURE;
         };
-        if let Err(e) = args.format.write_to_dir(&map, &args.root_dir, output_dir) {
+        let html_opts =
+            oxc_coverage_reports::html::HtmlOptions { high_threshold: args.html_threshold };
+        if let Err(e) =
+            args.format.write_to_dir_with_options(&map, &args.root_dir, output_dir, &html_opts)
+        {
             eprintln!("error: failed to render report: {e}");
             return ExitCode::FAILURE;
         }
@@ -403,6 +429,7 @@ REPORT OPTIONS:
     -o, --output <file>          Write report to file (default: stdout). Not valid for --format html.
     --output-dir <dir>           Output directory for multi-file formats (html). Default: ./coverage
     --root <dir>                 Root directory used to relativize source paths and resolve html source view (default: cwd)
+    --threshold <pct>            High/medium coverage cutoff for html reports (0-100, default: 80)
 
 GLOBAL OPTIONS:
     -V, --version                Print version
@@ -423,6 +450,7 @@ OPTIONS:
     -o, --output <file>          Write report to file (default: stdout). Not valid for --format html.
     --output-dir <dir>           Output directory for multi-file formats (html). Default: ./coverage
     --root <dir>                 Root directory used to relativize source paths and resolve html source view (default: cwd)
+    --threshold <pct>            High/medium coverage cutoff for html reports (0-100, default: 80)
     -h, --help                   Print this help"
     );
 }

--- a/crates/oxc-coverage-instrument-cli/src/main.rs
+++ b/crates/oxc-coverage-instrument-cli/src/main.rs
@@ -125,6 +125,7 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
     let mut coverage_file: Option<String> = None;
     let mut root_dir: Option<PathBuf> = None;
     let mut html_threshold: f64 = 80.0;
+    let mut threshold_was_set = false;
 
     let mut i = 0;
     while i < args.len() {
@@ -151,6 +152,17 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
                     );
                     ExitCode::FAILURE
                 })?;
+                // `f64::from_str` accepts `nan`, `inf`, `-inf`; the
+                // range check below uses comparisons that silently
+                // return false for NaN, so a `nan` input would slip
+                // through unnoticed and degrade every percent to the
+                // "medium" bucket. Reject non-finite values up front.
+                if !parsed.is_finite() {
+                    eprintln!(
+                        "error: --threshold must be a finite number between 0 and 100, got '{value}'"
+                    );
+                    return Err(ExitCode::FAILURE);
+                }
                 if !(0.0..=100.0).contains(&parsed) {
                     eprintln!(
                         "error: --threshold {parsed} is outside [0, 100]; pick a percentage in that range"
@@ -158,6 +170,7 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
                     return Err(ExitCode::FAILURE);
                 }
                 html_threshold = parsed;
+                threshold_was_set = true;
             }
             "--help" | "-h" => {
                 print_report_usage();
@@ -201,6 +214,14 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
             "error: --output-dir is only valid for multi-file formats (html); use -o for --format {}",
             format_name(format)
         );
+        return Err(ExitCode::FAILURE);
+    }
+    // `--threshold` only affects the html reporter (drives colour
+    // bucketing + the threshold-summary sentence). Reject it on other
+    // formats so the user knows it was a no-op rather than letting it
+    // silently slip through.
+    if threshold_was_set && !format.is_multi_file() {
+        eprintln!("error: --threshold only applies to --format html; remove it or switch formats");
         return Err(ExitCode::FAILURE);
     }
 
@@ -429,7 +450,10 @@ REPORT OPTIONS:
     -o, --output <file>          Write report to file (default: stdout). Not valid for --format html.
     --output-dir <dir>           Output directory for multi-file formats (html). Default: ./coverage
     --root <dir>                 Root directory used to relativize source paths and resolve html source view (default: cwd)
-    --threshold <pct>            High/medium coverage cutoff for html reports (0-100, default: 80)
+    --threshold <pct>            Percentage at or above which html-report cells render green
+                                 (0-100, default: 80). Cells below this go amber down to 50%
+                                 and red below 50%. Affects display only; does not gate the
+                                 process exit code. Rejected on non-html formats.
 
 GLOBAL OPTIONS:
     -V, --version                Print version
@@ -450,7 +474,10 @@ OPTIONS:
     -o, --output <file>          Write report to file (default: stdout). Not valid for --format html.
     --output-dir <dir>           Output directory for multi-file formats (html). Default: ./coverage
     --root <dir>                 Root directory used to relativize source paths and resolve html source view (default: cwd)
-    --threshold <pct>            High/medium coverage cutoff for html reports (0-100, default: 80)
+    --threshold <pct>            Percentage at or above which html-report cells render green
+                                 (0-100, default: 80). Cells below this go amber down to 50%
+                                 and red below 50%. Affects display only; does not gate the
+                                 process exit code. Rejected on non-html formats.
     -h, --help                   Print this help"
     );
 }

--- a/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
+++ b/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
@@ -327,11 +327,16 @@ fn report_html_format_writes_directory_tree() {
     assert!(out_dir.join("index.html").exists(), "root index.html missing");
     assert!(out_dir.join("base.css").exists(), "base.css missing");
     assert!(out_dir.join("base.js").exists(), "base.js missing");
+    // base.css `@import`s coverage-tokens.css: dropping the sibling file
+    // would silently break the palette without any compile-time signal,
+    // so guard it at the CLI integration layer too.
+    assert!(out_dir.join("coverage-tokens.css").exists(), "coverage-tokens.css missing");
     assert!(out_dir.join("a.js.html").exists(), "per-file detail page missing");
     let detail = std::fs::read_to_string(out_dir.join("a.js.html")).unwrap();
     assert!(detail.contains("<title>Coverage: a.js</title>"), "got:\n{detail}");
     assert!(detail.contains("Content-Security-Policy"), "CSP meta missing in CLI output");
     assert!(detail.contains("base.js"), "script reference missing in CLI output");
+    assert!(detail.contains("<meta name=\"generator\""), "generator meta missing in CLI output");
 }
 
 #[test]

--- a/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
+++ b/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
@@ -357,6 +357,53 @@ fn report_html_rejects_dash_o_with_friendly_error() {
 }
 
 #[test]
+fn report_html_threshold_flag_overrides_default_summary() {
+    let cov = write_temp("report_html_threshold.json", SAMPLE_COVERAGE);
+    let out_dir = std::env::temp_dir().join("oxc_cov_cli_html_threshold_out");
+    let _ = std::fs::remove_dir_all(&out_dir);
+    let out = cli()
+        .arg("report")
+        .arg("--format")
+        .arg("html")
+        .arg("--output-dir")
+        .arg(&out_dir)
+        .arg("--threshold")
+        .arg("40")
+        .arg(&cov)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let index = std::fs::read_to_string(out_dir.join("index.html")).unwrap();
+    // SAMPLE_COVERAGE has one file with 50% statement coverage. With the
+    // CLI default 80% threshold the sentence reads "below the 80%
+    // line-coverage threshold"; with --threshold 40 the cutoff drops and
+    // the file is now above, so the sentence flips to the all-met form.
+    assert!(
+        index.contains("40% line-coverage threshold"),
+        "summary should reflect --threshold 40, got:\n{index}",
+    );
+}
+
+#[test]
+fn report_html_threshold_rejects_out_of_range_values() {
+    let cov = write_temp("report_html_threshold_bad.json", SAMPLE_COVERAGE);
+    let out = cli()
+        .arg("report")
+        .arg("--format")
+        .arg("html")
+        .arg("--output-dir")
+        .arg(std::env::temp_dir().join("oxc_cov_cli_html_threshold_bad_out"))
+        .arg("--threshold")
+        .arg("150")
+        .arg(&cov)
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "should reject --threshold 150");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("outside [0, 100]"), "got: {stderr}");
+}
+
+#[test]
 fn report_text_rejects_output_dir_with_friendly_error() {
     let cov = write_temp("report_text_dash_dir.json", SAMPLE_COVERAGE);
     let out = cli()

--- a/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
+++ b/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
@@ -376,10 +376,10 @@ fn report_html_threshold_flag_overrides_default_summary() {
     let index = std::fs::read_to_string(out_dir.join("index.html")).unwrap();
     // SAMPLE_COVERAGE has one file with 50% statement coverage. With the
     // CLI default 80% threshold the sentence reads "below the 80%
-    // line-coverage threshold"; with --threshold 40 the cutoff drops and
+    // coverage threshold"; with --threshold 40 the cutoff drops and
     // the file is now above, so the sentence flips to the all-met form.
     assert!(
-        index.contains("40% line-coverage threshold"),
+        index.contains("40% coverage threshold"),
         "summary should reflect --threshold 40, got:\n{index}",
     );
 }
@@ -401,6 +401,50 @@ fn report_html_threshold_rejects_out_of_range_values() {
     assert!(!out.status.success(), "should reject --threshold 150");
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("outside [0, 100]"), "got: {stderr}");
+}
+
+#[test]
+fn report_html_threshold_rejects_non_finite_values() {
+    let cov = write_temp("report_html_threshold_nan.json", SAMPLE_COVERAGE);
+    // `f64::from_str` parses NaN successfully; without an explicit
+    // `is_finite()` guard the value would slip past the range check
+    // and silently degrade every percent to the "medium" bucket.
+    for bad in ["nan", "inf", "-inf"] {
+        let out = cli()
+            .arg("report")
+            .arg("--format")
+            .arg("html")
+            .arg("--output-dir")
+            .arg(std::env::temp_dir().join("oxc_cov_cli_html_threshold_nan_out"))
+            .arg("--threshold")
+            .arg(bad)
+            .arg(&cov)
+            .output()
+            .unwrap();
+        assert!(!out.status.success(), "should reject --threshold {bad}");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("finite number") || stderr.contains("outside [0, 100]"),
+            "rejection for {bad:?} should mention finite-number or range; got: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn report_threshold_rejected_on_non_html_formats() {
+    let cov = write_temp("report_threshold_lcov.json", SAMPLE_COVERAGE);
+    let out = cli()
+        .arg("report")
+        .arg("--format")
+        .arg("lcov")
+        .arg("--threshold")
+        .arg("70")
+        .arg(&cov)
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "should reject --threshold on lcov");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--threshold only applies to --format html"), "got: {stderr}");
 }
 
 #[test]

--- a/crates/oxc-coverage-reports/Cargo.toml
+++ b/crates/oxc-coverage-reports/Cargo.toml
@@ -14,12 +14,33 @@ categories = ["development-tools::testing"]
 [lints]
 workspace = true
 
+[features]
+# `html` pulls in the multi-file HTML reporter and its embedded syntect-based
+# server-side syntax highlighter (~500 KB of grammar / theme data in the
+# resulting binary). Downstream consumers that only need text / lcov /
+# cobertura / json-summary can opt out with `default-features = false`.
+default = ["html"]
+html = ["dep:syntect", "dep:two-face", "dep:rayon"]
+
 [dependencies]
 oxc_coverage_report = { path = "../oxc-coverage-report", version = "0.1.0" }
 oxc_coverage_source_maps = { path = "../oxc-coverage-source-maps", version = "0.1.0" }
 oxc_coverage_types = { path = "../oxc-coverage-types", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Server-side syntax highlighter for the html reporter. `default-fancy`
+# selects the pure-Rust `fancy-regex` backend (no Oniguruma C dep), keeping
+# cross-compilation simple on Windows. Bundled grammars and themes are
+# embedded into the binary via the same feature set.
+syntect = { version = "5.3", default-features = false, features = ["default-fancy"], optional = true }
+# Extra syntect grammars (TypeScript / TSX / JSX / and many others) that
+# the bundled `default-fancy` set leaves out. Used together with syntect
+# behind the same pure-Rust `fancy-regex` backend.
+two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"], optional = true }
+# Data parallelism for per-file detail-page rendering. Syntect tokenization
+# is CPU-bound; running it across cores keeps emit time linear in
+# wall-clock terms even on large monorepos.
+rayon = { version = "1.10", optional = true }
 
 [dev-dependencies]
 insta = { version = "1", features = ["json"] }

--- a/crates/oxc-coverage-reports/src/html/base.css
+++ b/crates/oxc-coverage-reports/src/html/base.css
@@ -1,153 +1,147 @@
 /* oxc-coverage-instrument HTML reporter base stylesheet.
  *
- * Hand-rolled, single-file, no external font / JS dependencies.
+ * Renders the static coverage report in fallow's "Mode B" (stakeholder
+ * artifact) visual language. The token layer lives in a sibling file,
+ * `coverage-tokens.css`, which is `@import`-ed at the top so the same
+ * palette can be vendored into fallow-cloud (or anywhere else) without
+ * touching the structural rules below.
  *
- * Theme:
- *   - Default palette is light; `prefers-color-scheme: dark` switches the
- *     palette automatically.
- *   - The `data-theme="dark"` / `data-theme="light"` attribute on <html>
- *     (set by base.js when the user clicks the toggle) overrides the
- *     media query, so the user choice always wins.
- *
- * Syntax highlighting: classes `.tok-k`, `.tok-s`, `.tok-c`, `.tok-n`,
- * `.tok-b`, `.tok-p` are applied to source spans by base.js. Without JS,
- * the source still renders in plain monospace text.
+ * Hard constraints: file://-portable, strict CSP (no web fonts, no
+ * external assets), no JS required for the visual layer (sortable +
+ * filter + line-anchor are progressive enhancement on top).
  */
+@import url("coverage-tokens.css");
 
-:root {
-  color-scheme: light dark;
+/* ---- Base + reset ----------------------------------------------------- */
+*,
+*::before,
+*::after { box-sizing: border-box; }
 
-  --bg: #ffffff;
-  --text: #1d2129;
-  --muted: #66707a;
-  --border: #e3e6ea;
-  --header-bg: #f5f6f8;
-  --hit-bg: #e6ffed;
-  --miss-bg: #ffeef0;
-  --partial-bg: #fff8c5;
-  --pct-high: #1f8b3a;
-  --pct-medium: #b08800;
-  --pct-low: #c1271d;
-  --row-high: #e6f4ea;
-  --row-medium: #fff8c5;
-  --row-low: #ffeef0;
-  --link: #0366d6;
-  --gutter-bg: #f6f8fa;
-  --code-bg: #fdfdfd;
-  --focus-ring: #0366d6;
-  --btn-bg: #ffffff;
-  --btn-bg-active: #0366d6;
-  --btn-fg-active: #ffffff;
+html,
+body { margin: 0; padding: 0; }
 
-  --tok-keyword: #cf222e;
-  --tok-string: #0a3069;
-  --tok-comment: #6e7781;
-  --tok-number: #0550ae;
-  --tok-builtin: #8250df;
-  --tok-punct: #57606a;
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    color-scheme: dark;
-
-    --bg: #14171c;
-    --text: #e6e9ef;
-    --muted: #9aa2ad;
-    --border: #2a2f37;
-    --header-bg: #1c2027;
-    --hit-bg: #173527;
-    --miss-bg: #3d1a1f;
-    --partial-bg: #3a3220;
-    --pct-high: #6ee787;
-    --pct-medium: #f0b429;
-    --pct-low: #ff7b72;
-    --row-high: #1b2a23;
-    --row-medium: #2b2620;
-    --row-low: #2a1b1f;
-    --link: #58a6ff;
-    --gutter-bg: #1a1e25;
-    --code-bg: #0d1117;
-    --focus-ring: #58a6ff;
-    --btn-bg: #1c2027;
-    --btn-bg-active: #1f6feb;
-    --btn-fg-active: #ffffff;
-
-    --tok-keyword: #ff7b72;
-    --tok-string: #a5d6ff;
-    --tok-comment: #8b949e;
-    --tok-number: #79c0ff;
-    --tok-builtin: #d2a8ff;
-    --tok-punct: #8b949e;
-  }
-}
-
-:root[data-theme="dark"] {
-  color-scheme: dark;
-
-  --bg: #14171c;
-  --text: #e6e9ef;
-  --muted: #9aa2ad;
-  --border: #2a2f37;
-  --header-bg: #1c2027;
-  --hit-bg: #173527;
-  --miss-bg: #3d1a1f;
-  --partial-bg: #3a3220;
-  --pct-high: #6ee787;
-  --pct-medium: #f0b429;
-  --pct-low: #ff7b72;
-  --row-high: #1b2a23;
-  --row-medium: #2b2620;
-  --row-low: #2a1b1f;
-  --link: #58a6ff;
-  --gutter-bg: #1a1e25;
-  --code-bg: #0d1117;
-  --focus-ring: #58a6ff;
-  --btn-bg: #1c2027;
-  --btn-bg-active: #1f6feb;
-  --btn-fg-active: #ffffff;
-
-  --tok-keyword: #ff7b72;
-  --tok-string: #a5d6ff;
-  --tok-comment: #8b949e;
-  --tok-number: #79c0ff;
-  --tok-builtin: #d2a8ff;
-  --tok-punct: #8b949e;
-}
-
-* { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; }
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  font-size: 14px;
-  line-height: 1.5;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  min-height: 100vh;
 }
-a { color: var(--link); text-decoration: none; }
-a:hover, a:focus { text-decoration: underline; }
-:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; border-radius: 2px; }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-heading);
+  color: var(--text-high);
+  line-height: var(--leading-tight);
+  margin: 0 0 0.5em;
+}
+h1 { font-size: var(--text-2xl); font-weight: 700; letter-spacing: var(--tracking-display); }
+h2 { font-size: var(--text-xl); font-weight: 700; }
+h3 { font-size: var(--text-lg); font-weight: 600; }
+
+a { color: var(--link); text-decoration: none; }
+a:hover,
+a:focus-visible { text-decoration: underline; }
+
+:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+::selection {
+  background-color: var(--blue-subtle);
+  color: var(--text-high);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Visually-hidden helper (for screen-reader-only labels) */
+.sr-only {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- Page header (h1 + breadcrumb + KPI row + theme toggle) ---------- */
 header.summary {
   background: var(--header-bg);
   border-bottom: 1px solid var(--border);
-  padding: 16px 24px;
+  padding: 24px 32px 20px;
   position: relative;
 }
 header.summary h1 {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  letter-spacing: var(--tracking-display);
   margin: 0 0 8px 0;
-  font-size: 20px;
-  font-weight: 600;
 }
-.breadcrumb {
-  font-size: 12px;
-  color: var(--muted);
-  margin-bottom: 12px;
-}
-.breadcrumb a { color: var(--link); }
-.breadcrumb .current { color: var(--text); font-weight: 500; }
 
-ul.metrics {
+/* Breadcrumb: <nav><ol><li>...</li></ol></nav> (a11y: aria-label="Breadcrumb",
+ * aria-current="page" on the last <span>). */
+.breadcrumb {
+  font-size: var(--text-xs);
+  color: var(--muted);
+  margin-bottom: 16px;
+}
+.breadcrumb ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.breadcrumb li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.breadcrumb a { color: var(--muted); }
+.breadcrumb a:hover { color: var(--text); text-decoration: underline; }
+.breadcrumb .current { color: var(--text); font-weight: 500; }
+.breadcrumb-sep {
+  color: var(--text-muted);
+  user-select: none;
+}
+
+/* Threshold summary sentence ("X of Y files below 80%"). Below the
+ * KPI row, before the table. Plain Inter, low-weight, muted. */
+.threshold-summary {
+  font-size: var(--text-sm);
+  color: var(--muted);
+  margin: 8px 0 0;
+}
+.threshold-summary strong { color: var(--text); font-weight: 600; }
+
+/* KPI metric pills (Statements / Branches / Functions / Lines) */
+.kpi-row {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -155,32 +149,52 @@ ul.metrics {
   flex-wrap: wrap;
   gap: 12px;
 }
-.metric {
-  background: var(--bg);
+.kpi-cell {
+  flex: 1 1 0;
+  min-width: 144px;
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 10px 14px;
-  min-width: 140px;
+  background: var(--bg);
+  padding: 12px 16px;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
-.metric .label { font-size: 11px; text-transform: uppercase; color: var(--muted); letter-spacing: 0.04em; }
-.metric .pct { font-size: 22px; font-weight: 700; }
-.metric .quiet { font-size: 12px; color: var(--muted); }
-.metric.high .pct { color: var(--pct-high); }
-.metric.medium .pct { color: var(--pct-medium); }
-.metric.low .pct { color: var(--pct-low); }
+.kpi-cell__label {
+  font-family: var(--font-code);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
+  color: var(--muted);
+  white-space: nowrap;
+}
+/* The default text colour for the value is the neutral text token, not
+ * a severity colour. Every metric pill must carry an explicit
+ * `kpi-cell--{high,medium,low}` modifier; a missing modifier renders
+ * neutral rather than silently green. */
+.kpi-cell__value {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: var(--tracking-display);
+  color: var(--text);
+}
+.kpi-cell--high .kpi-cell__value { color: var(--pct-high); }
+.kpi-cell--medium .kpi-cell__value { color: var(--pct-medium); }
+.kpi-cell--low .kpi-cell__value { color: var(--pct-low); }
+.kpi-cell__sub {
+  font-family: var(--font-code);
+  font-size: var(--text-xs);
+  color: var(--muted);
+}
 
-/* Theme toggle (inserted by base.js into header.summary) */
+/* Theme toggle (top-right of header.summary) */
 .theme-toggle {
   position: absolute;
-  top: 16px;
-  right: 24px;
+  top: 24px;
+  right: 32px;
   display: inline-flex;
   border: 1px solid var(--border);
-  border-radius: 6px;
-  overflow: hidden;
   background: var(--btn-bg);
 }
 .theme-toggle__btn {
@@ -189,10 +203,12 @@ ul.metrics {
   border: 0;
   color: var(--muted);
   font: inherit;
-  font-size: 12px;
-  padding: 6px 10px;
+  font-family: var(--font-code);
+  font-size: var(--text-xs);
+  padding: 6px 12px;
   cursor: pointer;
   border-right: 1px solid var(--border);
+  transition: color 100ms ease-out, background-color 100ms ease-out;
 }
 .theme-toggle__btn:last-child { border-right: 0; }
 .theme-toggle__btn:hover { color: var(--text); }
@@ -201,59 +217,187 @@ ul.metrics {
   color: var(--btn-fg-active);
 }
 
-.pad1 { padding: 16px 24px; }
+/* Ghost button (used by "Next uncovered" and any future action buttons).
+ * Carries fallow's brutalist offset shadow per the design-system token. */
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  background: var(--btn-bg);
+  color: var(--text);
+  font-family: var(--font-code);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  height: 32px;
+  padding: 0 14px;
+  cursor: pointer;
+  text-decoration: none;
+  box-shadow: var(--shadow-button-ghost);
+  transition: box-shadow 100ms ease-out, background-color 100ms ease-out;
+}
+.btn-ghost:hover:not(:disabled) {
+  background: var(--surface-2);
+  box-shadow: var(--shadow-button-ghost-hover);
+}
+.btn-ghost:active:not(:disabled) { box-shadow: var(--shadow-button-ghost-active); }
+.btn-ghost:disabled { opacity: 0.45; cursor: not-allowed; box-shadow: none; }
+@media (prefers-reduced-motion: reduce) {
+  .btn-ghost { transition: none; }
+}
 
+/* ---- Filter (index pages) -------------------------------------------- */
+.pad1 { padding: 24px 32px; }
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+  max-width: 480px;
+}
+.filter-group__label {
+  font-family: var(--font-code);
+  font-size: var(--text-xs);
+  color: var(--muted);
+}
+.filter-input {
+  display: block;
+  width: 100%;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--font-code);
+  font-size: var(--text-sm);
+  line-height: 1.3;
+  color: var(--text);
+  padding: 8px 12px;
+  transition: border-color 100ms ease-out, box-shadow 100ms ease-out;
+}
+.filter-input::placeholder { color: var(--muted); }
+.filter-input:hover:not(:focus) { border-color: var(--border-strong); }
+.filter-input:focus {
+  outline: none;
+  border-color: var(--blue-text);
+  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--blue-text);
+}
+.filter-count {
+  font-family: var(--font-code);
+  font-size: var(--text-xs);
+  color: var(--muted);
+  min-height: 1em;
+}
+@media (prefers-reduced-motion: reduce) {
+  .filter-input { transition: none; }
+}
+
+/* ---- Index summary table --------------------------------------------- */
 table.coverage-summary {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: var(--text-sm);
+}
+table.coverage-summary thead {
+  position: sticky;
+  top: 0;
+  background: var(--header-bg);
+  z-index: 1;
 }
 table.coverage-summary th,
 table.coverage-summary td {
   text-align: right;
-  padding: 6px 12px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--border);
 }
-table.coverage-summary th { font-weight: 600; color: var(--muted); }
+table.coverage-summary th {
+  font-family: var(--font-code);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
+  color: var(--muted);
+}
+table.coverage-summary tbody tr:hover { background: var(--surface-2); }
 table.coverage-summary td.file { text-align: left; }
+table.coverage-summary td.file a { color: var(--link); }
 table.coverage-summary tr.row-high { background: var(--row-high); }
 table.coverage-summary tr.row-medium { background: var(--row-medium); }
 table.coverage-summary tr.row-low { background: var(--row-low); }
 table.coverage-summary td.pct.high { color: var(--pct-high); }
 table.coverage-summary td.pct.medium { color: var(--pct-medium); }
 table.coverage-summary td.pct.low { color: var(--pct-low); }
-table.coverage-summary .quiet { color: var(--muted); font-size: 11px; }
+table.coverage-summary .quiet {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  font-family: var(--font-code);
+}
 
-/* Sortable column headers (enhanced by base.js; without JS, no .sortable class).
- * The indicator is an inline ::after sibling glued to the label text so it
- * stays adjacent regardless of cell alignment. Unicode triangles, no SVGs. */
+/* Sortable column headers: progressive enhancement, .sortable class
+ * added by base.js. Inline ::after Unicode arrows keep the indicator
+ * adjacent to the label regardless of cell alignment. */
 table.coverage-summary th.sortable {
   cursor: pointer;
   user-select: none;
 }
 table.coverage-summary th.sortable:first-child { text-align: left; }
 table.coverage-summary th.sortable::after {
-  content: " \2195"; /* ↕ both-directions, unsorted */
+  content: " \2195";
   margin-left: 4px;
   font-size: 0.85em;
   opacity: 0.35;
   display: inline-block;
 }
 table.coverage-summary th.sortable[aria-sort="ascending"]::after {
-  content: " \25B2"; /* ▲ */
+  content: " \25B2";
   opacity: 0.95;
 }
 table.coverage-summary th.sortable[aria-sort="descending"]::after {
-  content: " \25BC"; /* ▼ */
+  content: " \25BC";
   opacity: 0.95;
 }
 table.coverage-summary th.sortable:hover { color: var(--text); }
+table.coverage-summary th.sortable:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
 
+/* Mini coverage meter inline in the index table. Track + severity fill,
+ * 1px outline, 0 radius (fallow Meter pattern). */
+.cov-meter {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 6px;
+  margin-left: 8px;
+  vertical-align: middle;
+  background: var(--gutter-bg);
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+.cov-meter__fill {
+  display: block;
+  height: 100%;
+  background: var(--hit-solid);
+}
+.cov-meter--medium .cov-meter__fill { background: var(--partial-solid); }
+.cov-meter--low .cov-meter__fill { background: var(--miss-solid); }
+
+/* ---- Detail page: action header (Next uncovered + back) -------------- */
+.detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+/* ---- Detail page source table ---------------------------------------- */
 table.source {
   width: 100%;
   border-collapse: collapse;
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 13px;
+  font-family: var(--font-code);
+  font-size: var(--text-sm);
+  line-height: 1.5;
   background: var(--code-bg);
 }
 table.source th,
@@ -263,49 +407,118 @@ table.source td {
 }
 table.source thead {
   background: var(--header-bg);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  font-weight: 600;
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: 500;
   color: var(--muted);
-  font-size: 11px;
   text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
 }
-table.source th { text-align: left; padding: 6px 12px; border-bottom: 1px solid var(--border); }
+table.source th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* Gutter cells (line-num + hits + severity glyph) */
 table.source td.line-num {
   text-align: right;
   background: var(--gutter-bg);
   color: var(--muted);
-  width: 56px;
+  width: 64px;
   user-select: none;
+  border-left: 2px solid transparent;
+  position: relative;
 }
 table.source td.hits {
   text-align: right;
-  color: var(--muted);
-  width: 64px;
   background: var(--gutter-bg);
+  color: var(--muted);
+  width: 80px;
   user-select: none;
+  font-size: var(--text-xs);
 }
 table.source td.src pre {
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* Line anchor button: appears inside td.line-num. Renders the line
+ * number as a clickable button that copies #L<n> to the URL hash and
+ * the clipboard. Falls back to plain text without JS. */
+.line-anchor {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+.line-anchor:hover { color: var(--text); text-decoration: underline; }
+.line-anchor:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Coverage row backgrounds + 2px left luminance bar.
+ * The luminance values are chosen so all three are distinguishable
+ * under grayscale (WCAG 1.4.1 non-color cue). */
 table.source tr.line.hit { background: var(--hit-bg); }
 table.source tr.line.miss { background: var(--miss-bg); }
 table.source tr.line.partial { background: var(--partial-bg); }
 table.source tr.line.no-stmt { background: var(--code-bg); }
+
+table.source tr.line.hit > td.line-num { border-left-color: var(--hit-solid); }
+table.source tr.line.miss > td.line-num { border-left-color: var(--miss-solid); }
+table.source tr.line.partial > td.line-num { border-left-color: var(--partial-solid); }
+
+/* Keyboard parity with mouse hover: any row containing keyboard focus
+ * gets the same emphasis a hover would give. */
+table.source tr.line:hover,
+table.source tr.line:focus-within {
+  filter: brightness(0.98);
+}
+
+/* Anchor target (when navigating to #L42) */
+table.source tr.line:target {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+  scroll-margin-top: 80px;
+}
+
+/* Branch note appended after partial lines */
 table.source .branch-note {
   display: inline-block;
   margin-left: 8px;
-  font-size: 11px;
+  font-size: var(--text-xs);
+  font-family: var(--font-body);
   color: var(--muted);
 }
 
-/* Syntax highlighting, applied to syntect-rendered spans on detail
- * pages. Classes use the `stok-` prefix (server-side syntect emits
- * them via ClassStyle::SpacedPrefixed) so they cannot collide with
- * coverage row classes. Selectors match the leading TextMate scope
- * segment; trailing segments (e.g. `stok-double-slash`, `stok-quoted`)
- * are kept in markup for finer theming in G4 but ignored here. */
+/* Severity glyph (`[H]`/`[P]`/`[M]`) placed in the hits cell so it sits
+ * alongside the per-line hit count and acts as a non-color coverage cue
+ * for users with deuteranopia/protanopia. aria-hidden in markup; the
+ * row's aria-label conveys the same information to screen readers. */
+.sev-glyph {
+  display: inline-block;
+  font-family: var(--font-code);
+  font-weight: 700;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  margin-right: 6px;
+}
+.sev-glyph--hit { color: var(--hit-solid); }
+.sev-glyph--partial { color: var(--partial-solid); }
+.sev-glyph--miss { color: var(--miss-solid); }
+
+/* ---- Syntax-highlighting tokens (consumed by syntect-emitted spans) -- */
+/* Selectors target the leading TextMate scope segment that syntect
+ * emits via ClassStyle::SpacedPrefixed { prefix: "stok-" }. Trailing
+ * scope-tail classes (e.g. `stok-double-slash`) are kept in markup for
+ * finer theming but unused here. */
 .stok-comment { color: var(--tok-comment); font-style: italic; }
 .stok-keyword { color: var(--tok-keyword); font-weight: 600; }
 .stok-storage { color: var(--tok-keyword); font-weight: 600; }
@@ -315,3 +528,24 @@ table.source .branch-note {
 .stok-entity { color: var(--tok-builtin); }
 .stok-variable.stok-language { color: var(--tok-keyword); }
 .stok-punctuation { color: var(--tok-punct); }
+
+/* ---- Copy-toast live region for the line-anchor confirmation -------- */
+.copy-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface-3);
+  color: var(--text);
+  border: 1px solid var(--border);
+  font-family: var(--font-code);
+  font-size: var(--text-xs);
+  padding: 8px 12px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease-out;
+}
+.copy-toast.visible { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .copy-toast { transition: none; }
+}

--- a/crates/oxc-coverage-reports/src/html/base.css
+++ b/crates/oxc-coverage-reports/src/html/base.css
@@ -300,10 +300,18 @@ table.source .branch-note {
   color: var(--muted);
 }
 
-/* Syntax highlighting (applied by base.js prettify pass) */
-.tok-k { color: var(--tok-keyword); font-weight: 600; }
-.tok-s { color: var(--tok-string); }
-.tok-c { color: var(--tok-comment); font-style: italic; }
-.tok-n { color: var(--tok-number); }
-.tok-b { color: var(--tok-builtin); }
-.tok-p { color: var(--tok-punct); }
+/* Syntax highlighting, applied to syntect-rendered spans on detail
+ * pages. Classes use the `stok-` prefix (server-side syntect emits
+ * them via ClassStyle::SpacedPrefixed) so they cannot collide with
+ * coverage row classes. Selectors match the leading TextMate scope
+ * segment; trailing segments (e.g. `stok-double-slash`, `stok-quoted`)
+ * are kept in markup for finer theming in G4 but ignored here. */
+.stok-comment { color: var(--tok-comment); font-style: italic; }
+.stok-keyword { color: var(--tok-keyword); font-weight: 600; }
+.stok-storage { color: var(--tok-keyword); font-weight: 600; }
+.stok-string { color: var(--tok-string); }
+.stok-constant { color: var(--tok-number); }
+.stok-support { color: var(--tok-builtin); }
+.stok-entity { color: var(--tok-builtin); }
+.stok-variable.stok-language { color: var(--tok-keyword); }
+.stok-punctuation { color: var(--tok-punct); }

--- a/crates/oxc-coverage-reports/src/html/base.js
+++ b/crates/oxc-coverage-reports/src/html/base.js
@@ -1,13 +1,16 @@
-/* oxc-coverage-instrument HTML reporter, PR G2 polish layer.
+/* oxc-coverage-instrument HTML reporter client script.
  *
  * Self-contained, no external dependencies, no network access. Provides:
  *   1. theme toggle (auto / light / dark, persisted to localStorage),
- *   2. sortable index tables (click or keyboard, aria-sort updates),
- *   3. lightweight JS / TS syntax highlighting on detail-page sources.
+ *   2. sortable index tables (click or keyboard, aria-sort updates).
  *
- * The page is fully usable without JS: missing JS just means no sort, no
- * explicit toggle (prefers-color-scheme still works), and no syntax
- * highlighting. Every feature is progressive enhancement.
+ * Syntax highlighting of source view is done server-side in Rust via
+ * syntect; the detail-page HTML arrives pre-spanned so there is no
+ * client-side tokenizer or paint-time work here.
+ *
+ * The page is fully usable without JS: missing JS just means no sort
+ * and no explicit theme toggle (prefers-color-scheme still works).
+ * Every feature is progressive enhancement.
  *
  * Note: this script uses DOM methods (createElement / textContent /
  * appendChild) exclusively. It never assigns HTML strings, so it cannot
@@ -183,159 +186,14 @@
     return trimmed;
   }
 
-  // ---------- Source prettify -------------------------------------------
-  // Tiny tokenizer covering JS / TS / JSX surface adequate for an
-  // unminified source view. Aims for "GitHub-style readable", not a
-  // full language parser. Emits <span class="tok-*"> nodes via the DOM.
-  var KEYWORDS = (
-    'abstract,any,as,async,await,boolean,break,case,catch,class,const,' +
-    'constructor,continue,debugger,declare,default,delete,do,else,enum,' +
-    'export,extends,false,finally,for,from,function,get,if,implements,' +
-    'import,in,infer,instanceof,interface,is,keyof,let,module,namespace,' +
-    'never,new,null,number,object,of,override,package,private,protected,' +
-    'public,readonly,require,return,satisfies,set,static,string,super,' +
-    'switch,symbol,this,throw,true,try,type,typeof,undefined,unique,unknown,' +
-    'var,void,while,with,yield'
-  ).split(',');
-  var KEYWORD_SET = {};
-  for (var ki = 0; ki < KEYWORDS.length; ki++) { KEYWORD_SET[KEYWORDS[ki]] = true; }
-
-  var BUILTINS = (
-    'Array,ArrayBuffer,Boolean,Buffer,console,DataView,Date,document,Error,' +
-    'EvalError,Function,globalThis,Infinity,Intl,JSON,Map,Math,NaN,' +
-    'Number,Object,process,Promise,Proxy,RangeError,ReferenceError,Reflect,' +
-    'RegExp,Set,String,Symbol,SyntaxError,TypeError,URIError,WeakMap,WeakSet,window'
-  ).split(',');
-  var BUILTIN_SET = {};
-  for (var bi = 0; bi < BUILTINS.length; bi++) { BUILTIN_SET[BUILTINS[bi]] = true; }
-
-  function isIdentStart(ch) {
-    return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch === '_' || ch === '$';
-  }
-  function isIdentCont(ch) {
-    return isIdentStart(ch) || (ch >= '0' && ch <= '9');
-  }
-  function isDigit(ch) { return ch >= '0' && ch <= '9'; }
-  function isHexCont(ch) {
-    return isDigit(ch) || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
-      || ch === '_' || ch === '.';
-  }
-
-  function tokenize(src) {
-    var tokens = [];
-    var i = 0;
-    var n = src.length;
-    while (i < n) {
-      var ch = src.charAt(i);
-
-      // line comment
-      if (ch === '/' && src.charAt(i + 1) === '/') {
-        var j = i + 2;
-        while (j < n && src.charAt(j) !== '\n') { j++; }
-        tokens.push(['c', src.slice(i, j)]);
-        i = j;
-        continue;
-      }
-
-      // block comment
-      if (ch === '/' && src.charAt(i + 1) === '*') {
-        var k = i + 2;
-        while (k + 1 < n && !(src.charAt(k) === '*' && src.charAt(k + 1) === '/')) {
-          k++;
-        }
-        k = k + 1 < n ? k + 2 : n;
-        tokens.push(['c', src.slice(i, k)]);
-        i = k;
-        continue;
-      }
-
-      // string / template
-      if (ch === '"' || ch === '\'' || ch === '`') {
-        var quote = ch;
-        var m = i + 1;
-        while (m < n) {
-          var cc = src.charAt(m);
-          if (cc === '\\' && m + 1 < n) { m += 2; continue; }
-          if (cc === quote) { m++; break; }
-          if (cc === '\n' && quote !== '`') { break; }
-          m++;
-        }
-        tokens.push(['s', src.slice(i, m)]);
-        i = m;
-        continue;
-      }
-
-      // number (decimal / hex / float). Heuristic; good enough.
-      if (isDigit(ch) || (ch === '.' && isDigit(src.charAt(i + 1)))) {
-        var p = i + 1;
-        while (p < n && isHexCont(src.charAt(p))) { p++; }
-        if (p < n && (src.charAt(p) === 'n' || src.charAt(p) === 'e' || src.charAt(p) === 'E')) {
-          p++;
-          if (p < n && (src.charAt(p) === '+' || src.charAt(p) === '-')) { p++; }
-          while (p < n && isDigit(src.charAt(p))) { p++; }
-        }
-        tokens.push(['n', src.slice(i, p)]);
-        i = p;
-        continue;
-      }
-
-      // identifier / keyword / builtin
-      if (isIdentStart(ch)) {
-        var q = i + 1;
-        while (q < n && isIdentCont(src.charAt(q))) { q++; }
-        var word = src.slice(i, q);
-        if (KEYWORD_SET[word]) { tokens.push(['k', word]); }
-        else if (BUILTIN_SET[word]) { tokens.push(['b', word]); }
-        else { tokens.push(['i', word]); }
-        i = q;
-        continue;
-      }
-
-      // punctuation (single char is enough for highlight purposes)
-      if ('+-*/%=<>!&|^~?:,;.(){}[]'.indexOf(ch) !== -1) {
-        tokens.push(['p', ch]);
-        i++;
-        continue;
-      }
-
-      // anything else (whitespace / unicode / etc): pass through plain
-      tokens.push(['t', ch]);
-      i++;
-    }
-    return tokens;
-  }
-
-  function renderTokensInto(pre, tokens) {
-    while (pre.firstChild) { pre.removeChild(pre.firstChild); }
-    for (var i = 0; i < tokens.length; i++) {
-      var kind = tokens[i][0];
-      var text = tokens[i][1];
-      if (kind === 't' || kind === 'i') {
-        pre.appendChild(document.createTextNode(text));
-      } else {
-        var span = document.createElement('span');
-        span.className = 'tok-' + kind;
-        span.textContent = text;
-        pre.appendChild(span);
-      }
-    }
-  }
-
-  function initPrettify() {
-    var pres = document.querySelectorAll('table.source td.src pre');
-    for (var i = 0; i < pres.length; i++) {
-      var pre = pres[i];
-      var text = pre.textContent;
-      if (!text || text === '(source unavailable)') { continue; }
-      renderTokensInto(pre, tokenize(text));
-    }
-  }
+  // Source syntax highlighting is rendered server-side by syntect, so
+  // there is no client-side tokenizer here. The detail-page <pre> cells
+  // arrive with `<span class="stok-...">` markup already in the HTML.
 
   // ---------- Boot ------------------------------------------------------
   function boot() {
     buildThemeToggle();
     initSortable();
-    initPrettify();
   }
 
   if (document.readyState === 'loading') {

--- a/crates/oxc-coverage-reports/src/html/base.js
+++ b/crates/oxc-coverage-reports/src/html/base.js
@@ -261,7 +261,8 @@
 
   // ---------- Line anchors (detail pages) -------------------------------
   // Hooks: <button class="line-anchor" data-line="42"> inside td.line-num,
-  // + <div id="cov-copy-toast" role="status" aria-live="polite">.
+  // + <div id="cov-copy-toast" role="status">. (role="status" implies
+  // aria-live="polite" per the WAI-ARIA spec, no need to declare both.)
   // Clicking the button: scrolls to the row via hash, copies the
   // canonical link to the clipboard, flashes a toast.
   function initLineAnchors() {

--- a/crates/oxc-coverage-reports/src/html/base.js
+++ b/crates/oxc-coverage-reports/src/html/base.js
@@ -190,10 +190,164 @@
   // there is no client-side tokenizer here. The detail-page <pre> cells
   // arrive with `<span class="stok-...">` markup already in the HTML.
 
+  // ---------- File filter (index pages) ---------------------------------
+  // Hooks: <input id="cov-filter"> + <div id="cov-filter-count"> +
+  // <table id="cov-file-table">. Each tbody row carries data-file="..."
+  // populated by the Rust render. Without JS the input is inert and the
+  // count region stays empty; the table is fully usable.
+  function initFilter() {
+    var input = document.getElementById('cov-filter');
+    var table = document.getElementById('cov-file-table');
+    var count = document.getElementById('cov-filter-count');
+    if (!input || !table) { return; }
+    var tbody = table.tBodies[0];
+    if (!tbody) { return; }
+    var rows = Array.prototype.slice.call(tbody.rows);
+    var total = rows.length;
+    if (count && count.getAttribute('data-total')) {
+      total = parseInt(count.getAttribute('data-total'), 10) || total;
+    }
+
+    var debounceHandle = 0;
+    function applyFilter() {
+      var q = input.value.trim().toLowerCase();
+      var shown = 0;
+      for (var i = 0; i < rows.length; i++) {
+        var r = rows[i];
+        var name = (r.getAttribute('data-file') || '').toLowerCase();
+        var match = q === '' || name.indexOf(q) !== -1;
+        r.style.display = match ? '' : 'none';
+        if (match) { shown++; }
+      }
+      if (count) {
+        if (q === '') {
+          count.textContent = '';
+        } else {
+          count.textContent = shown + ' of ' + total + ' files match';
+        }
+      }
+    }
+    input.addEventListener('input', function () {
+      if (debounceHandle) { clearTimeout(debounceHandle); }
+      debounceHandle = setTimeout(applyFilter, 80);
+    });
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        input.value = '';
+        applyFilter();
+      }
+    });
+
+    // Power-user shortcut: pressing `/` anywhere in the page (when not
+    // already inside a form field) focuses the filter input. Guarded
+    // against active form fields to avoid stealing focus from a user
+    // typing into another input, and against contentEditable to avoid
+    // intercepting normal text entry. Browse-mode screen-reader users
+    // still see `/` as a "find in page" gesture because we only act
+    // when the activeElement is the body itself.
+    document.addEventListener('keydown', function (e) {
+      if (e.key !== '/' || e.ctrlKey || e.metaKey || e.altKey) { return; }
+      var ae = document.activeElement;
+      if (ae && ae !== document.body) {
+        var tag = ae.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') { return; }
+        if (ae.isContentEditable) { return; }
+      }
+      e.preventDefault();
+      input.focus();
+      input.select();
+    });
+  }
+
+  // ---------- Line anchors (detail pages) -------------------------------
+  // Hooks: <button class="line-anchor" data-line="42"> inside td.line-num,
+  // + <div id="cov-copy-toast" role="status" aria-live="polite">.
+  // Clicking the button: scrolls to the row via hash, copies the
+  // canonical link to the clipboard, flashes a toast.
+  function initLineAnchors() {
+    var anchors = document.querySelectorAll('button.line-anchor[data-line]');
+    if (anchors.length === 0) { return; }
+    var toast = document.getElementById('cov-copy-toast');
+    var toastTimer = 0;
+
+    function flashToast(message) {
+      if (!toast) { return; }
+      // The screen-reader announcement is triggered by the textContent
+      // assignment below, not by the `visible` class toggle. The class
+      // controls only the visual fade-in; do not switch to display:none
+      // for the hide step or the live-region observer will detach.
+      toast.textContent = message;
+      toast.classList.add('visible');
+      if (toastTimer) { clearTimeout(toastTimer); }
+      toastTimer = setTimeout(function () {
+        toast.classList.remove('visible');
+        toast.textContent = '';
+      }, 1500);
+    }
+
+    function copyAndAnchor(line) {
+      var hash = '#L' + line;
+      history.replaceState(null, '', hash);
+      var url = location.href;
+      var ok = false;
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(url).then(function () {
+          flashToast('Link to line ' + line + ' copied');
+        }).catch(function () {
+          flashToast('Linked to line ' + line);
+        });
+        ok = true;
+      }
+      if (!ok) {
+        // Older browsers / file:// origins where clipboard API is
+        // unavailable: still anchor the URL so the user can copy it
+        // from the address bar.
+        flashToast('Linked to line ' + line);
+      }
+    }
+
+    anchors.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var line = btn.getAttribute('data-line');
+        if (line) { copyAndAnchor(line); }
+      });
+    });
+  }
+
+  // ---------- "Next uncovered" jump button ------------------------------
+  // Hook: <button id="cov-next-uncovered">. Cycles through
+  // tr.line.miss and tr.line.partial in document order; wraps at end.
+  // Disabled when the page has no uncovered rows.
+  function initNextUncovered() {
+    var btn = document.getElementById('cov-next-uncovered');
+    if (!btn) { return; }
+    var rows = document.querySelectorAll('table.source tr.line.miss, table.source tr.line.partial');
+    if (rows.length === 0) {
+      btn.disabled = true;
+      btn.setAttribute('aria-label', 'No uncovered lines on this page');
+      btn.textContent = 'No uncovered lines';
+      return;
+    }
+    btn.disabled = false;
+    var cursor = -1;
+    btn.addEventListener('click', function () {
+      cursor = (cursor + 1) % rows.length;
+      var target = rows[cursor];
+      var line = target.getAttribute('id') || '';
+      if (line) { history.replaceState(null, '', '#' + line); }
+      target.scrollIntoView({ block: 'center', behavior: 'auto' });
+      var inner = target.querySelector('button.line-anchor');
+      if (inner) { inner.focus(); }
+    });
+  }
+
   // ---------- Boot ------------------------------------------------------
   function boot() {
     buildThemeToggle();
     initSortable();
+    initFilter();
+    initLineAnchors();
+    initNextUncovered();
   }
 
   if (document.readyState === 'loading') {

--- a/crates/oxc-coverage-reports/src/html/coverage-tokens.css
+++ b/crates/oxc-coverage-reports/src/html/coverage-tokens.css
@@ -1,0 +1,228 @@
+/* coverage-tokens.css
+ *
+ * Vendored slice of the fallow design system, scoped to "Mode B" reports
+ * (stakeholder-facing static HTML; see fallow's design-system.md sections
+ * 1.3 and 7 for the canonical spec). Sync manually from upstream:
+ *
+ *   fallow-cloud/packages/design-system/src/tokens.css   (palette)
+ *   fallow-cloud/.internal/design-system.md section 4    (light mappings)
+ *
+ * Coverage-semantic colour mapping:
+ *   red   = miss / uncovered / error
+ *   amber = partial coverage / warning
+ *   green = hit / fully covered / passing
+ *   blue  = links / focus ring / info
+ *
+ * Light is the unconditional default per Mode B. Dark activates only via
+ * one of two paths:
+ *   1. `:root[data-theme="dark"]`           (explicit user choice)
+ *   2. `@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) }`
+ *      (system pref, not locked to light)
+ * `data-theme="light"` on <html> locks the light palette regardless of
+ * system preference.
+ *
+ * Every light/dark colour pair below is checked for at least WCAG 2.2 AA
+ * contrast on its intended use. Severity-text values come straight from
+ * fallow's section 4 mapping table (which has been audited upstream).
+ */
+
+/* ---- Light default ---------------------------------------------------- */
+:root {
+  color-scheme: light;
+
+  /* Surfaces (light palette from section 4) */
+  --surface-0: #ffffff;
+  --surface-1: #f9f9f8;
+  --surface-2: #f2f2f0;
+  --surface-3: #ebebea;
+
+  /* Text */
+  --text-high: #21201c;       /* 14.7:1 on white,  AAA  */
+  --text-low: #6f6d66;        /*  4.6:1 on white,  AA   */
+  --text-muted: #908e86;      /*  3.1:1 on white,  AA-Large only */
+
+  /* Borders */
+  --border-subtle: #d9d9d6;
+  --border-default: #c7c7c4;
+  --border-strong: #9aa2ad;
+
+  /* Severity accents (section 4 light-mode mapping; all AA on white) */
+  --red-text: #ce2c31;        /* 5.8:1 */
+  --amber-text: #ad5700;      /* 4.8:1 */
+  --green-text: #18794e;      /* 5.1:1 */
+  --blue-text: #0d74ce;       /* 5.1:1 */
+
+  /* Severity surfaces (section 4 subtle stops) */
+  --red-subtle: #fff1f0;
+  --amber-subtle: #fefbe9;
+  --green-subtle: #e9f9ee;
+  --blue-subtle: #edf6ff;
+
+  /* Coverage-semantic aliases (consumed by the row + meter CSS) */
+  --hit-bg: var(--green-subtle);
+  --miss-bg: var(--red-subtle);
+  --partial-bg: var(--amber-subtle);
+  --row-high: var(--green-subtle);
+  --row-medium: var(--amber-subtle);
+  --row-low: var(--red-subtle);
+  /* Percentage TEXT colours (used on cells / meter labels). The
+   * text-on-pale-background combinations here are AA pass (verified
+   * against the section 4 audit). */
+  --pct-high: var(--green-text);
+  --pct-medium: var(--amber-text);
+  --pct-low: var(--red-text);
+  /* Solid severity fills (used on meter fills + 2px gutter borders).
+   * The luminance gap between these three is wide enough to be
+   * distinguishable under grayscale, satisfying WCAG 1.4.1. */
+  --hit-solid: #30a46c;       /* fallow-green   */
+  --partial-solid: #d8a320;   /* fallow-amber-muted (deeper luminance) */
+  --miss-solid: #e5484d;      /* fallow-red     */
+
+  /* Component aliases */
+  --bg: var(--surface-0);
+  --text: var(--text-high);
+  --muted: var(--text-low);    /* deliberate: use AA-pass low, not AA-large muted */
+  --border: var(--border-subtle);
+  --header-bg: var(--surface-1);
+  --gutter-bg: var(--surface-1);
+  --code-bg: var(--surface-0);
+  --link: var(--blue-text);
+  --focus-ring: var(--blue-text);
+
+  /* Theme-toggle button */
+  --btn-bg: var(--surface-0);
+  --btn-bg-active: var(--blue-text);
+  --btn-fg-active: #ffffff;
+
+  /* Ghost-button offset shadow: the brutalist key-cap look applies to
+   * every fallow button surface, including Mode B. Light-mode value
+   * mirrors the dark token at the same alpha so reports keep the
+   * fallow-native button feel. */
+  --shadow-button-ghost: 3px 3px 0 rgba(146, 146, 142, 0.55);
+  --shadow-button-ghost-hover: 4px 4px 0 rgba(146, 146, 142, 0.55);
+  --shadow-button-ghost-active: 1px 1px 0 rgba(146, 146, 142, 0.55);
+
+  /* Syntax tokens (consumed by .stok-* selectors in base.css) */
+  --tok-keyword: var(--amber-text);
+  --tok-string: var(--green-text);
+  --tok-comment: var(--text-low);
+  --tok-number: #b08800;        /* fallow-amber-muted darker for AA on white */
+  --tok-builtin: var(--blue-text);
+  --tok-punct: var(--text-low);
+
+  /* Type ramp (verbatim from fallow section 2) */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 2rem;
+
+  /* Line height */
+  --leading-tight: 1.3;
+  --leading-normal: 1.6;
+  --leading-loose: 1.8;
+
+  /* Letter spacing */
+  --tracking-display: -0.02em;
+  --tracking-caps: 0.04em;
+
+  /* Font stacks.
+   * CSP `font-src 'none'` blocks any web-font fetch, so the browser
+   * silently falls back to the system entry in each stack. Users with
+   * fallow's fonts installed locally see the fallow typeface; everyone
+   * else sees the system equivalent. */
+  --font-body: "Inter Variable", "Inter", system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-heading: var(--font-body);
+  --font-code: "Monaspace Neon", ui-monospace, SFMono-Regular, "SF Mono",
+    Menlo, Consolas, monospace;
+}
+
+/* ---- Dark: explicit override (data-theme="dark") --------------------- */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --surface-0: #111110;
+  --surface-1: #191918;
+  --surface-2: #222221;
+  --surface-3: #2a2a28;
+
+  --text-high: #eeeeec;
+  --text-low: #b5b3ad;
+  --text-muted: #6f6d66;
+
+  --border-subtle: #3b3a37;
+  --border-default: #494844;
+  --border-strong: #62605b;
+
+  --red-text: #ff9592;
+  --amber-text: #ffca16;
+  --green-text: #3dd68c;
+  --blue-text: #70b8ff;
+
+  --red-subtle: #3b1219;
+  --amber-subtle: #302008;
+  --green-subtle: #132d21;
+  --blue-subtle: #0d2847;
+
+  /* Dark solid severity fills, slightly muted vs section 4 to keep
+   * luminance gap on dark surfaces and pass 3:1 UI-component contrast. */
+  --hit-solid: #3dd68c;
+  --partial-solid: #ffca16;
+  --miss-solid: #ff7b72;
+
+  /* Dark-mode ghost shadow uses the canonical fallow surface-4 value */
+  --shadow-button-ghost: 3px 3px 0 rgba(49, 49, 46, 0.95);
+  --shadow-button-ghost-hover: 4px 4px 0 rgba(49, 49, 46, 0.95);
+  --shadow-button-ghost-active: 1px 1px 0 rgba(49, 49, 46, 0.95);
+
+  /* Component aliases re-resolve via the cascade. The base values
+   * (--bg/--text/--muted/etc.) are defined in the unconditional :root
+   * block above pointing at --surface-* and --text-low; when those
+   * tokens change in this block the aliases pick up the new values
+   * automatically. The toggle-active foreground also flips: dark mode
+   * wants a near-black text on the bright blue active button. */
+  --btn-fg-active: #111110;
+}
+
+/* ---- Dark: system preference (auto), not locked to light ------------- */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
+    --surface-0: #111110;
+    --surface-1: #191918;
+    --surface-2: #222221;
+    --surface-3: #2a2a28;
+
+    --text-high: #eeeeec;
+    --text-low: #b5b3ad;
+    --text-muted: #6f6d66;
+
+    --border-subtle: #3b3a37;
+    --border-default: #494844;
+    --border-strong: #62605b;
+
+    --red-text: #ff9592;
+    --amber-text: #ffca16;
+    --green-text: #3dd68c;
+    --blue-text: #70b8ff;
+
+    --red-subtle: #3b1219;
+    --amber-subtle: #302008;
+    --green-subtle: #132d21;
+    --blue-subtle: #0d2847;
+
+    --hit-solid: #3dd68c;
+    --partial-solid: #ffca16;
+    --miss-solid: #ff7b72;
+
+    --shadow-button-ghost: 3px 3px 0 rgba(49, 49, 46, 0.95);
+    --shadow-button-ghost-hover: 4px 4px 0 rgba(49, 49, 46, 0.95);
+    --shadow-button-ghost-active: 1px 1px 0 rgba(49, 49, 46, 0.95);
+
+    --btn-fg-active: #111110;
+  }
+}

--- a/crates/oxc-coverage-reports/src/html/highlight.rs
+++ b/crates/oxc-coverage-reports/src/html/highlight.rs
@@ -1,0 +1,208 @@
+//! Server-side syntax highlighter for the html reporter's detail pages.
+//!
+//! Wraps [`syntect`] with a per-line facade: callers hand over the source
+//! text and the file path, and get back a `Vec<String>` where each entry
+//! is the highlighted HTML for the corresponding line of the input. The
+//! per-line shape matches the line-numbered table layout in `html.rs`,
+//! so each line drops straight into a `<pre>` cell.
+//!
+//! Token spans use [`syntect::html::ClassStyle::SpacedPrefixed`] with the
+//! prefix `stok-`, so emitted classes look like `class="stok-comment
+//! stok-line stok-double-slash"`. CSS targets the leading-segment
+//! classes (`stok-comment`, `stok-keyword`, `stok-string`, ...) and maps
+//! them to our `--tok-*` vars (G3) or fallow's `--fallow-syntax-token-*`
+//! vars (G4). Trailing scope-tail classes are kept in markup for future
+//! finer-grained theming.
+//!
+//! Scope state is carried across lines via a shared
+//! [`syntect::parsing::ScopeStack`], so multi-line strings, block
+//! comments, and template literals colour their continuation lines
+//! correctly.
+//!
+//! The `SyntaxSet` is built on first use and cached behind a
+//! [`std::sync::OnceLock`]; subsequent calls share the bundled
+//! ~500 KB grammar archive.
+//!
+//! [syntect]: https://docs.rs/syntect
+
+use std::path::Path;
+use std::sync::OnceLock;
+use syntect::html::{ClassStyle, line_tokens_to_classed_spans};
+use syntect::parsing::{ParseState, ScopeStack, SyntaxReference, SyntaxSet};
+use syntect::util::LinesWithEndings;
+
+/// Prefix applied to every emitted token class. Keeps the syntax-token
+/// class namespace separate from the existing coverage-row classes
+/// (`hit`, `miss`, `partial`, `no-stmt`, `sortable`, `tok-k`, ...).
+const CLASS_PREFIX: &str = "stok-";
+
+const CLASS_STYLE: ClassStyle = ClassStyle::SpacedPrefixed { prefix: CLASS_PREFIX };
+
+/// Cache the syntect `SyntaxSet`. Parsing the bundled grammar archive on
+/// first use takes ~5 ms; we want to pay that exactly once per process.
+///
+/// Uses [`two_face::syntax::extra_newlines`] which extends syntect's
+/// default-fancy bundle with TypeScript, TSX, JSX, and many other
+/// grammars not included in the stock syntect ship-set.
+fn syntax_set() -> &'static SyntaxSet {
+    static SET: OnceLock<SyntaxSet> = OnceLock::new();
+    SET.get_or_init(two_face::syntax::extra_newlines)
+}
+
+/// Render `source` as a `Vec<String>` of HTML lines.
+///
+/// Returns one entry per input line. Trailing newlines are stripped
+/// from each entry; the caller chooses whether and how to re-insert
+/// them (the line-numbered table layout in `html.rs` does not need
+/// them).
+///
+/// `file_path` is consulted only for the extension-based language
+/// lookup; the file does not need to exist on disk. Pass `Path::new("")`
+/// if no path hint is available, and lines will be rendered as plain
+/// HTML-escaped text (no colours), which is what we also do for unknown
+/// extensions so the report never breaks on obscure file types.
+pub fn highlight_lines(source: &str, file_path: &Path) -> Vec<String> {
+    let ss = syntax_set();
+    let Some(syntax) = pick_syntax(ss, file_path) else {
+        // Plain HTML-escaped fallback, one line per `\n`. Mirrors the
+        // shape of the highlighted path so the caller does not branch
+        // on language availability.
+        return source.split('\n').map(html_escape).collect();
+    };
+
+    let mut parse_state = ParseState::new(syntax);
+    let mut scope_stack = ScopeStack::new();
+    let mut out: Vec<String> = Vec::new();
+
+    for line in LinesWithEndings::from(source) {
+        // syntect produces tokens for `line` including the trailing `\n`.
+        // `line_tokens_to_classed_spans` returns the HTML for the line
+        // and mutates `scope_stack` to reflect the post-line state.
+        let ops = parse_state
+            .parse_line(line, ss)
+            .expect("syntect line parsing should succeed on valid UTF-8");
+        let (mut html, _delta) =
+            line_tokens_to_classed_spans(line, ops.as_slice(), CLASS_STYLE, &mut scope_stack)
+                .expect("syntect span emission should succeed on valid UTF-8");
+        // Drop the trailing newline syntect echoes from the input; the
+        // table cell uses `<pre>` per line and re-adds newlines via row
+        // boundaries.
+        if html.ends_with('\n') {
+            html.pop();
+        }
+        out.push(html);
+    }
+
+    // `LinesWithEndings::from` skips a final trailing empty line if the
+    // input ends in `\n`. Coverage rendering walks `source.split('\n')`,
+    // which produces one extra empty trailing line in that case. Match
+    // that shape so line numbers line up with the caller's iteration.
+    if source.ends_with('\n') {
+        out.push(String::new());
+    }
+    // If the input is empty entirely (no lines at all), produce one
+    // empty entry so the caller's `enumerate` yields the same shape as
+    // `"".split('\n')`.
+    if source.is_empty() {
+        out.push(String::new());
+    }
+    out
+}
+
+/// Look up a syntect [`SyntaxReference`] for `file_path`.
+///
+/// Tries the file extension first (covers `.ts`, `.tsx`, `.js`, `.jsx`,
+/// `.rs`, `.py`, `.json`, ... out of the box). Returns `None` if no
+/// matching grammar is bundled.
+fn pick_syntax<'a>(ss: &'a SyntaxSet, file_path: &Path) -> Option<&'a SyntaxReference> {
+    let ext = file_path.extension().and_then(|e| e.to_str())?;
+    ss.find_syntax_by_extension(ext)
+}
+
+/// Plain HTML escaping used for the unknown-language fallback path.
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn highlights_typescript_with_prefixed_classes() {
+        let lines = highlight_lines("const x: number = 1;\n", Path::new("a.ts"));
+        // Two entries: the actual line + a trailing empty (matches
+        // `.split('\n')` behavior on trailing-newline input).
+        assert_eq!(lines.len(), 2, "got {} lines: {lines:?}", lines.len());
+        assert!(lines[0].contains("stok-"), "expected prefixed class: {}", lines[0]);
+        assert!(lines[0].contains("const"), "must keep source literal text");
+        assert!(lines[0].contains("number"), "must keep source literal text");
+        assert_eq!(lines[1], "");
+    }
+
+    #[test]
+    fn unknown_extension_falls_back_to_escaped_text() {
+        let lines = highlight_lines("hello <world> & friends", Path::new("file.unknown"));
+        assert_eq!(lines.len(), 1, "single line, no trailing newline");
+        assert!(lines[0].contains("hello"));
+        assert!(lines[0].contains("&lt;world&gt;"));
+        assert!(lines[0].contains("&amp;"));
+        assert!(!lines[0].contains("stok-"), "fallback should not emit token spans: {}", lines[0]);
+    }
+
+    #[test]
+    fn empty_source_yields_one_empty_line() {
+        // Mirrors `"".split('\n')` which yields one empty string.
+        assert_eq!(highlight_lines("", Path::new("a.ts")), vec![String::new()]);
+        assert_eq!(highlight_lines("", Path::new("")), vec![String::new()]);
+    }
+
+    #[test]
+    fn no_path_hint_falls_back_to_plain() {
+        let lines = highlight_lines("const x = 1;", Path::new(""));
+        assert!(!lines[0].contains("stok-"), "no path hint -> no spans");
+        assert!(lines[0].contains("const x = 1;"));
+    }
+
+    #[test]
+    fn multi_line_string_carries_scope_state() {
+        // Template literal spans multiple lines. With per-line ScopeStack
+        // continuity, the second line should also carry a `stok-string`
+        // class somewhere in its tokens, NOT plain identifier markup.
+        let src = "const s = `line1\nline2`;\n";
+        let lines = highlight_lines(src, Path::new("a.ts"));
+        // Line 1 contains the opening backtick + "line1" -> string scope.
+        assert!(lines[0].contains("stok-string"), "line 1 string scope missing: {}", lines[0]);
+        // Line 2 is the continuation of the template literal; the
+        // continuation should still be in string scope until the closing
+        // backtick.
+        assert!(
+            lines[1].contains("stok-string"),
+            "line 2 should continue string scope: {}",
+            lines[1]
+        );
+    }
+
+    #[test]
+    fn hostile_source_is_escaped_under_highlight() {
+        let lines = highlight_lines("// <script>alert(1)</script>\n", Path::new("a.js"));
+        assert!(!lines[0].contains("<script>"), "raw <script> tag leaked: {}", lines[0]);
+        assert!(lines[0].contains("&lt;script&gt;"), "expected escaped script tag: {}", lines[0]);
+    }
+
+    #[test]
+    fn line_count_matches_split_newline() {
+        let src = "a\nb\nc";
+        let lines = highlight_lines(src, Path::new("a.ts"));
+        assert_eq!(lines.len(), src.split('\n').count(), "line count must match `.split('\\n')`");
+    }
+}

--- a/crates/oxc-coverage-reports/src/html/mod.rs
+++ b/crates/oxc-coverage-reports/src/html/mod.rs
@@ -27,17 +27,30 @@
 //!   report makes zero network requests even if served from an HTTP
 //!   origin behind an inspecting proxy.
 //! - **Progressive enhancement**: without JS the report still renders
-//!   correctly; JS adds sortable index tables, an explicit
-//!   auto/light/dark toggle that overrides `prefers-color-scheme`, and
-//!   lightweight syntax highlighting on detail-page source views.
+//!   correctly; JS adds sortable index tables and an explicit
+//!   auto/light/dark toggle that overrides `prefers-color-scheme`.
+//! - **Server-side syntax highlighting**: detail-page source views are
+//!   tokenized in Rust via [`syntect`] (extended with [`two_face`] for
+//!   TypeScript / TSX / JSX coverage) and emitted as
+//!   `<span class="stok-...">` markup. No client-side tokenizer, no
+//!   flash of unstyled source, works with JS off. Per-file rendering
+//!   parallelizes across cores via [`rayon`]: on a 100-file project at
+//!   200 LOC per file emit takes under two seconds on a typical laptop.
 //! - **Graceful missing-source**: if a file's source cannot be read from
 //!   disk (CI runs without the original tree, remapped path that does
 //!   not exist locally), the detail page shows the coverage statistics
 //!   alongside a `(source unavailable)` placeholder rather than failing.
+//!
+//! [syntect]: https://docs.rs/syntect
+//! [two_face]: https://docs.rs/two-face
+//! [rayon]: https://docs.rs/rayon
+
+mod highlight;
 
 use oxc_coverage_report::{CoverageMap, CoverageSummary, NodeKind, ReportNode, summarize};
 use oxc_coverage_source_maps::remap_coverage_map;
 use oxc_coverage_types::{BranchEntry, FileCoverage, FnEntry};
+use rayon::prelude::*;
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::fs;
@@ -51,15 +64,16 @@ const INDEX_FILE: &str = "index.html";
 const DETAIL_SUFFIX: &str = ".html";
 
 /// Embedded stylesheet copied to `<output_dir>/base.css`.
-const BASE_CSS: &str = include_str!("html/base.css");
+const BASE_CSS: &str = include_str!("base.css");
 
 /// Embedded enhancement script copied to `<output_dir>/base.js`.
 ///
-/// Provides the sortable index tables, the auto / light / dark theme
-/// toggle, and the lightweight JS/TS syntax highlighter. Pure DOM API,
-/// never assigns `innerHTML`, never makes a network request, so the
-/// page stays compatible with the strict CSP emitted by [`render_page`].
-const BASE_JS: &str = include_str!("html/base.js");
+/// Provides the sortable index tables and the auto / light / dark theme
+/// toggle. Pure DOM API, never assigns HTML strings, never makes a
+/// network request, so the page stays compatible with the strict CSP
+/// emitted by [`render_page`]. Syntax highlighting is done server-side
+/// in Rust via [`syntect`] in the sibling [`highlight`] module.
+const BASE_JS: &str = include_str!("base.js");
 
 /// Strict Content-Security-Policy applied to every emitted page.
 ///
@@ -120,9 +134,16 @@ fn render_node(
             let html = render_folder_index(node, children, depth);
             fs::write(folder_dir.join(INDEX_FILE), html)?;
 
-            for child in children {
-                render_node(child, ctx, output_dir, depth + child_depth_delta(node, child))?;
-            }
+            // Render children in parallel. The file branch is CPU-bound
+            // (syntect tokenization), so per-file fan-out scales well on
+            // multi-core CI runners. Folder children re-enter
+            // `render_node` and parallelize their own subtrees.
+            children
+                .par_iter()
+                .map(|child| {
+                    render_node(child, ctx, output_dir, depth + child_depth_delta(node, child))
+                })
+                .collect::<io::Result<Vec<_>>>()?;
         }
         NodeKind::File { coverage } => {
             // Detail page lives next to the folder index.
@@ -229,7 +250,16 @@ fn render_detail(
     body.push_str("      <table class=\"source\">\n");
     match source {
         Some(text) => {
-            body.push_str(&render_source_table(&text, &line_hits, &branched_lines, &fn_lines));
+            // Highlight up front so the per-line table render gets
+            // pre-escaped, span-wrapped HTML; this also keeps scope
+            // state consistent across multi-line strings/comments.
+            let highlighted = highlight::highlight_lines(&text, Path::new(&coverage.path));
+            body.push_str(&render_source_table(
+                &highlighted,
+                &line_hits,
+                &branched_lines,
+                &fn_lines,
+            ));
         }
         None => body.push_str(&render_source_unavailable(&line_hits)),
     }
@@ -239,27 +269,29 @@ fn render_detail(
 }
 
 fn render_source_table(
-    source: &str,
+    lines: &[String],
     line_hits: &BTreeMap<u32, u32>,
     branched: &BTreeMap<u32, BranchSummary>,
     fns: &BTreeMap<u32, u32>,
 ) -> String {
     let mut out = String::new();
     out.push_str("        <thead><tr><th class=\"line-num\">Line</th><th class=\"hits\">Hits</th><th class=\"src\">Source</th></tr></thead>\n        <tbody>\n");
-    for (idx, line) in source.split('\n').enumerate() {
+    for (idx, line_html) in lines.iter().enumerate() {
         let line_no = (idx + 1) as u32;
         let stmt_hits = line_hits.get(&line_no).copied();
         let branch = branched.get(&line_no);
         let fn_hits = fns.get(&line_no).copied();
-        out.push_str(&render_source_row(line_no, line, stmt_hits, branch, fn_hits));
+        out.push_str(&render_source_row(line_no, line_html, stmt_hits, branch, fn_hits));
     }
     out.push_str("        </tbody>\n");
     out
 }
 
+/// Render one source row. `src_html` is already escaped and may carry
+/// syntect `<span class="stok-...">` markup; do not re-escape.
 fn render_source_row(
     line_no: u32,
-    src: &str,
+    src_html: &str,
     stmt_hits: Option<u32>,
     branch: Option<&BranchSummary>,
     fn_hits: Option<u32>,
@@ -277,8 +309,7 @@ fn render_source_row(
         }
     });
     format!(
-        "          <tr class=\"line {class}\"><td class=\"line-num\">{line_no}</td><td class=\"hits\">{hits_cell}</td><td class=\"src\"><pre>{src}</pre>{branch_note}</td></tr>\n",
-        src = html_text_escape(src),
+        "          <tr class=\"line {class}\"><td class=\"line-num\">{line_no}</td><td class=\"hits\">{hits_cell}</td><td class=\"src\"><pre>{src_html}</pre>{branch_note}</td></tr>\n",
     )
 }
 
@@ -619,14 +650,17 @@ mod tests {
         let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
         let dir = write_to_temp(json);
         let js = fs::read_to_string(dir.path().join("base.js")).unwrap();
-        // Sanity-check the three feature blocks are present in the emitted JS.
+        // Sanity-check the remaining feature blocks are present in the
+        // emitted JS. Syntax highlighting moved server-side in G3 so the
+        // prettify section is intentionally gone.
         assert!(js.contains("Theme toggle"), "base.js missing theme toggle section");
         assert!(js.contains("Sortable tables"), "base.js missing sortable tables section");
-        assert!(js.contains("Source prettify"), "base.js missing prettify section");
-        // The three feature areas must be wired into the boot path.
         assert!(js.contains("buildThemeToggle"), "base.js missing theme toggle invocation");
         assert!(js.contains("initSortable"), "base.js missing sortable init invocation");
-        assert!(js.contains("initPrettify"), "base.js missing prettify init invocation");
+        // No client-side tokenizer: the source view is pre-rendered by
+        // syntect on the Rust side.
+        assert!(!js.contains("initPrettify"), "client prettify must not be re-added");
+        assert!(!js.contains("KEYWORD_SET"), "client tokenizer must not be re-added");
     }
 
     #[test]
@@ -704,7 +738,16 @@ mod tests {
         assert!(css.contains(":root:not([data-theme=\"light\"])"), "missing light escape hatch");
         assert!(css.contains(".sortable"), "missing .sortable selector");
         assert!(css.contains("aria-sort=\"ascending\""), "missing aria-sort hook");
-        for cls in [".tok-k", ".tok-s", ".tok-c", ".tok-n", ".tok-b", ".tok-p"] {
+        for cls in [
+            ".stok-comment",
+            ".stok-keyword",
+            ".stok-storage",
+            ".stok-string",
+            ".stok-constant",
+            ".stok-support",
+            ".stok-entity",
+            ".stok-punctuation",
+        ] {
             assert!(css.contains(cls), "missing token class {cls}");
         }
         assert!(css.contains(".theme-toggle__btn"), "missing theme-toggle button class");

--- a/crates/oxc-coverage-reports/src/html/mod.rs
+++ b/crates/oxc-coverage-reports/src/html/mod.rs
@@ -117,7 +117,24 @@ font-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'";
 /// `base.js`. All three must travel together; copying only `base.css`
 /// to a new location without `coverage-tokens.css` leaves the report
 /// visually broken (the token cascade resolves to the browser default).
+///
+/// Uses [`HtmlOptions::default()`] (80% high-coverage threshold matching
+/// Istanbul's convention). Call [`write_with_options`] to override.
 pub fn write(coverage_map: &CoverageMap, root_dir: &Path, output_dir: &Path) -> io::Result<()> {
+    write_with_options(coverage_map, root_dir, output_dir, &HtmlOptions::default())
+}
+
+/// Render a complete HTML coverage report with explicit [`HtmlOptions`].
+///
+/// Same semantics as [`write()`], but the caller controls the threshold
+/// that drives the high/medium/low colour bucketing and the index
+/// page's threshold-summary sentence.
+pub fn write_with_options(
+    coverage_map: &CoverageMap,
+    root_dir: &Path,
+    output_dir: &Path,
+    options: &HtmlOptions,
+) -> io::Result<()> {
     let remapped = remap_coverage_map(coverage_map);
     let root = summarize(&remapped);
 
@@ -126,13 +143,37 @@ pub fn write(coverage_map: &CoverageMap, root_dir: &Path, output_dir: &Path) -> 
     fs::write(output_dir.join("coverage-tokens.css"), COVERAGE_TOKENS_CSS)?;
     fs::write(output_dir.join("base.js"), BASE_JS)?;
 
-    let ctx = RenderContext { root_dir };
+    let ctx = RenderContext { root_dir, options };
     render_node(&root, &ctx, output_dir, 0)?;
     Ok(())
 }
 
+/// Tunable knobs for the HTML reporter.
+///
+/// Stable across breaking changes; new fields are added at the end with
+/// defaults supplied by [`HtmlOptions::default`]. Construct via
+/// `HtmlOptions { high_threshold: 75.0, ..Default::default() }` so
+/// future fields don't require updating every call site.
+#[derive(Debug, Clone)]
+pub struct HtmlOptions {
+    /// Percentage cutoff that separates "high" coverage (green) from
+    /// "medium" (amber) on per-metric colouring, and powers the index
+    /// page's "N of M files fall below the X% line-coverage threshold"
+    /// sentence. The medium-to-low boundary stays fixed at 50%.
+    /// Must be in `[0.0, 100.0]`; the CLI clamps user input.
+    /// Default: `80.0` (Istanbul's traditional value).
+    pub high_threshold: f64,
+}
+
+impl Default for HtmlOptions {
+    fn default() -> Self {
+        Self { high_threshold: 80.0 }
+    }
+}
+
 struct RenderContext<'a> {
     root_dir: &'a Path,
+    options: &'a HtmlOptions,
 }
 
 fn render_node(
@@ -150,7 +191,7 @@ fn render_node(
                 output_dir.join(&node.relative_path)
             };
             fs::create_dir_all(&folder_dir)?;
-            let html = render_folder_index(node, children, depth);
+            let html = render_folder_index(node, children, ctx, depth);
             fs::write(folder_dir.join(INDEX_FILE), html)?;
 
             // Render children in parallel. The file branch is CPU-bound
@@ -193,22 +234,28 @@ fn child_depth_delta(_parent: &ReportNode, child: &ReportNode) -> usize {
 
 // -- Folder index page ------------------------------------------------------
 
-fn render_folder_index(node: &ReportNode, children: &[ReportNode], depth: usize) -> String {
+fn render_folder_index(
+    node: &ReportNode,
+    children: &[ReportNode],
+    ctx: &RenderContext,
+    depth: usize,
+) -> String {
     let title = if node.relative_path.is_empty() {
         "All files".to_owned()
     } else {
         node.relative_path.clone()
     };
+    let threshold = ctx.options.high_threshold;
     let mut body = String::new();
-    body.push_str(&render_summary_header(&title, &node.summary, depth, node));
+    body.push_str(&render_summary_header(&title, &node.summary, depth, node, threshold));
     body.push_str("    <div class=\"pad1\">\n");
-    body.push_str(&render_threshold_summary(children));
+    body.push_str(&render_threshold_summary(children, threshold));
     body.push_str(&render_filter_group(children.len()));
     body.push_str("      <table class=\"coverage-summary\" id=\"cov-file-table\">\n");
     body.push_str(&render_summary_table_header());
     body.push_str("        <tbody>\n");
     for child in children {
-        body.push_str(&render_summary_row(child));
+        body.push_str(&render_summary_row(child, threshold));
     }
     body.push_str("        </tbody>\n");
     body.push_str("      </table>\n");
@@ -216,23 +263,22 @@ fn render_folder_index(node: &ReportNode, children: &[ReportNode], depth: usize)
     render_page(&title, depth, &body)
 }
 
-/// One-line summary above the file table: "N of M files below the 80%
+/// One-line summary above the file table: "N of M files below the X%
 /// line-coverage threshold". Renders as muted body text when at least
 /// one file falls below; silent when every file is at or above.
-fn render_threshold_summary(children: &[ReportNode]) -> String {
-    const THRESHOLD: f64 = 80.0;
+fn render_threshold_summary(children: &[ReportNode], threshold: f64) -> String {
     let total = children.len();
     if total == 0 {
         return String::new();
     }
-    let below = children.iter().filter(|c| c.summary.lines.pct < THRESHOLD).count();
+    let below = children.iter().filter(|c| c.summary.lines.pct < threshold).count();
     if below == 0 {
         return format!(
-            "      <p class=\"threshold-summary\"><strong>All {total} files</strong> meet the {THRESHOLD:.0}% line-coverage threshold.</p>\n",
+            "      <p class=\"threshold-summary\"><strong>All {total} files</strong> meet the {threshold:.0}% line-coverage threshold.</p>\n",
         );
     }
     format!(
-        "      <p class=\"threshold-summary\"><strong>{below}</strong> of {total} files fall below the {THRESHOLD:.0}% line-coverage threshold.</p>\n",
+        "      <p class=\"threshold-summary\"><strong>{below}</strong> of {total} files fall below the {threshold:.0}% line-coverage threshold.</p>\n",
     )
 }
 
@@ -260,13 +306,13 @@ fn render_summary_table_header() -> String {
     out
 }
 
-fn render_summary_row(child: &ReportNode) -> String {
+fn render_summary_row(child: &ReportNode, threshold: f64) -> String {
     let href = match &child.kind {
         NodeKind::Folder { .. } => format!("{}/{INDEX_FILE}", html_attr_escape(&child.name)),
         NodeKind::File { .. } => format!("{}{DETAIL_SUFFIX}", html_attr_escape(&child.name)),
     };
     let display = html_text_escape(&child.name);
-    let row_class = pct_class(child.summary.lines.pct);
+    let row_class = pct_class(child.summary.lines.pct, threshold);
     let mut out = format!(
         "          <tr class=\"row-{row_class}\" data-file=\"{file}\">\n",
         file = html_attr_escape(&child.name),
@@ -279,7 +325,7 @@ fn render_summary_row(child: &ReportNode) -> String {
         ("Lines", child.summary.lines),
     ];
     for (idx, (label, metric)) in metrics.iter().enumerate() {
-        let mc = pct_class(metric.pct);
+        let mc = pct_class(metric.pct, threshold);
         // Mini coverage meter only on the Lines column (final column);
         // duplicating it on every column would clutter the table.
         let meter = if idx == metrics.len() - 1 {
@@ -316,7 +362,13 @@ fn render_detail(
     let fn_lines = compute_fn_lines(coverage);
 
     let mut body = String::new();
-    body.push_str(&render_summary_header(&title, &node.summary, depth, node));
+    body.push_str(&render_summary_header(
+        &title,
+        &node.summary,
+        depth,
+        node,
+        ctx.options.high_threshold,
+    ));
     body.push_str("    <div class=\"pad1\">\n");
     body.push_str(
         "      <div class=\"detail-actions\">\n        <button type=\"button\" class=\"btn-ghost\" id=\"cov-next-uncovered\" aria-label=\"Jump to next uncovered line\" disabled>Next uncovered</button>\n      </div>\n",
@@ -503,6 +555,7 @@ fn render_summary_header(
     summary: &CoverageSummary,
     depth: usize,
     node: &ReportNode,
+    threshold: f64,
 ) -> String {
     let mut out = String::from("    <header class=\"summary\">\n");
     let _ = writeln!(out, "      <h1>{}</h1>", html_text_escape(title));
@@ -514,7 +567,7 @@ fn render_summary_header(
         ("Functions", summary.functions),
         ("Lines", summary.lines),
     ] {
-        let class = pct_class(m.pct);
+        let class = pct_class(m.pct, threshold);
         let _ = writeln!(
             out,
             "        <li class=\"kpi-cell kpi-cell--{class}\"><span class=\"kpi-cell__label\">[ {label} ]</span><span class=\"kpi-cell__value\">{:.2}%</span><span class=\"kpi-cell__sub\">{}/{}</span></li>",
@@ -654,8 +707,14 @@ fn read_source(file: &FileCoverage, root_dir: &Path) -> Option<String> {
 
 // -- Class assignment ------------------------------------------------------
 
-fn pct_class(pct: f64) -> &'static str {
-    if pct >= 80.0 {
+/// Map a percentage to one of `"high"`/`"medium"`/`"low"`, used as the
+/// `kpi-cell--*`, `row-*`, `pct *`, and `cov-meter--*` modifier
+/// suffixes. `high_threshold` separates high from medium; the medium /
+/// low boundary is fixed at 50% (a hardcoded medium threshold below
+/// `high_threshold` keeps the three-bucket UX legible while still
+/// honouring caller preferences for the green/amber line).
+fn pct_class(pct: f64, high_threshold: f64) -> &'static str {
+    if pct >= high_threshold {
         "high"
     } else if pct >= 50.0 {
         "medium"
@@ -1006,6 +1065,52 @@ mod tests {
                 "missing generator meta in {html_path:?}",
             );
         }
+    }
+
+    #[test]
+    fn custom_threshold_drives_summary_sentence_and_pct_class() {
+        // Two files: one at 70% lines, one at 90% lines. With the default
+        // 80% threshold the 70% file is "below"; with --threshold 60 both
+        // are "above" and the row colour bucketing flips.
+        let json = r#"{
+            "lo.js":{"path":"lo.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":1}},"1":{"start":{"line":2,"column":0},"end":{"line":2,"column":1}},"2":{"start":{"line":3,"column":0},"end":{"line":3,"column":1}},"3":{"start":{"line":4,"column":0},"end":{"line":4,"column":1}},"4":{"start":{"line":5,"column":0},"end":{"line":5,"column":1}},"5":{"start":{"line":6,"column":0},"end":{"line":6,"column":1}},"6":{"start":{"line":7,"column":0},"end":{"line":7,"column":1}},"7":{"start":{"line":8,"column":0},"end":{"line":8,"column":1}},"8":{"start":{"line":9,"column":0},"end":{"line":9,"column":1}},"9":{"start":{"line":10,"column":0},"end":{"line":10,"column":1}}},"fnMap":{},"branchMap":{},"s":{"0":1,"1":1,"2":1,"3":1,"4":1,"5":1,"6":1,"7":0,"8":0,"9":0},"f":{},"b":{}},
+            "hi.js":{"path":"hi.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":1}},"1":{"start":{"line":2,"column":0},"end":{"line":2,"column":1}},"2":{"start":{"line":3,"column":0},"end":{"line":3,"column":1}},"3":{"start":{"line":4,"column":0},"end":{"line":4,"column":1}},"4":{"start":{"line":5,"column":0},"end":{"line":5,"column":1}},"5":{"start":{"line":6,"column":0},"end":{"line":6,"column":1}},"6":{"start":{"line":7,"column":0},"end":{"line":7,"column":1}},"7":{"start":{"line":8,"column":0},"end":{"line":8,"column":1}},"8":{"start":{"line":9,"column":0},"end":{"line":9,"column":1}},"9":{"start":{"line":10,"column":0},"end":{"line":10,"column":1}}},"fnMap":{},"branchMap":{},"s":{"0":1,"1":1,"2":1,"3":1,"4":1,"5":1,"6":1,"7":1,"8":1,"9":0},"f":{},"b":{}}
+        }"#;
+        let map = parse_coverage_map(json).unwrap();
+
+        // Default (80%): 70% file is "low" via lines pct < 50.0? Actually
+        // 70% > 50%, so it's "medium"; threshold-summary should say
+        // "1 of 2 files fall below the 80% line-coverage threshold".
+        let dir_default = tempfile::TempDir::new().unwrap();
+        write(&map, Path::new(""), dir_default.path()).unwrap();
+        let default_root = fs::read_to_string(dir_default.path().join("index.html")).unwrap();
+        assert!(
+            default_root.contains("1</strong> of 2 files fall below the 80%"),
+            "default threshold should report 1 below 80%: {default_root}",
+        );
+        assert!(
+            default_root.contains("row-medium"),
+            "70% file should bucket medium under default threshold",
+        );
+
+        // Custom 60%: both files are above; sentence should report all met.
+        let dir_loose = tempfile::TempDir::new().unwrap();
+        write_with_options(
+            &map,
+            Path::new(""),
+            dir_loose.path(),
+            &HtmlOptions { high_threshold: 60.0 },
+        )
+        .unwrap();
+        let loose_root = fs::read_to_string(dir_loose.path().join("index.html")).unwrap();
+        assert!(
+            loose_root.contains("All 2 files</strong> meet the 60% line-coverage threshold"),
+            "60% threshold should clear all files: {loose_root}",
+        );
+        assert!(
+            loose_root.contains("row-high"),
+            "70% file should bucket high under a 60% threshold",
+        );
     }
 
     fn walkdir(dir: &Path) -> Vec<PathBuf> {

--- a/crates/oxc-coverage-reports/src/html/mod.rs
+++ b/crates/oxc-coverage-reports/src/html/mod.rs
@@ -158,7 +158,7 @@ pub fn write_with_options(
 pub struct HtmlOptions {
     /// Percentage cutoff that separates "high" coverage (green) from
     /// "medium" (amber) on per-metric colouring, and powers the index
-    /// page's "N of M files fall below the X% line-coverage threshold"
+    /// page's "N of M files fall below the X% coverage threshold"
     /// sentence. The medium-to-low boundary stays fixed at 50%.
     /// Must be in `[0.0, 100.0]`; the CLI clamps user input.
     /// Default: `80.0` (Istanbul's traditional value).
@@ -263,9 +263,16 @@ fn render_folder_index(
     render_page(&title, depth, &body)
 }
 
-/// One-line summary above the file table: "N of M files below the X%
-/// line-coverage threshold". Renders as muted body text when at least
-/// one file falls below; silent when every file is at or above.
+/// One-line summary above the file table: "N of M files fall below the
+/// X% coverage threshold". The wording deliberately says "coverage
+/// threshold" rather than "line-coverage threshold" because the same
+/// `threshold` value drives the colour bucketing for every metric
+/// (statements, branches, functions, lines), and the file-below count
+/// is itself computed against line coverage as the canonical proxy
+/// for "is this file healthy enough". The file-list inclusion still
+/// uses `lines.pct` so a file with 95% lines and 30% branches is
+/// considered "above"; the bucketed colour cells then surface the
+/// underlying per-metric reality.
 fn render_threshold_summary(children: &[ReportNode], threshold: f64) -> String {
     let total = children.len();
     if total == 0 {
@@ -274,11 +281,11 @@ fn render_threshold_summary(children: &[ReportNode], threshold: f64) -> String {
     let below = children.iter().filter(|c| c.summary.lines.pct < threshold).count();
     if below == 0 {
         return format!(
-            "      <p class=\"threshold-summary\"><strong>All {total} files</strong> meet the {threshold:.0}% line-coverage threshold.</p>\n",
+            "      <p class=\"threshold-summary\"><strong>All {total} files</strong> meet the {threshold:.0}% coverage threshold.</p>\n",
         );
     }
     format!(
-        "      <p class=\"threshold-summary\"><strong>{below}</strong> of {total} files fall below the {threshold:.0}% line-coverage threshold.</p>\n",
+        "      <p class=\"threshold-summary\"><strong>{below}</strong> of {total} files fall below the {threshold:.0}% coverage threshold.</p>\n",
     )
 }
 
@@ -1080,7 +1087,7 @@ mod tests {
 
         // Default (80%): 70% file is "low" via lines pct < 50.0? Actually
         // 70% > 50%, so it's "medium"; threshold-summary should say
-        // "1 of 2 files fall below the 80% line-coverage threshold".
+        // "1 of 2 files fall below the 80% coverage threshold".
         let dir_default = tempfile::TempDir::new().unwrap();
         write(&map, Path::new(""), dir_default.path()).unwrap();
         let default_root = fs::read_to_string(dir_default.path().join("index.html")).unwrap();
@@ -1104,7 +1111,7 @@ mod tests {
         .unwrap();
         let loose_root = fs::read_to_string(dir_loose.path().join("index.html")).unwrap();
         assert!(
-            loose_root.contains("All 2 files</strong> meet the 60% line-coverage threshold"),
+            loose_root.contains("All 2 files</strong> meet the 60% coverage threshold"),
             "60% threshold should clear all files: {loose_root}",
         );
         assert!(

--- a/crates/oxc-coverage-reports/src/html/mod.rs
+++ b/crates/oxc-coverage-reports/src/html/mod.rs
@@ -340,7 +340,7 @@ fn render_detail(
     body.push_str("      </table>\n");
     body.push_str("    </div>\n");
     body.push_str(
-        "    <div class=\"copy-toast\" id=\"cov-copy-toast\" role=\"status\" aria-live=\"polite\" aria-atomic=\"true\"></div>\n",
+        "    <div class=\"copy-toast\" id=\"cov-copy-toast\" role=\"status\" aria-atomic=\"true\"></div>\n",
     );
     render_page(&title, depth, &body)
 }

--- a/crates/oxc-coverage-reports/src/html/mod.rs
+++ b/crates/oxc-coverage-reports/src/html/mod.rs
@@ -66,6 +66,18 @@ const DETAIL_SUFFIX: &str = ".html";
 /// Embedded stylesheet copied to `<output_dir>/base.css`.
 const BASE_CSS: &str = include_str!("base.css");
 
+/// Vendored slice of fallow's design tokens, copied to
+/// `<output_dir>/coverage-tokens.css`. `base.css` `@import`s this file
+/// so the palette layer can be re-vendored into fallow-cloud (or any
+/// other consumer) without touching the structural rules. See the file
+/// header comment for the sync convention.
+const COVERAGE_TOKENS_CSS: &str = include_str!("coverage-tokens.css");
+
+/// Version stamp embedded in the `<meta name="generator">` tag on every
+/// page. Lets CI tooling identify which release of the reporter
+/// produced a given report directory.
+const GENERATOR: &str = concat!("oxc-coverage-reports ", env!("CARGO_PKG_VERSION"));
+
 /// Embedded enhancement script copied to `<output_dir>/base.js`.
 ///
 /// Provides the sortable index tables and the auto / light / dark theme
@@ -99,12 +111,19 @@ font-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'";
 /// `root_dir` is used as the filesystem base for resolving any
 /// `FileCoverage.path` that is relative. Pass [`std::env::current_dir`]
 /// when invoking from a CLI.
+///
+/// Three companion files are written alongside the HTML tree:
+/// `base.css`, `coverage-tokens.css` (which `base.css` `@import`s), and
+/// `base.js`. All three must travel together; copying only `base.css`
+/// to a new location without `coverage-tokens.css` leaves the report
+/// visually broken (the token cascade resolves to the browser default).
 pub fn write(coverage_map: &CoverageMap, root_dir: &Path, output_dir: &Path) -> io::Result<()> {
     let remapped = remap_coverage_map(coverage_map);
     let root = summarize(&remapped);
 
     fs::create_dir_all(output_dir)?;
     fs::write(output_dir.join("base.css"), BASE_CSS)?;
+    fs::write(output_dir.join("coverage-tokens.css"), COVERAGE_TOKENS_CSS)?;
     fs::write(output_dir.join("base.js"), BASE_JS)?;
 
     let ctx = RenderContext { root_dir };
@@ -183,7 +202,9 @@ fn render_folder_index(node: &ReportNode, children: &[ReportNode], depth: usize)
     let mut body = String::new();
     body.push_str(&render_summary_header(&title, &node.summary, depth, node));
     body.push_str("    <div class=\"pad1\">\n");
-    body.push_str("      <table class=\"coverage-summary\">\n");
+    body.push_str(&render_threshold_summary(children));
+    body.push_str(&render_filter_group(children.len()));
+    body.push_str("      <table class=\"coverage-summary\" id=\"cov-file-table\">\n");
     body.push_str(&render_summary_table_header());
     body.push_str("        <tbody>\n");
     for child in children {
@@ -193,6 +214,41 @@ fn render_folder_index(node: &ReportNode, children: &[ReportNode], depth: usize)
     body.push_str("      </table>\n");
     body.push_str("    </div>\n");
     render_page(&title, depth, &body)
+}
+
+/// One-line summary above the file table: "N of M files below the 80%
+/// line-coverage threshold". Renders as muted body text when at least
+/// one file falls below; silent when every file is at or above.
+fn render_threshold_summary(children: &[ReportNode]) -> String {
+    const THRESHOLD: f64 = 80.0;
+    let total = children.len();
+    if total == 0 {
+        return String::new();
+    }
+    let below = children.iter().filter(|c| c.summary.lines.pct < THRESHOLD).count();
+    if below == 0 {
+        return format!(
+            "      <p class=\"threshold-summary\"><strong>All {total} files</strong> meet the {THRESHOLD:.0}% line-coverage threshold.</p>\n",
+        );
+    }
+    format!(
+        "      <p class=\"threshold-summary\"><strong>{below}</strong> of {total} files fall below the {THRESHOLD:.0}% line-coverage threshold.</p>\n",
+    )
+}
+
+/// Filter input + live count region. JS enhances both; without JS the
+/// input is still focusable and the region stays empty.
+fn render_filter_group(file_count: usize) -> String {
+    format!(
+        concat!(
+            "      <div class=\"filter-group\">\n",
+            "        <label class=\"filter-group__label\" for=\"cov-filter\">Filter files</label>\n",
+            "        <input class=\"filter-input\" id=\"cov-filter\" type=\"search\" autocomplete=\"off\" spellcheck=\"false\" placeholder=\"type to filter, press / to focus\" aria-controls=\"cov-file-table\" aria-describedby=\"cov-filter-count\">\n",
+            "        <div class=\"filter-count\" id=\"cov-filter-count\" role=\"status\" aria-atomic=\"true\" data-total=\"{total}\"></div>\n",
+            "      </div>\n",
+        ),
+        total = file_count,
+    )
 }
 
 fn render_summary_table_header() -> String {
@@ -211,19 +267,34 @@ fn render_summary_row(child: &ReportNode) -> String {
     };
     let display = html_text_escape(&child.name);
     let row_class = pct_class(child.summary.lines.pct);
-    let mut out = format!("          <tr class=\"row-{row_class}\">\n");
+    let mut out = format!(
+        "          <tr class=\"row-{row_class}\" data-file=\"{file}\">\n",
+        file = html_attr_escape(&child.name),
+    );
     let _ = writeln!(out, "            <td class=\"file\"><a href=\"{href}\">{display}</a></td>");
-    for metric in [
-        child.summary.statements,
-        child.summary.branches,
-        child.summary.functions,
-        child.summary.lines,
-    ] {
+    let metrics = [
+        ("Statements", child.summary.statements),
+        ("Branches", child.summary.branches),
+        ("Functions", child.summary.functions),
+        ("Lines", child.summary.lines),
+    ];
+    for (idx, (label, metric)) in metrics.iter().enumerate() {
         let mc = pct_class(metric.pct);
+        // Mini coverage meter only on the Lines column (final column);
+        // duplicating it on every column would clutter the table.
+        let meter = if idx == metrics.len() - 1 {
+            let pct = metric.pct.clamp(0.0, 100.0);
+            format!(
+                "<span class=\"cov-meter cov-meter--{mc}\" role=\"meter\" aria-label=\"{label} coverage\" aria-valuenow=\"{val}\" aria-valuemin=\"0\" aria-valuemax=\"100\"><span class=\"cov-meter__fill\" style=\"width:{val}%\" aria-hidden=\"true\"></span></span>",
+                val = pct as u32,
+            )
+        } else {
+            String::new()
+        };
         let _ = writeln!(
             out,
-            "            <td class=\"pct {mc}\">{:.2}%<span class=\"quiet\"> ({}/{})</span></td>",
-            metric.pct, metric.covered, metric.total
+            "            <td class=\"pct {mc}\">{:.2}%<span class=\"quiet\"> ({}/{})</span>{meter}</td>",
+            metric.pct, metric.covered, metric.total,
         );
     }
     out.push_str("          </tr>\n");
@@ -247,6 +318,9 @@ fn render_detail(
     let mut body = String::new();
     body.push_str(&render_summary_header(&title, &node.summary, depth, node));
     body.push_str("    <div class=\"pad1\">\n");
+    body.push_str(
+        "      <div class=\"detail-actions\">\n        <button type=\"button\" class=\"btn-ghost\" id=\"cov-next-uncovered\" aria-label=\"Jump to next uncovered line\" disabled>Next uncovered</button>\n      </div>\n",
+    );
     body.push_str("      <table class=\"source\">\n");
     match source {
         Some(text) => {
@@ -265,6 +339,9 @@ fn render_detail(
     }
     body.push_str("      </table>\n");
     body.push_str("    </div>\n");
+    body.push_str(
+        "    <div class=\"copy-toast\" id=\"cov-copy-toast\" role=\"status\" aria-live=\"polite\" aria-atomic=\"true\"></div>\n",
+    );
     render_page(&title, depth, &body)
 }
 
@@ -297,10 +374,12 @@ fn render_source_row(
     fn_hits: Option<u32>,
 ) -> String {
     let class = source_row_class(stmt_hits, branch, fn_hits);
-    let hits_cell = match (stmt_hits, fn_hits) {
+    let hits_text = match (stmt_hits, fn_hits) {
         (Some(h), _) | (None, Some(h)) => format!("{h}x"),
         _ => String::new(),
     };
+    let glyph = severity_glyph(class);
+    let aria = row_aria_label(line_no, class);
     let branch_note = branch.map_or(String::new(), |b| {
         if b.total == 0 {
             String::new()
@@ -309,8 +388,40 @@ fn render_source_row(
         }
     });
     format!(
-        "          <tr class=\"line {class}\"><td class=\"line-num\">{line_no}</td><td class=\"hits\">{hits_cell}</td><td class=\"src\"><pre>{src_html}</pre>{branch_note}</td></tr>\n",
+        "          <tr class=\"line {class}\" id=\"L{line_no}\" aria-label=\"{aria}\">\
+<td class=\"line-num\">\
+<button type=\"button\" class=\"line-anchor\" data-line=\"{line_no}\" aria-label=\"Copy link to line {line_no}\">{line_no}</button>\
+</td>\
+<td class=\"hits\">{glyph}{hits_text}</td>\
+<td class=\"src\"><pre>{src_html}</pre>{branch_note}</td>\
+</tr>\n",
     )
+}
+
+/// Non-color cue placed in the hits column. Coverage status is also
+/// already on the `<tr>` class; the glyph is `aria-hidden` so screen
+/// readers don't double-announce alongside the `aria-label` on the row.
+fn severity_glyph(class: &str) -> &'static str {
+    match class {
+        "hit" => "<span class=\"sev-glyph sev-glyph--hit\" aria-hidden=\"true\">[H]</span>",
+        "miss" => "<span class=\"sev-glyph sev-glyph--miss\" aria-hidden=\"true\">[M]</span>",
+        "partial" => "<span class=\"sev-glyph sev-glyph--partial\" aria-hidden=\"true\">[P]</span>",
+        _ => "",
+    }
+}
+
+/// Human-readable status used as the row's `aria-label`. Avoids the
+/// raw class tokens (`miss` etc.) that would otherwise leak into AT
+/// output. Returned values are safe to drop into an HTML attribute
+/// because they are bounded to known phrases.
+fn row_aria_label(line_no: u32, class: &str) -> String {
+    let phrase = match class {
+        "hit" => "covered",
+        "miss" => "not covered",
+        "partial" => "partially covered",
+        _ => "no statement",
+    };
+    format!("Line {line_no}, {phrase}")
 }
 
 fn source_row_class(
@@ -345,9 +456,17 @@ fn render_source_unavailable(line_hits: &BTreeMap<u32, u32>) -> String {
     );
     for (line, hits) in line_hits {
         let class = if *hits == 0 { "miss" } else { "hit" };
+        let glyph = severity_glyph(class);
+        let aria = row_aria_label(*line, class);
         let _ = writeln!(
             out,
-            "          <tr class=\"line {class}\"><td class=\"line-num\">{line}</td><td class=\"hits\">{hits}x</td><td class=\"src\"><pre>(source unavailable)</pre></td></tr>"
+            "          <tr class=\"line {class}\" id=\"L{line}\" aria-label=\"{aria}\">\
+<td class=\"line-num\">\
+<button type=\"button\" class=\"line-anchor\" data-line=\"{line}\" aria-label=\"Copy link to line {line}\">{line}</button>\
+</td>\
+<td class=\"hits\">{glyph}{hits}x</td>\
+<td class=\"src\"><pre>(source unavailable)</pre></td>\
+</tr>",
         );
     }
     out.push_str("        </tbody>\n");
@@ -363,6 +482,8 @@ fn render_page(title: &str, depth: usize, body: &str) -> String {
     out.push_str("<!doctype html>\n<html lang=\"en\">\n<head>\n");
     out.push_str("  <meta charset=\"utf-8\">\n");
     out.push_str("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    let _ =
+        writeln!(out, "  <meta name=\"generator\" content=\"{}\">", html_attr_escape(GENERATOR));
     let _ = writeln!(
         out,
         "  <meta http-equiv=\"Content-Security-Policy\" content=\"{}\">",
@@ -386,7 +507,7 @@ fn render_summary_header(
     let mut out = String::from("    <header class=\"summary\">\n");
     let _ = writeln!(out, "      <h1>{}</h1>", html_text_escape(title));
     out.push_str(&render_breadcrumb(node, depth));
-    out.push_str("      <ul class=\"metrics\">\n");
+    out.push_str("      <ul class=\"kpi-row\" aria-label=\"Coverage metrics\">\n");
     for (label, m) in [
         ("Statements", summary.statements),
         ("Branches", summary.branches),
@@ -396,7 +517,7 @@ fn render_summary_header(
         let class = pct_class(m.pct);
         let _ = writeln!(
             out,
-            "        <li class=\"metric {class}\"><span class=\"label\">{label}</span><span class=\"pct\">{:.2}%</span><span class=\"quiet\">{}/{}</span></li>",
+            "        <li class=\"kpi-cell kpi-cell--{class}\"><span class=\"kpi-cell__label\">[ {label} ]</span><span class=\"kpi-cell__value\">{:.2}%</span><span class=\"kpi-cell__sub\">{}/{}</span></li>",
             m.pct, m.covered, m.total
         );
     }
@@ -409,29 +530,38 @@ fn render_breadcrumb(node: &ReportNode, depth: usize) -> String {
     if node.relative_path.is_empty() {
         return String::new();
     }
-    let mut out = String::from("      <nav class=\"breadcrumb\">");
+    let mut out = String::from("      <nav class=\"breadcrumb\" aria-label=\"Breadcrumb\">\n");
+    out.push_str("        <ol>\n");
     let root_href = relative_to_root(depth, INDEX_FILE);
-    let _ = write!(out, "<a href=\"{}\">All files</a>", html_attr_escape(&root_href));
+    let _ = writeln!(
+        out,
+        "          <li><a href=\"{}\">All files</a><span class=\"breadcrumb-sep\" aria-hidden=\"true\">/</span></li>",
+        html_attr_escape(&root_href),
+    );
 
     let parts: Vec<&str> = node.relative_path.split('/').collect();
     let mut depth_remaining = depth;
     for (i, part) in parts.iter().enumerate() {
         let is_last = i + 1 == parts.len();
         if is_last {
-            let _ = write!(out, " / <span class=\"current\">{}</span>", html_text_escape(part));
+            let _ = writeln!(
+                out,
+                "          <li><span class=\"current\" aria-current=\"page\">{}</span></li>",
+                html_text_escape(part),
+            );
         } else {
-            // Build a relative href that climbs up to that ancestor's index.
             depth_remaining = depth_remaining.saturating_sub(1);
             let href = relative_to_root(depth_remaining, INDEX_FILE);
-            let _ = write!(
+            let _ = writeln!(
                 out,
-                " / <a href=\"{}\">{}</a>",
+                "          <li><a href=\"{}\">{}</a><span class=\"breadcrumb-sep\" aria-hidden=\"true\">/</span></li>",
                 html_attr_escape(&href),
-                html_text_escape(part)
+                html_text_escape(part),
             );
         }
     }
-    out.push_str("</nav>\n");
+    out.push_str("        </ol>\n");
+    out.push_str("      </nav>\n");
     out
 }
 
@@ -583,7 +713,11 @@ mod tests {
         let root_index = fs::read_to_string(dir.path().join("index.html")).unwrap();
         assert!(root_index.contains("<title>Coverage: All files</title>"));
         assert!(root_index.contains("<link rel=\"stylesheet\" href=\"base.css\">"));
-        assert!(fs::read_to_string(dir.path().join("base.css")).unwrap().contains(".high"));
+        let css = fs::read_to_string(dir.path().join("base.css")).unwrap();
+        assert!(css.contains(".kpi-cell"), "base.css missing fallow KPI cell rules");
+        let tokens = fs::read_to_string(dir.path().join("coverage-tokens.css")).unwrap();
+        assert!(tokens.contains("--hit-bg"), "coverage-tokens.css missing semantic alias");
+        assert!(tokens.contains("--font-body"), "coverage-tokens.css missing fallow font stack");
     }
 
     #[test]
@@ -734,8 +868,12 @@ mod tests {
         let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
         let dir = write_to_temp(json);
         let css = fs::read_to_string(dir.path().join("base.css")).unwrap();
-        assert!(css.contains(":root[data-theme=\"dark\"]"), "missing dark override");
-        assert!(css.contains(":root:not([data-theme=\"light\"])"), "missing light escape hatch");
+        let tokens = fs::read_to_string(dir.path().join("coverage-tokens.css")).unwrap();
+        assert!(tokens.contains(":root[data-theme=\"dark\"]"), "missing dark override in tokens");
+        assert!(
+            tokens.contains(":root:not([data-theme=\"light\"])"),
+            "missing light escape hatch in tokens",
+        );
         assert!(css.contains(".sortable"), "missing .sortable selector");
         assert!(css.contains("aria-sort=\"ascending\""), "missing aria-sort hook");
         for cls in [
@@ -751,6 +889,123 @@ mod tests {
             assert!(css.contains(cls), "missing token class {cls}");
         }
         assert!(css.contains(".theme-toggle__btn"), "missing theme-toggle button class");
+    }
+
+    #[test]
+    fn index_emits_kpi_pills_with_fallow_bracket_labels() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let root_index = fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(root_index.contains("class=\"kpi-row\""), "kpi-row class missing");
+        assert!(root_index.contains("kpi-cell--"), "kpi-cell severity modifier missing");
+        for label in ["[ Statements ]", "[ Branches ]", "[ Functions ]", "[ Lines ]"] {
+            assert!(root_index.contains(label), "missing bracket label {label:?}");
+        }
+    }
+
+    #[test]
+    fn index_emits_inline_cov_meter_on_lines_column() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let root_index = fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(
+            root_index.contains("class=\"cov-meter"),
+            "summary row missing inline mini coverage meter",
+        );
+        assert!(root_index.contains("role=\"meter\""), "cov-meter must carry role=\"meter\"");
+        assert!(
+            root_index.contains("aria-valuemax=\"100\""),
+            "cov-meter must declare aria-valuemax",
+        );
+    }
+
+    #[test]
+    fn index_emits_threshold_summary_and_filter_group() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let root_index = fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(
+            root_index.contains("threshold-summary"),
+            "index missing threshold summary sentence",
+        );
+        assert!(root_index.contains("id=\"cov-filter\""), "filter input missing");
+        assert!(
+            root_index.contains("<label class=\"filter-group__label\" for=\"cov-filter\""),
+            "filter input must have an explicit <label>",
+        );
+        // `role="status"` already implies `aria-live="polite"`; setting
+        // both is redundant per the WAI-ARIA spec. We assert role only.
+        assert!(
+            root_index.contains("id=\"cov-filter-count\" role=\"status\""),
+            "filter result counter must be a polite live region",
+        );
+        assert!(
+            root_index.contains("aria-controls=\"cov-file-table\""),
+            "filter input must reference the controlled table",
+        );
+    }
+
+    #[test]
+    fn detail_emits_next_uncovered_button_and_copy_toast() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        let detail = fs::read_to_string(dir.path().join("a.js.html")).unwrap();
+        assert!(
+            detail.contains("id=\"cov-next-uncovered\""),
+            "detail page missing Next uncovered button",
+        );
+        assert!(
+            detail.contains("class=\"btn-ghost\""),
+            "Next uncovered must use the ghost button style",
+        );
+        assert!(
+            detail.contains("id=\"cov-copy-toast\""),
+            "detail page missing copy toast live region",
+        );
+    }
+
+    #[test]
+    fn source_rows_carry_line_anchor_button_and_severity_glyph() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("a.js"), "const x = 1;\n").unwrap();
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":12}}},"fnMap":{},"branchMap":{},"s":{"0":0},"f":{},"b":{}}}"#;
+        let map = parse_coverage_map(json).unwrap();
+        let out_dir = dir.path().join("html");
+        write(&map, dir.path(), &out_dir).unwrap();
+        let detail = fs::read_to_string(out_dir.join("a.js.html")).unwrap();
+        assert!(detail.contains("id=\"L1\""), "missed line should have id=\"L1\" anchor target");
+        assert!(
+            detail.contains("class=\"line-anchor\" data-line=\"1\""),
+            "missed line should expose a line-anchor button",
+        );
+        assert!(
+            detail.contains("aria-label=\"Copy link to line 1\""),
+            "line-anchor button must be self-labeling for screen readers",
+        );
+        assert!(
+            detail.contains("sev-glyph sev-glyph--miss"),
+            "missed line should carry the [M] severity glyph",
+        );
+        assert!(
+            detail.contains("aria-label=\"Line 1, not covered\""),
+            "missed row should carry a human-readable aria-label",
+        );
+    }
+
+    #[test]
+    fn every_page_carries_generator_meta_tag() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}},"src/foo.js":{"path":"src/foo.js","statementMap":{},"fnMap":{},"branchMap":{},"s":{},"f":{},"b":{}}}"#;
+        let dir = write_to_temp(json);
+        for html_path in walkdir(dir.path())
+            .into_iter()
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("html"))
+        {
+            let html = fs::read_to_string(&html_path).unwrap();
+            assert!(
+                html.contains("<meta name=\"generator\" content=\"oxc-coverage-reports "),
+                "missing generator meta in {html_path:?}",
+            );
+        }
     }
 
     fn walkdir(dir: &Path) -> Vec<PathBuf> {

--- a/crates/oxc-coverage-reports/src/lib.rs
+++ b/crates/oxc-coverage-reports/src/lib.rs
@@ -18,9 +18,15 @@
 //!   Azure DevOps, and Codecov.
 //! - [`html`]: self-contained directory of HTML pages with per-file source
 //!   gutter. Multi-file output (uses [`Format::write_to_dir`]). Ships
-//!   sortable index tables, an auto/light/dark theme toggle, JS/TS
-//!   syntax highlighting on detail pages, and a strict Content-Security-
-//!   Policy so the report performs zero outbound network requests.
+//!   sortable index tables, an auto/light/dark theme toggle, server-side
+//!   syntax highlighting via [`syntect`], and a strict
+//!   Content-Security-Policy so the report performs zero outbound network
+//!   requests. Gated behind the `html` Cargo feature (enabled by default)
+//!   so consumers that only need text / lcov / cobertura / json-summary
+//!   can drop the syntect grammar + theme payload via
+//!   `default-features = false`.
+//!
+//! [syntect]: https://docs.rs/syntect
 //!
 //! # Example
 //!
@@ -40,6 +46,7 @@
 //! [rn]: oxc_coverage_report::ReportNode
 
 pub mod cobertura;
+#[cfg(feature = "html")]
 pub mod html;
 pub mod json_summary;
 pub mod lcov;
@@ -58,7 +65,9 @@ pub enum Format {
     Cobertura,
     /// Multi-file directory output. Use [`Format::write_to_dir`]; calling
     /// [`Format::write`] on this variant returns an error because there is
-    /// no single stream to write to.
+    /// no single stream to write to. Available only when the `html`
+    /// Cargo feature is enabled.
+    #[cfg(feature = "html")]
     Html,
 }
 
@@ -73,6 +82,7 @@ impl Format {
             "json-summary" => Some(Self::JsonSummary),
             "lcov" => Some(Self::Lcov),
             "cobertura" => Some(Self::Cobertura),
+            #[cfg(feature = "html")]
             "html" => Some(Self::Html),
             _ => None,
         }
@@ -81,8 +91,22 @@ impl Format {
     /// `true` when the format writes a directory tree instead of a single
     /// stream. The CLI dispatches such formats through [`Format::write_to_dir`]
     /// and rejects `-o <file>` for them.
+    #[cfg_attr(
+        not(feature = "html"),
+        expect(
+            clippy::unused_self,
+            reason = "self is only inspected when the `html` feature adds a multi-file variant",
+        )
+    )]
     pub fn is_multi_file(self) -> bool {
-        matches!(self, Self::Html)
+        #[cfg(feature = "html")]
+        {
+            matches!(self, Self::Html)
+        }
+        #[cfg(not(feature = "html"))]
+        {
+            false
+        }
     }
 
     /// Render `root` in this format to `out`.
@@ -106,6 +130,7 @@ impl Format {
             Self::JsonSummary => json_summary::write(root, out),
             Self::Lcov => lcov::write(root, root_dir, out),
             Self::Cobertura => cobertura::write(root, root_dir, out),
+            #[cfg(feature = "html")]
             Self::Html => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "html format produces a directory tree; use Format::write_to_dir",
@@ -126,7 +151,9 @@ impl Format {
         root_dir: &Path,
         output_dir: &Path,
     ) -> std::io::Result<()> {
+        let _ = (coverage_map, root_dir, output_dir);
         match self {
+            #[cfg(feature = "html")]
             Self::Html => html::write(coverage_map, root_dir, output_dir),
             _ => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,

--- a/crates/oxc-coverage-reports/src/lib.rs
+++ b/crates/oxc-coverage-reports/src/lib.rs
@@ -161,4 +161,27 @@ impl Format {
             )),
         }
     }
+
+    /// Like [`Format::write_to_dir`] but threads through caller-supplied
+    /// options. Currently only [`Format::Html`] consumes the options
+    /// (via [`html::HtmlOptions`]); other multi-file formats added in
+    /// the future may extend this signature.
+    #[cfg(feature = "html")]
+    pub fn write_to_dir_with_options(
+        self,
+        coverage_map: &oxc_coverage_report::CoverageMap,
+        root_dir: &Path,
+        output_dir: &Path,
+        html_options: &html::HtmlOptions,
+    ) -> std::io::Result<()> {
+        match self {
+            Self::Html => {
+                html::write_with_options(coverage_map, root_dir, output_dir, html_options)
+            }
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "single-file format; use Format::write",
+            )),
+        }
+    }
 }

--- a/crates/oxc-coverage-reports/tests/html_smoke.rs
+++ b/crates/oxc-coverage-reports/tests/html_smoke.rs
@@ -5,9 +5,13 @@
 //! rendered detail page contains the actual source text (proving the
 //! source-read fallback works) plus per-line coverage classes for hit
 //! vs miss vs partial vs no-statement rows. The unit tests in
-//! `src/html.rs` exercise edge cases on synthetic input; this test
+//! `src/html/mod.rs` exercise edge cases on synthetic input; this test
 //! covers the realistic path where the user has a coverage-final.json
 //! pointing at files on disk.
+//!
+//! Skipped entirely when the `html` feature is disabled.
+
+#![cfg(feature = "html")]
 
 use oxc_coverage_reports::html;
 use oxc_coverage_types::parse_coverage_map;
@@ -48,9 +52,17 @@ fn renders_actual_source_with_coverage_classes() {
     let detail_file = walk_for_filename(&out_dir, "module.js.html").expect("detail page exists");
     let detail = fs::read_to_string(&detail_file).unwrap();
 
-    assert!(detail.contains("const x = 1;"), "source line 1 should appear in detail page");
-    assert!(detail.contains("const y = 2;"), "source line 2 should appear in detail page");
-    assert!(detail.contains("if (x) y;"), "source line 3 should appear in detail page");
+    // syntect splits each source line into per-token spans, so the raw
+    // line text is not a single contiguous substring in the HTML. Match
+    // on individual token texts that round-trip identically (identifiers
+    // and numeric literals do; whitespace and punctuation get wrapped
+    // and re-emitted, but the literal characters survive in textContent).
+    for token in ["const", "x", "1", "y", "2", "if"] {
+        assert!(detail.contains(token), "expected `{token}` somewhere in detail page");
+    }
+    // Server-side highlighting must produce token spans on a known
+    // extension (`.js` -> JavaScript grammar).
+    assert!(detail.contains("stok-"), "expected syntect token classes in detail page");
     assert!(detail.contains("line hit"), "line 1 should be class=hit");
     assert!(detail.contains("line miss"), "line 2 should be class=miss");
     assert!(detail.contains("line partial"), "line 3 should be class=partial (branch 1/2)");

--- a/crates/oxc-coverage-reports/tests/snapshot.rs
+++ b/crates/oxc-coverage-reports/tests/snapshot.rs
@@ -134,9 +134,11 @@ fn unknown_format_returns_none() {
 fn all_supported_formats_parse() {
     assert_eq!(Format::parse("lcov"), Some(Format::Lcov));
     assert_eq!(Format::parse("cobertura"), Some(Format::Cobertura));
+    #[cfg(feature = "html")]
     assert_eq!(Format::parse("html"), Some(Format::Html));
 }
 
+#[cfg(feature = "html")]
 #[test]
 fn html_is_multi_file_others_are_not() {
     assert!(Format::Html.is_multi_file());
@@ -145,4 +147,15 @@ fn html_is_multi_file_others_are_not() {
     {
         assert!(!f.is_multi_file(), "{f:?} should not be multi-file");
     }
+}
+
+#[cfg(not(feature = "html"))]
+#[test]
+fn no_format_reports_multi_file_without_html_feature() {
+    for f in
+        [Format::Text, Format::TextSummary, Format::JsonSummary, Format::Lcov, Format::Cobertura]
+    {
+        assert!(!f.is_multi_file(), "{f:?} should not be multi-file");
+    }
+    assert_eq!(Format::parse("html"), None);
 }

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,16 @@
 [advisories]
 version = 2
+ignore = [
+    # bincode 1.3.3 is "unmaintained" only because the team stopped
+    # development; the 1.x line is feature-frozen. Pulled in transitively
+    # by syntect 5.x (via plist). No safe upstream upgrade is available
+    # and we are not in a position to migrate syntect off of it.
+    { id = "RUSTSEC-2025-0141", reason = "transitive via syntect; no safe upgrade" },
+    # yaml-rust 0.4.5 is unmaintained but functional; pulled in
+    # transitively by syntect 5.x for grammar / theme parsing. The
+    # `yaml-rust2` replacement is not yet adopted upstream.
+    { id = "RUSTSEC-2024-0320", reason = "transitive via syntect; no safe upgrade" },
+]
 
 [licenses]
 allow = [


### PR DESCRIPTION
> Stacks on #54. Review after that PR lands.

## Summary

- Address G4 follow-up #1 from the panel: replace the hard-coded 80% line-coverage threshold with a configurable knob.
- New `html::HtmlOptions { high_threshold: f64 }` (Default 80.0, additive struct so future knobs don't break callers).
- New `html::write_with_options()` + `Format::write_to_dir_with_options()` companions; the original entry points keep their signatures.
- New `--threshold <pct>` CLI flag with input validation (0–100, friendly error otherwise).
- Threshold drives both the index page summary sentence and the high/medium/low row colour bucketing so the visual story stays consistent.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo doc` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo deny check`
- [x] Unit test verifying both summary sentence and pct_class respect the configured threshold
- [x] CLI integration tests for `--threshold 40` (override) and `--threshold 150` (rejection)

Refs #45.