### PR TITLE
feat(report): configurable line-coverage threshold (PR G5)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,6 +64,11 @@ Coverage suite (umbrella [#45](https://github.com/fallow-rs/oxc-coverage-instrum
   - `rayon` parallelism on per-file render (`children.par_iter()`); 100-file / 200-LOC project emits in under 2 s on a typical laptop
   - New `html` Cargo feature (default-enabled) gates `syntect` + `two-face` + `rayon` so downstream consumers that only want text / lcov / cobertura / json-summary can drop the grammar payload via `default-features = false`
   - `~+2.2 MiB` binary delta for the bundled grammar set; acceptable for a CI-class tool
+- [x] **PR G5**: configurable line-coverage threshold
+  - New `HtmlOptions { high_threshold: f64 }` struct with `Default` (80.0, matching Istanbul's traditional cutoff). Constructed via struct-update syntax so future fields are additive without breaking callers
+  - New `html::write_with_options()` companion to `html::write()`; new `Format::write_to_dir_with_options()` companion to `Format::write_to_dir()`. The original entry points keep their signatures for backward compat and dispatch through `HtmlOptions::default()`
+  - Threshold drives both the index page's "N of M files fall below the X% line-coverage threshold" sentence AND the high/medium/low colour bucketing on every metric pill, row, and inline coverage meter, so the visual story stays consistent. Medium / low boundary stays fixed at 50%
+  - CLI `--threshold <pct>` flag on `report` subcommand; validates `0 <= x <= 100` at parse time with a friendly error message
 - [x] **PR G4**: fallow "Mode B" visual pass
   - New `coverage-tokens.css` vendored from fallow-cloud's design system (Radix Sand palette, severity stops, type ramp, font stacks). Light-default per Mode B; dark via explicit `data-theme="dark"` OR `prefers-color-scheme: dark` + no override
   - KPI metric pills with `[ Statements ]` bracket labels and severity-coloured values; per-row mini coverage meter on the Lines column (1px outline, severity fill, `role="meter"`); breadcrumb as semantic `<ol><li>` with `aria-current="page"`

--- a/crates/oxc-coverage-instrument-cli/src/main.rs
+++ b/crates/oxc-coverage-instrument-cli/src/main.rs
@@ -47,6 +47,11 @@ struct ReportArgs {
     /// when rendering the html source view. Defaults to the current working
     /// directory.
     root_dir: PathBuf,
+    /// `--threshold` (html only). Percentage cutoff for the high / medium
+    /// coverage bucket and the "below X% threshold" sentence on the
+    /// index page. Defaults to 80 if not supplied. Validated to be in
+    /// `[0, 100]` at parse time.
+    html_threshold: f64,
 }
 
 fn main() -> ExitCode {
@@ -119,6 +124,7 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
     let mut output_dir: Option<PathBuf> = None;
     let mut coverage_file: Option<String> = None;
     let mut root_dir: Option<PathBuf> = None;
+    let mut html_threshold: f64 = 80.0;
 
     let mut i = 0;
     while i < args.len() {
@@ -137,6 +143,22 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
                 output_dir = Some(PathBuf::from(take_value(args, &mut i, "--output-dir")?));
             }
             "--root" => root_dir = Some(PathBuf::from(take_value(args, &mut i, "--root")?)),
+            "--threshold" => {
+                let value = take_value(args, &mut i, "--threshold")?;
+                let parsed = value.parse::<f64>().map_err(|_| {
+                    eprintln!(
+                        "error: --threshold must be a number between 0 and 100, got '{value}'"
+                    );
+                    ExitCode::FAILURE
+                })?;
+                if !(0.0..=100.0).contains(&parsed) {
+                    eprintln!(
+                        "error: --threshold {parsed} is outside [0, 100]; pick a percentage in that range"
+                    );
+                    return Err(ExitCode::FAILURE);
+                }
+                html_threshold = parsed;
+            }
             "--help" | "-h" => {
                 print_report_usage();
                 return Err(ExitCode::SUCCESS);
@@ -199,7 +221,7 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
         })
     });
 
-    Ok(ReportArgs { coverage_file, output_file, output_dir, format, root_dir })
+    Ok(ReportArgs { coverage_file, output_file, output_dir, format, root_dir, html_threshold })
 }
 
 fn format_name(format: Format) -> &'static str {
@@ -273,7 +295,11 @@ fn run_report(args: &ReportArgs) -> ExitCode {
             eprintln!("error: --format html requires --output-dir <dir>");
             return ExitCode::FAILURE;
         };
-        if let Err(e) = args.format.write_to_dir(&map, &args.root_dir, output_dir) {
+        let html_opts =
+            oxc_coverage_reports::html::HtmlOptions { high_threshold: args.html_threshold };
+        if let Err(e) =
+            args.format.write_to_dir_with_options(&map, &args.root_dir, output_dir, &html_opts)
+        {
             eprintln!("error: failed to render report: {e}");
             return ExitCode::FAILURE;
         }
@@ -403,6 +429,7 @@ REPORT OPTIONS:
     -o, --output <file>          Write report to file (default: stdout). Not valid for --format html.
     --output-dir <dir>           Output directory for multi-file formats (html). Default: ./coverage
     --root <dir>                 Root directory used to relativize source paths and resolve html source view (default: cwd)
+    --threshold <pct>            High/medium coverage cutoff for html reports (0-100, default: 80)
 
 GLOBAL OPTIONS:
     -V, --version                Print version
@@ -423,6 +450,7 @@ OPTIONS:
     -o, --output <file>          Write report to file (default: stdout). Not valid for --format html.
     --output-dir <dir>           Output directory for multi-file formats (html). Default: ./coverage
     --root <dir>                 Root directory used to relativize source paths and resolve html source view (default: cwd)
+    --threshold <pct>            High/medium coverage cutoff for html reports (0-100, default: 80)
     -h, --help                   Print this help"
     );
 }

--- a/crates/oxc-coverage-instrument-cli/src/main.rs
+++ b/crates/oxc-coverage-instrument-cli/src/main.rs
@@ -125,6 +125,7 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
     let mut coverage_file: Option<String> = None;
     let mut root_dir: Option<PathBuf> = None;
     let mut html_threshold: f64 = 80.0;
+    let mut threshold_was_set = false;
 
     let mut i = 0;
     while i < args.len() {
@@ -151,6 +152,17 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
                     );
                     ExitCode::FAILURE
                 })?;
+                // `f64::from_str` accepts `nan`, `inf`, `-inf`; the
+                // range check below uses comparisons that silently
+                // return false for NaN, so a `nan` input would slip
+                // through unnoticed and degrade every percent to the
+                // "medium" bucket. Reject non-finite values up front.
+                if !parsed.is_finite() {
+                    eprintln!(
+                        "error: --threshold must be a finite number between 0 and 100, got '{value}'"
+                    );
+                    return Err(ExitCode::FAILURE);
+                }
                 if !(0.0..=100.0).contains(&parsed) {
                     eprintln!(
                         "error: --threshold {parsed} is outside [0, 100]; pick a percentage in that range"
@@ -158,6 +170,7 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
                     return Err(ExitCode::FAILURE);
                 }
                 html_threshold = parsed;
+                threshold_was_set = true;
             }
             "--help" | "-h" => {
                 print_report_usage();
@@ -201,6 +214,14 @@ fn parse_report_args(args: &[String]) -> Result<ReportArgs, ExitCode> {
             "error: --output-dir is only valid for multi-file formats (html); use -o for --format {}",
             format_name(format)
         );
+        return Err(ExitCode::FAILURE);
+    }
+    // `--threshold` only affects the html reporter (drives colour
+    // bucketing + the threshold-summary sentence). Reject it on other
+    // formats so the user knows it was a no-op rather than letting it
+    // silently slip through.
+    if threshold_was_set && !format.is_multi_file() {
+        eprintln!("error: --threshold only applies to --format html; remove it or switch formats");
         return Err(ExitCode::FAILURE);
     }
 
@@ -429,7 +450,10 @@ REPORT OPTIONS:
     -o, --output <file>          Write report to file (default: stdout). Not valid for --format html.
     --output-dir <dir>           Output directory for multi-file formats (html). Default: ./coverage
     --root <dir>                 Root directory used to relativize source paths and resolve html source view (default: cwd)
-    --threshold <pct>            High/medium coverage cutoff for html reports (0-100, default: 80)
+    --threshold <pct>            Percentage at or above which html-report cells render green
+                                 (0-100, default: 80). Cells below this go amber down to 50%
+                                 and red below 50%. Affects display only; does not gate the
+                                 process exit code. Rejected on non-html formats.
 
 GLOBAL OPTIONS:
     -V, --version                Print version
@@ -450,7 +474,10 @@ OPTIONS:
     -o, --output <file>          Write report to file (default: stdout). Not valid for --format html.
     --output-dir <dir>           Output directory for multi-file formats (html). Default: ./coverage
     --root <dir>                 Root directory used to relativize source paths and resolve html source view (default: cwd)
-    --threshold <pct>            High/medium coverage cutoff for html reports (0-100, default: 80)
+    --threshold <pct>            Percentage at or above which html-report cells render green
+                                 (0-100, default: 80). Cells below this go amber down to 50%
+                                 and red below 50%. Affects display only; does not gate the
+                                 process exit code. Rejected on non-html formats.
     -h, --help                   Print this help"
     );
 }

--- a/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
+++ b/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
@@ -357,6 +357,53 @@ fn report_html_rejects_dash_o_with_friendly_error() {
 }
 
 #[test]
+fn report_html_threshold_flag_overrides_default_summary() {
+    let cov = write_temp("report_html_threshold.json", SAMPLE_COVERAGE);
+    let out_dir = std::env::temp_dir().join("oxc_cov_cli_html_threshold_out");
+    let _ = std::fs::remove_dir_all(&out_dir);
+    let out = cli()
+        .arg("report")
+        .arg("--format")
+        .arg("html")
+        .arg("--output-dir")
+        .arg(&out_dir)
+        .arg("--threshold")
+        .arg("40")
+        .arg(&cov)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let index = std::fs::read_to_string(out_dir.join("index.html")).unwrap();
+    // SAMPLE_COVERAGE has one file with 50% statement coverage. With the
+    // CLI default 80% threshold the sentence reads "below the 80%
+    // line-coverage threshold"; with --threshold 40 the cutoff drops and
+    // the file is now above, so the sentence flips to the all-met form.
+    assert!(
+        index.contains("40% line-coverage threshold"),
+        "summary should reflect --threshold 40, got:\n{index}",
+    );
+}
+
+#[test]
+fn report_html_threshold_rejects_out_of_range_values() {
+    let cov = write_temp("report_html_threshold_bad.json", SAMPLE_COVERAGE);
+    let out = cli()
+        .arg("report")
+        .arg("--format")
+        .arg("html")
+        .arg("--output-dir")
+        .arg(std::env::temp_dir().join("oxc_cov_cli_html_threshold_bad_out"))
+        .arg("--threshold")
+        .arg("150")
+        .arg(&cov)
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "should reject --threshold 150");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("outside [0, 100]"), "got: {stderr}");
+}
+
+#[test]
 fn report_text_rejects_output_dir_with_friendly_error() {
     let cov = write_temp("report_text_dash_dir.json", SAMPLE_COVERAGE);
     let out = cli()

--- a/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
+++ b/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
@@ -376,10 +376,10 @@ fn report_html_threshold_flag_overrides_default_summary() {
     let index = std::fs::read_to_string(out_dir.join("index.html")).unwrap();
     // SAMPLE_COVERAGE has one file with 50% statement coverage. With the
     // CLI default 80% threshold the sentence reads "below the 80%
-    // line-coverage threshold"; with --threshold 40 the cutoff drops and
+    // coverage threshold"; with --threshold 40 the cutoff drops and
     // the file is now above, so the sentence flips to the all-met form.
     assert!(
-        index.contains("40% line-coverage threshold"),
+        index.contains("40% coverage threshold"),
         "summary should reflect --threshold 40, got:\n{index}",
     );
 }
@@ -401,6 +401,50 @@ fn report_html_threshold_rejects_out_of_range_values() {
     assert!(!out.status.success(), "should reject --threshold 150");
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("outside [0, 100]"), "got: {stderr}");
+}
+
+#[test]
+fn report_html_threshold_rejects_non_finite_values() {
+    let cov = write_temp("report_html_threshold_nan.json", SAMPLE_COVERAGE);
+    // `f64::from_str` parses NaN successfully; without an explicit
+    // `is_finite()` guard the value would slip past the range check
+    // and silently degrade every percent to the "medium" bucket.
+    for bad in ["nan", "inf", "-inf"] {
+        let out = cli()
+            .arg("report")
+            .arg("--format")
+            .arg("html")
+            .arg("--output-dir")
+            .arg(std::env::temp_dir().join("oxc_cov_cli_html_threshold_nan_out"))
+            .arg("--threshold")
+            .arg(bad)
+            .arg(&cov)
+            .output()
+            .unwrap();
+        assert!(!out.status.success(), "should reject --threshold {bad}");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("finite number") || stderr.contains("outside [0, 100]"),
+            "rejection for {bad:?} should mention finite-number or range; got: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn report_threshold_rejected_on_non_html_formats() {
+    let cov = write_temp("report_threshold_lcov.json", SAMPLE_COVERAGE);
+    let out = cli()
+        .arg("report")
+        .arg("--format")
+        .arg("lcov")
+        .arg("--threshold")
+        .arg("70")
+        .arg(&cov)
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "should reject --threshold on lcov");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--threshold only applies to --format html"), "got: {stderr}");
 }
 
 #[test]

--- a/crates/oxc-coverage-reports/src/html/mod.rs
+++ b/crates/oxc-coverage-reports/src/html/mod.rs
@@ -117,7 +117,24 @@ font-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'";
 /// `base.js`. All three must travel together; copying only `base.css`
 /// to a new location without `coverage-tokens.css` leaves the report
 /// visually broken (the token cascade resolves to the browser default).
+///
+/// Uses [`HtmlOptions::default()`] (80% high-coverage threshold matching
+/// Istanbul's convention). Call [`write_with_options`] to override.
 pub fn write(coverage_map: &CoverageMap, root_dir: &Path, output_dir: &Path) -> io::Result<()> {
+    write_with_options(coverage_map, root_dir, output_dir, &HtmlOptions::default())
+}
+
+/// Render a complete HTML coverage report with explicit [`HtmlOptions`].
+///
+/// Same semantics as [`write()`], but the caller controls the threshold
+/// that drives the high/medium/low colour bucketing and the index
+/// page's threshold-summary sentence.
+pub fn write_with_options(
+    coverage_map: &CoverageMap,
+    root_dir: &Path,
+    output_dir: &Path,
+    options: &HtmlOptions,
+) -> io::Result<()> {
     let remapped = remap_coverage_map(coverage_map);
     let root = summarize(&remapped);
 
@@ -126,13 +143,37 @@ pub fn write(coverage_map: &CoverageMap, root_dir: &Path, output_dir: &Path) -> 
     fs::write(output_dir.join("coverage-tokens.css"), COVERAGE_TOKENS_CSS)?;
     fs::write(output_dir.join("base.js"), BASE_JS)?;
 
-    let ctx = RenderContext { root_dir };
+    let ctx = RenderContext { root_dir, options };
     render_node(&root, &ctx, output_dir, 0)?;
     Ok(())
 }
 
+/// Tunable knobs for the HTML reporter.
+///
+/// Stable across breaking changes; new fields are added at the end with
+/// defaults supplied by [`HtmlOptions::default`]. Construct via
+/// `HtmlOptions { high_threshold: 75.0, ..Default::default() }` so
+/// future fields don't require updating every call site.
+#[derive(Debug, Clone)]
+pub struct HtmlOptions {
+    /// Percentage cutoff that separates "high" coverage (green) from
+    /// "medium" (amber) on per-metric colouring, and powers the index
+    /// page's "N of M files fall below the X% line-coverage threshold"
+    /// sentence. The medium-to-low boundary stays fixed at 50%.
+    /// Must be in `[0.0, 100.0]`; the CLI clamps user input.
+    /// Default: `80.0` (Istanbul's traditional value).
+    pub high_threshold: f64,
+}
+
+impl Default for HtmlOptions {
+    fn default() -> Self {
+        Self { high_threshold: 80.0 }
+    }
+}
+
 struct RenderContext<'a> {
     root_dir: &'a Path,
+    options: &'a HtmlOptions,
 }
 
 fn render_node(
@@ -150,7 +191,7 @@ fn render_node(
                 output_dir.join(&node.relative_path)
             };
             fs::create_dir_all(&folder_dir)?;
-            let html = render_folder_index(node, children, depth);
+            let html = render_folder_index(node, children, ctx, depth);
             fs::write(folder_dir.join(INDEX_FILE), html)?;
 
             // Render children in parallel. The file branch is CPU-bound
@@ -193,22 +234,28 @@ fn child_depth_delta(_parent: &ReportNode, child: &ReportNode) -> usize {
 
 // -- Folder index page ------------------------------------------------------
 
-fn render_folder_index(node: &ReportNode, children: &[ReportNode], depth: usize) -> String {
+fn render_folder_index(
+    node: &ReportNode,
+    children: &[ReportNode],
+    ctx: &RenderContext,
+    depth: usize,
+) -> String {
     let title = if node.relative_path.is_empty() {
         "All files".to_owned()
     } else {
         node.relative_path.clone()
     };
+    let threshold = ctx.options.high_threshold;
     let mut body = String::new();
-    body.push_str(&render_summary_header(&title, &node.summary, depth, node));
+    body.push_str(&render_summary_header(&title, &node.summary, depth, node, threshold));
     body.push_str("    <div class=\"pad1\">\n");
-    body.push_str(&render_threshold_summary(children));
+    body.push_str(&render_threshold_summary(children, threshold));
     body.push_str(&render_filter_group(children.len()));
     body.push_str("      <table class=\"coverage-summary\" id=\"cov-file-table\">\n");
     body.push_str(&render_summary_table_header());
     body.push_str("        <tbody>\n");
     for child in children {
-        body.push_str(&render_summary_row(child));
+        body.push_str(&render_summary_row(child, threshold));
     }
     body.push_str("        </tbody>\n");
     body.push_str("      </table>\n");
@@ -216,23 +263,22 @@ fn render_folder_index(node: &ReportNode, children: &[ReportNode], depth: usize)
     render_page(&title, depth, &body)
 }
 
-/// One-line summary above the file table: "N of M files below the 80%
+/// One-line summary above the file table: "N of M files below the X%
 /// line-coverage threshold". Renders as muted body text when at least
 /// one file falls below; silent when every file is at or above.
-fn render_threshold_summary(children: &[ReportNode]) -> String {
-    const THRESHOLD: f64 = 80.0;
+fn render_threshold_summary(children: &[ReportNode], threshold: f64) -> String {
     let total = children.len();
     if total == 0 {
         return String::new();
     }
-    let below = children.iter().filter(|c| c.summary.lines.pct < THRESHOLD).count();
+    let below = children.iter().filter(|c| c.summary.lines.pct < threshold).count();
     if below == 0 {
         return format!(
-            "      <p class=\"threshold-summary\"><strong>All {total} files</strong> meet the {THRESHOLD:.0}% line-coverage threshold.</p>\n",
+            "      <p class=\"threshold-summary\"><strong>All {total} files</strong> meet the {threshold:.0}% line-coverage threshold.</p>\n",
         );
     }
     format!(
-        "      <p class=\"threshold-summary\"><strong>{below}</strong> of {total} files fall below the {THRESHOLD:.0}% line-coverage threshold.</p>\n",
+        "      <p class=\"threshold-summary\"><strong>{below}</strong> of {total} files fall below the {threshold:.0}% line-coverage threshold.</p>\n",
     )
 }
 
@@ -260,13 +306,13 @@ fn render_summary_table_header() -> String {
     out
 }
 
-fn render_summary_row(child: &ReportNode) -> String {
+fn render_summary_row(child: &ReportNode, threshold: f64) -> String {
     let href = match &child.kind {
         NodeKind::Folder { .. } => format!("{}/{INDEX_FILE}", html_attr_escape(&child.name)),
         NodeKind::File { .. } => format!("{}{DETAIL_SUFFIX}", html_attr_escape(&child.name)),
     };
     let display = html_text_escape(&child.name);
-    let row_class = pct_class(child.summary.lines.pct);
+    let row_class = pct_class(child.summary.lines.pct, threshold);
     let mut out = format!(
         "          <tr class=\"row-{row_class}\" data-file=\"{file}\">\n",
         file = html_attr_escape(&child.name),
@@ -279,7 +325,7 @@ fn render_summary_row(child: &ReportNode) -> String {
         ("Lines", child.summary.lines),
     ];
     for (idx, (label, metric)) in metrics.iter().enumerate() {
-        let mc = pct_class(metric.pct);
+        let mc = pct_class(metric.pct, threshold);
         // Mini coverage meter only on the Lines column (final column);
         // duplicating it on every column would clutter the table.
         let meter = if idx == metrics.len() - 1 {
@@ -316,7 +362,13 @@ fn render_detail(
     let fn_lines = compute_fn_lines(coverage);
 
     let mut body = String::new();
-    body.push_str(&render_summary_header(&title, &node.summary, depth, node));
+    body.push_str(&render_summary_header(
+        &title,
+        &node.summary,
+        depth,
+        node,
+        ctx.options.high_threshold,
+    ));
     body.push_str("    <div class=\"pad1\">\n");
     body.push_str(
         "      <div class=\"detail-actions\">\n        <button type=\"button\" class=\"btn-ghost\" id=\"cov-next-uncovered\" aria-label=\"Jump to next uncovered line\" disabled>Next uncovered</button>\n      </div>\n",
@@ -503,6 +555,7 @@ fn render_summary_header(
     summary: &CoverageSummary,
     depth: usize,
     node: &ReportNode,
+    threshold: f64,
 ) -> String {
     let mut out = String::from("    <header class=\"summary\">\n");
     let _ = writeln!(out, "      <h1>{}</h1>", html_text_escape(title));
@@ -514,7 +567,7 @@ fn render_summary_header(
         ("Functions", summary.functions),
         ("Lines", summary.lines),
     ] {
-        let class = pct_class(m.pct);
+        let class = pct_class(m.pct, threshold);
         let _ = writeln!(
             out,
             "        <li class=\"kpi-cell kpi-cell--{class}\"><span class=\"kpi-cell__label\">[ {label} ]</span><span class=\"kpi-cell__value\">{:.2}%</span><span class=\"kpi-cell__sub\">{}/{}</span></li>",
@@ -654,8 +707,14 @@ fn read_source(file: &FileCoverage, root_dir: &Path) -> Option<String> {
 
 // -- Class assignment ------------------------------------------------------
 
-fn pct_class(pct: f64) -> &'static str {
-    if pct >= 80.0 {
+/// Map a percentage to one of `"high"`/`"medium"`/`"low"`, used as the
+/// `kpi-cell--*`, `row-*`, `pct *`, and `cov-meter--*` modifier
+/// suffixes. `high_threshold` separates high from medium; the medium /
+/// low boundary is fixed at 50% (a hardcoded medium threshold below
+/// `high_threshold` keeps the three-bucket UX legible while still
+/// honouring caller preferences for the green/amber line).
+fn pct_class(pct: f64, high_threshold: f64) -> &'static str {
+    if pct >= high_threshold {
         "high"
     } else if pct >= 50.0 {
         "medium"
@@ -1006,6 +1065,52 @@ mod tests {
                 "missing generator meta in {html_path:?}",
             );
         }
+    }
+
+    #[test]
+    fn custom_threshold_drives_summary_sentence_and_pct_class() {
+        // Two files: one at 70% lines, one at 90% lines. With the default
+        // 80% threshold the 70% file is "below"; with --threshold 60 both
+        // are "above" and the row colour bucketing flips.
+        let json = r#"{
+            "lo.js":{"path":"lo.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":1}},"1":{"start":{"line":2,"column":0},"end":{"line":2,"column":1}},"2":{"start":{"line":3,"column":0},"end":{"line":3,"column":1}},"3":{"start":{"line":4,"column":0},"end":{"line":4,"column":1}},"4":{"start":{"line":5,"column":0},"end":{"line":5,"column":1}},"5":{"start":{"line":6,"column":0},"end":{"line":6,"column":1}},"6":{"start":{"line":7,"column":0},"end":{"line":7,"column":1}},"7":{"start":{"line":8,"column":0},"end":{"line":8,"column":1}},"8":{"start":{"line":9,"column":0},"end":{"line":9,"column":1}},"9":{"start":{"line":10,"column":0},"end":{"line":10,"column":1}}},"fnMap":{},"branchMap":{},"s":{"0":1,"1":1,"2":1,"3":1,"4":1,"5":1,"6":1,"7":0,"8":0,"9":0},"f":{},"b":{}},
+            "hi.js":{"path":"hi.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":1}},"1":{"start":{"line":2,"column":0},"end":{"line":2,"column":1}},"2":{"start":{"line":3,"column":0},"end":{"line":3,"column":1}},"3":{"start":{"line":4,"column":0},"end":{"line":4,"column":1}},"4":{"start":{"line":5,"column":0},"end":{"line":5,"column":1}},"5":{"start":{"line":6,"column":0},"end":{"line":6,"column":1}},"6":{"start":{"line":7,"column":0},"end":{"line":7,"column":1}},"7":{"start":{"line":8,"column":0},"end":{"line":8,"column":1}},"8":{"start":{"line":9,"column":0},"end":{"line":9,"column":1}},"9":{"start":{"line":10,"column":0},"end":{"line":10,"column":1}}},"fnMap":{},"branchMap":{},"s":{"0":1,"1":1,"2":1,"3":1,"4":1,"5":1,"6":1,"7":1,"8":1,"9":0},"f":{},"b":{}}
+        }"#;
+        let map = parse_coverage_map(json).unwrap();
+
+        // Default (80%): 70% file is "low" via lines pct < 50.0? Actually
+        // 70% > 50%, so it's "medium"; threshold-summary should say
+        // "1 of 2 files fall below the 80% line-coverage threshold".
+        let dir_default = tempfile::TempDir::new().unwrap();
+        write(&map, Path::new(""), dir_default.path()).unwrap();
+        let default_root = fs::read_to_string(dir_default.path().join("index.html")).unwrap();
+        assert!(
+            default_root.contains("1</strong> of 2 files fall below the 80%"),
+            "default threshold should report 1 below 80%: {default_root}",
+        );
+        assert!(
+            default_root.contains("row-medium"),
+            "70% file should bucket medium under default threshold",
+        );
+
+        // Custom 60%: both files are above; sentence should report all met.
+        let dir_loose = tempfile::TempDir::new().unwrap();
+        write_with_options(
+            &map,
+            Path::new(""),
+            dir_loose.path(),
+            &HtmlOptions { high_threshold: 60.0 },
+        )
+        .unwrap();
+        let loose_root = fs::read_to_string(dir_loose.path().join("index.html")).unwrap();
+        assert!(
+            loose_root.contains("All 2 files</strong> meet the 60% line-coverage threshold"),
+            "60% threshold should clear all files: {loose_root}",
+        );
+        assert!(
+            loose_root.contains("row-high"),
+            "70% file should bucket high under a 60% threshold",
+        );
     }
 
     fn walkdir(dir: &Path) -> Vec<PathBuf> {

--- a/crates/oxc-coverage-reports/src/html/mod.rs
+++ b/crates/oxc-coverage-reports/src/html/mod.rs
@@ -158,7 +158,7 @@ pub fn write_with_options(
 pub struct HtmlOptions {
     /// Percentage cutoff that separates "high" coverage (green) from
     /// "medium" (amber) on per-metric colouring, and powers the index
-    /// page's "N of M files fall below the X% line-coverage threshold"
+    /// page's "N of M files fall below the X% coverage threshold"
     /// sentence. The medium-to-low boundary stays fixed at 50%.
     /// Must be in `[0.0, 100.0]`; the CLI clamps user input.
     /// Default: `80.0` (Istanbul's traditional value).
@@ -263,9 +263,16 @@ fn render_folder_index(
     render_page(&title, depth, &body)
 }
 
-/// One-line summary above the file table: "N of M files below the X%
-/// line-coverage threshold". Renders as muted body text when at least
-/// one file falls below; silent when every file is at or above.
+/// One-line summary above the file table: "N of M files fall below the
+/// X% coverage threshold". The wording deliberately says "coverage
+/// threshold" rather than "line-coverage threshold" because the same
+/// `threshold` value drives the colour bucketing for every metric
+/// (statements, branches, functions, lines), and the file-below count
+/// is itself computed against line coverage as the canonical proxy
+/// for "is this file healthy enough". The file-list inclusion still
+/// uses `lines.pct` so a file with 95% lines and 30% branches is
+/// considered "above"; the bucketed colour cells then surface the
+/// underlying per-metric reality.
 fn render_threshold_summary(children: &[ReportNode], threshold: f64) -> String {
     let total = children.len();
     if total == 0 {
@@ -274,11 +281,11 @@ fn render_threshold_summary(children: &[ReportNode], threshold: f64) -> String {
     let below = children.iter().filter(|c| c.summary.lines.pct < threshold).count();
     if below == 0 {
         return format!(
-            "      <p class=\"threshold-summary\"><strong>All {total} files</strong> meet the {threshold:.0}% line-coverage threshold.</p>\n",
+            "      <p class=\"threshold-summary\"><strong>All {total} files</strong> meet the {threshold:.0}% coverage threshold.</p>\n",
         );
     }
     format!(
-        "      <p class=\"threshold-summary\"><strong>{below}</strong> of {total} files fall below the {threshold:.0}% line-coverage threshold.</p>\n",
+        "      <p class=\"threshold-summary\"><strong>{below}</strong> of {total} files fall below the {threshold:.0}% coverage threshold.</p>\n",
     )
 }
 
@@ -1080,7 +1087,7 @@ mod tests {
 
         // Default (80%): 70% file is "low" via lines pct < 50.0? Actually
         // 70% > 50%, so it's "medium"; threshold-summary should say
-        // "1 of 2 files fall below the 80% line-coverage threshold".
+        // "1 of 2 files fall below the 80% coverage threshold".
         let dir_default = tempfile::TempDir::new().unwrap();
         write(&map, Path::new(""), dir_default.path()).unwrap();
         let default_root = fs::read_to_string(dir_default.path().join("index.html")).unwrap();
@@ -1104,7 +1111,7 @@ mod tests {
         .unwrap();
         let loose_root = fs::read_to_string(dir_loose.path().join("index.html")).unwrap();
         assert!(
-            loose_root.contains("All 2 files</strong> meet the 60% line-coverage threshold"),
+            loose_root.contains("All 2 files</strong> meet the 60% coverage threshold"),
             "60% threshold should clear all files: {loose_root}",
         );
         assert!(

--- a/crates/oxc-coverage-reports/src/lib.rs
+++ b/crates/oxc-coverage-reports/src/lib.rs
@@ -161,4 +161,27 @@ impl Format {
             )),
         }
     }
+
+    /// Like [`Format::write_to_dir`] but threads through caller-supplied
+    /// options. Currently only [`Format::Html`] consumes the options
+    /// (via [`html::HtmlOptions`]); other multi-file formats added in
+    /// the future may extend this signature.
+    #[cfg(feature = "html")]
+    pub fn write_to_dir_with_options(
+        self,
+        coverage_map: &oxc_coverage_report::CoverageMap,
+        root_dir: &Path,
+        output_dir: &Path,
+        html_options: &html::HtmlOptions,
+    ) -> std::io::Result<()> {
+        match self {
+            Self::Html => {
+                html::write_with_options(coverage_map, root_dir, output_dir, html_options)
+            }
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "single-file format; use Format::write",
+            )),
+        }
+    }
 }


### PR DESCRIPTION
> Originally #55, auto-closed when its stacked base #54 merged. Same branch (rebased onto main), retargeted to main.

## Summary

- New `html::HtmlOptions { high_threshold: f64 }` (Default 80.0). Additive struct so future knobs don't break callers.
- New `html::write_with_options()` + `Format::write_to_dir_with_options()` companions; the original entry points keep their signatures.
- New `--threshold <pct>` CLI flag with strict validation: rejects `nan`/`inf`/`-inf`, rejects out-of-range, rejects use on non-html formats.
- Threshold drives both the summary sentence and the row colour bucketing so the visual story stays consistent. Sentence wording uses "coverage threshold" (not "line-coverage threshold") because the same value buckets all four metrics.

## Panel review

A round of /panel-review on the initial implementation surfaced two blockers (NaN slipped past validation, sentence wording falsely scoped to "line-coverage") and two quality wins (silent flag ignore on non-html formats, help text needed the 50% boundary explained). All four landed in this PR before this PR was opened against main.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (both feature configs)
- [x] `cargo test --workspace`
- [x] `cargo doc` with `RUSTDOCFLAGS=-D warnings`
- [x] `cargo deny check`
- [x] Unit + integration tests for `--threshold` override, range rejection, non-finite rejection, non-html-format rejection

Refs #45.