### PR TITLE
feat(instrument): strip_typescript option for TS-source-direct coverage (PR 1/5 of #47)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +235,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +254,15 @@ name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -307,6 +340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctor"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +364,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
+
+[[package]]
 name = "dragonbox_ecma"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +385,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -541,6 +606,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "id-arena"
@@ -808,6 +882,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "oxc-browserslist"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "939b33dabf9f7f1cf6c7cebd977b95fe8f6ecae0ef00cfc8f25b8da89d52983d"
+dependencies = [
+ "flate2",
+ "postcard",
+ "rustc-hash",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "oxc-coverage-instrument-cli"
 version = "0.2.0"
 dependencies = [
@@ -921,6 +1008,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_compat"
+version = "0.126.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f77da0005857510f28764642bfd0f299924dbd5169c6d35752f754a0c35062ce"
+dependencies = [
+ "cow-utils",
+ "oxc-browserslist",
+ "oxc_syntax",
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
 name = "oxc_coverage_instrument"
 version = "0.5.1"
 dependencies = [
@@ -937,6 +1037,7 @@ dependencies = [
  "oxc_sourcemap",
  "oxc_span",
  "oxc_syntax",
+ "oxc_transformer",
  "oxc_traverse",
  "serde",
  "serde_json",
@@ -1011,6 +1112,9 @@ name = "oxc_data_structures"
 version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdea5ebbfe376448e83f9749828f31a0ad9b85a1b01e31f70597565b74f809a"
+dependencies = [
+ "ropey",
+]
 
 [[package]]
 name = "oxc_diagnostics"
@@ -1177,6 +1281,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_transformer"
+version = "0.126.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d6604b8394fe33df53a4641388d4e8c36efdaf36c8e0e1d60313c0b554e7c2"
+dependencies = [
+ "base64",
+ "compact_str",
+ "indexmap",
+ "itoa",
+ "memchr",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_compat",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_ecmascript",
+ "oxc_regular_expression",
+ "oxc_semantic",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+ "oxc_traverse",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sha1",
+]
+
+[[package]]
 name = "oxc_traverse"
 version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1436,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1544,16 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "ropey"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
+dependencies = [
+ "smallvec",
+ "str_indices",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -1501,6 +1657,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1696,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smawk"
@@ -1590,6 +1763,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
 name = "syn"
@@ -1718,6 +1897,12 @@ dependencies = [
  "serde_derive",
  "syntect",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-id-start"

--- a/crates/oxc-coverage-instrument-napi/src/lib.rs
+++ b/crates/oxc-coverage-instrument-napi/src/lib.rs
@@ -29,6 +29,14 @@ pub struct InstrumentOptions {
     pub report_logic: Option<bool>,
     /// Class method names to exclude from coverage instrumentation.
     pub ignore_class_methods: Option<Vec<String>>,
+    /// When true, run the TypeScript-strip pass before instrumentation.
+    /// Set this when passing raw TypeScript source that has not been
+    /// pre-transformed by Babel / tsc / esbuild. Defaults to false, which
+    /// preserves backward compatibility with existing Vitest / nyc callers
+    /// that supply already-transformed JavaScript. If false and you pass
+    /// raw TypeScript, the output will contain TypeScript syntax and will
+    /// not be executable as JavaScript (no error is returned).
+    pub strip_typescript: Option<bool>,
 }
 
 /// A coverage pragma comment that was found but not handled.
@@ -73,7 +81,7 @@ pub fn instrument(
             input_source_map: o.input_source_map,
             report_logic: o.report_logic.unwrap_or(false),
             ignore_class_methods: o.ignore_class_methods.unwrap_or_default(),
-            strip_typescript: false,
+            strip_typescript: o.strip_typescript.unwrap_or(false),
         }
     });
 

--- a/crates/oxc-coverage-instrument-napi/src/lib.rs
+++ b/crates/oxc-coverage-instrument-napi/src/lib.rs
@@ -73,6 +73,7 @@ pub fn instrument(
             input_source_map: o.input_source_map,
             report_logic: o.report_logic.unwrap_or(false),
             ignore_class_methods: o.ignore_class_methods.unwrap_or_default(),
+            strip_typescript: false,
         }
     });
 

--- a/crates/oxc-coverage-instrument-napi/test.mjs
+++ b/crates/oxc-coverage-instrument-napi/test.mjs
@@ -676,4 +676,26 @@ function runInstrumented(result, filename, callExpression) {
   console.log('  [PASS] v8ToIstanbul resolves if-arm[0] through collected body span');
 }
 
+// Test: stripTypescript option strips TS annotations and produces executable JS
+{
+  const result = instrument(
+    'const x: number = 1;\nconsole.log(x);\n',
+    'app.ts',
+    { stripTypescript: true, sourceMap: true },
+  );
+  assert(!result.code.includes(': number'), 'TS annotation must be stripped');
+  assert(result.code.includes('const x ='), 'output must contain executable JS');
+  const cov = JSON.parse(result.coverageMap);
+  assert(cov.path === 'app.ts', 'coverage map path should be app.ts');
+  assert(Object.keys(cov.statementMap).length >= 2, 'statementMap should be populated');
+  console.log('  [PASS] stripTypescript option strips TS and produces executable JS');
+}
+
+// Test: stripTypescript defaults to false (preserves backward compatibility)
+{
+  const result = instrument('const x: number = 1;\n', 'app.ts');
+  assert(result.code.includes(': number'), 'without stripTypescript the TS annotation must remain');
+  console.log('  [PASS] stripTypescript defaults to false');
+}
+
 console.log('\nAll tests passed!');

--- a/crates/oxc-coverage-instrument/Cargo.toml
+++ b/crates/oxc-coverage-instrument/Cargo.toml
@@ -28,6 +28,7 @@ oxc_semantic = "0.126"
 oxc_sourcemap = "6.1"
 oxc_span = "0.126"
 oxc_syntax = "0.126"
+oxc_transformer = "0.126"
 oxc_traverse = "0.126"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/oxc-coverage-instrument/src/instrument.rs
+++ b/crates/oxc-coverage-instrument/src/instrument.rs
@@ -1,6 +1,6 @@
 //! Top-level instrumentation API.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
@@ -8,6 +8,7 @@ use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_parser::{Parser, ParserReturn};
 use oxc_semantic::{Scoping, SemanticBuilder};
 use oxc_span::SourceType;
+use oxc_transformer::{TransformOptions, Transformer, TypeScriptOptions};
 use oxc_traverse::traverse_mut;
 
 use std::collections::BTreeMap;
@@ -39,6 +40,12 @@ pub struct InstrumentOptions {
     /// Matches Istanbul's `ignoreClassMethods` behavior for class methods and
     /// named function expressions with a matching id.
     pub ignore_class_methods: Vec<String>,
+    /// When true, run `oxc_transformer`'s TypeScript-strip pass on the parsed
+    /// AST before coverage instrumentation. Required when the caller passes
+    /// raw TypeScript source that has not been pre-transformed by Babel /
+    /// tsc / esbuild. Defaults to false so existing callers that supply
+    /// pre-transformed JS are unaffected.
+    pub strip_typescript: bool,
 }
 
 impl Default for InstrumentOptions {
@@ -49,6 +56,7 @@ impl Default for InstrumentOptions {
             input_source_map: None,
             report_logic: false,
             ignore_class_methods: Vec::new(),
+            strip_typescript: false,
         }
     }
 }
@@ -132,7 +140,12 @@ pub fn instrument(
         return Ok(empty_coverage_result(filename, source, unhandled_pragmas));
     }
 
-    let scoping = SemanticBuilder::new().build(&parsed.program).semantic.into_scoping();
+    let mut scoping = SemanticBuilder::new().build(&parsed.program).semantic.into_scoping();
+
+    if options.strip_typescript {
+        scoping = strip_typescript_pass(&allocator, filename, &mut parsed.program, scoping)?;
+    }
+
     let cov_fn_name = generate_cov_fn_name(filename);
 
     let mut transform = CoverageTransform::new(TransformInit {
@@ -182,6 +195,31 @@ pub fn instrument(
         source_map,
         unhandled_pragmas,
     })
+}
+
+/// Run `oxc_transformer`'s TypeScript-strip pass on the parsed program in
+/// place. Returns the updated `Scoping` produced by the transformer (the
+/// semantic state may change as type-only nodes are removed). Surviving nodes
+/// retain their original `Span` values, so positions still refer to the
+/// original TypeScript source offsets.
+fn strip_typescript_pass<'a>(
+    allocator: &'a Allocator,
+    filename: &str,
+    program: &mut Program<'a>,
+    scoping: Scoping,
+) -> Result<Scoping, InstrumentError> {
+    let options = TransformOptions {
+        typescript: TypeScriptOptions::default(),
+        ..TransformOptions::default()
+    };
+    let transformer = Transformer::new(allocator, Path::new(filename), &options);
+    let ret = transformer.build_with_scoping(scoping, program);
+    if !ret.errors.is_empty() {
+        return Err(InstrumentError::TransformError(
+            ret.errors.iter().map(|e| format!("{e}")).collect::<Vec<_>>().join("; "),
+        ));
+    }
+    Ok(ret.scoping)
 }
 
 fn parse_program<'a>(
@@ -390,6 +428,7 @@ fn finalize_source_map(
 
 /// Error type for instrumentation failures.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum InstrumentError {
     /// The source could not be parsed.
     ParseError(String),
@@ -399,6 +438,9 @@ pub enum InstrumentError {
     /// `FileCoverage` shape only contains types whose serde implementations are
     /// infallible, so `instrument()` does not currently construct this variant.
     SerializationError(String),
+    /// The TypeScript strip pass produced diagnostics. Only emitted when
+    /// `InstrumentOptions::strip_typescript` is enabled.
+    TransformError(String),
 }
 
 impl std::fmt::Display for InstrumentError {
@@ -406,6 +448,7 @@ impl std::fmt::Display for InstrumentError {
         match self {
             Self::ParseError(msg) => write!(f, "parse error: {msg}"),
             Self::SerializationError(msg) => write!(f, "serialization error: {msg}"),
+            Self::TransformError(msg) => write!(f, "transform error: {msg}"),
             Self::InvalidCoverageVariable(name) => {
                 write!(
                     f,

--- a/crates/oxc-coverage-instrument/src/instrument.rs
+++ b/crates/oxc-coverage-instrument/src/instrument.rs
@@ -8,7 +8,7 @@ use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_parser::{Parser, ParserReturn};
 use oxc_semantic::{Scoping, SemanticBuilder};
 use oxc_span::SourceType;
-use oxc_transformer::{TransformOptions, Transformer, TypeScriptOptions};
+use oxc_transformer::{JsxOptions, TransformOptions, Transformer, TypeScriptOptions};
 use oxc_traverse::traverse_mut;
 
 use std::collections::BTreeMap;
@@ -208,8 +208,15 @@ fn strip_typescript_pass<'a>(
     program: &mut Program<'a>,
     scoping: Scoping,
 ) -> Result<Scoping, InstrumentError> {
+    // `JsxOptions::default()` calls `JsxOptions::enable()`, which would
+    // rewrite `<div>` to `React.createElement` / `_jsx` on `.tsx` input.
+    // Strip-pass only removes type syntax; JSX must round-trip unchanged
+    // so codegen can emit it verbatim. Pin the JSX pass off explicitly.
+    // `typescript` is also listed explicitly so a future change to
+    // `TransformOptions::default()` cannot silently alter the strip pass.
     let options = TransformOptions {
         typescript: TypeScriptOptions::default(),
+        jsx: JsxOptions::disable(),
         ..TransformOptions::default()
     };
     let transformer = Transformer::new(allocator, Path::new(filename), &options);

--- a/crates/oxc-coverage-instrument/src/instrument.rs
+++ b/crates/oxc-coverage-instrument/src/instrument.rs
@@ -41,10 +41,24 @@ pub struct InstrumentOptions {
     /// named function expressions with a matching id.
     pub ignore_class_methods: Vec<String>,
     /// When true, run `oxc_transformer`'s TypeScript-strip pass on the parsed
-    /// AST before coverage instrumentation. Required when the caller passes
-    /// raw TypeScript source that has not been pre-transformed by Babel /
-    /// tsc / esbuild. Defaults to false so existing callers that supply
-    /// pre-transformed JS are unaffected.
+    /// AST before coverage instrumentation. Set this when passing raw
+    /// TypeScript source that has not been pre-transformed by Babel /
+    /// tsc / esbuild.
+    ///
+    /// Output: instrumented JavaScript whose `statementMap` / `branchMap`
+    /// positions reference the original TypeScript byte offsets (surviving
+    /// AST nodes retain their `Span` through the strip pass).
+    ///
+    /// Defaults to false so existing Vitest / nyc callers that supply
+    /// already-transformed JavaScript are unaffected. **If false and you
+    /// pass raw TypeScript, the output will contain TypeScript syntax and
+    /// will not be executable as JavaScript** (no error is returned).
+    ///
+    /// Limitations: TC39 Stage 3 decorators are supported via
+    /// `DecoratorOptions::default()`; legacy `experimentalDecorators`
+    /// syntax (`@Injectable()` style) is not currently supported and will
+    /// return `InstrumentError::TransformError`. JSX is preserved verbatim
+    /// on `.tsx` files (the codegen pass emits it unchanged).
     pub strip_typescript: bool,
 }
 
@@ -223,7 +237,7 @@ fn strip_typescript_pass<'a>(
     let ret = transformer.build_with_scoping(scoping, program);
     if !ret.errors.is_empty() {
         return Err(InstrumentError::TransformError(
-            ret.errors.iter().map(|e| format!("{e}")).collect::<Vec<_>>().join("; "),
+            ret.errors.iter().map(|e| format!("{e}")).collect::<Vec<_>>(),
         ));
     }
     Ok(ret.scoping)
@@ -446,8 +460,11 @@ pub enum InstrumentError {
     /// infallible, so `instrument()` does not currently construct this variant.
     SerializationError(String),
     /// The TypeScript strip pass produced diagnostics. Only emitted when
-    /// `InstrumentOptions::strip_typescript` is enabled.
-    TransformError(String),
+    /// `InstrumentOptions::strip_typescript` is enabled. The vector
+    /// contains one entry per transformer diagnostic so callers can
+    /// surface them individually instead of string-scraping a joined
+    /// message.
+    TransformError(Vec<String>),
 }
 
 impl std::fmt::Display for InstrumentError {
@@ -455,7 +472,7 @@ impl std::fmt::Display for InstrumentError {
         match self {
             Self::ParseError(msg) => write!(f, "parse error: {msg}"),
             Self::SerializationError(msg) => write!(f, "serialization error: {msg}"),
-            Self::TransformError(msg) => write!(f, "transform error: {msg}"),
+            Self::TransformError(msgs) => write!(f, "transform error: {}", msgs.join("; ")),
             Self::InvalidCoverageVariable(name) => {
                 write!(
                     f,

--- a/crates/oxc-coverage-instrument/tests/typescript_direct_test.rs
+++ b/crates/oxc-coverage-instrument/tests/typescript_direct_test.rs
@@ -115,3 +115,28 @@ fn ts_direct_default_off_preserves_existing_behavior() {
         result.code
     );
 }
+
+#[test]
+fn ts_direct_tsx_jsx_is_preserved_in_output() {
+    let src = "const greet = (name: string) => <div>Hello {name}</div>;\nconsole.log(greet(\"world\"));\n";
+    let result = instrument(src, "app.tsx", &ts_opts()).expect("instrument");
+    assert!(
+        result.code.contains("<div>"),
+        "JSX must survive strip_typescript on .tsx, got: {}",
+        result.code
+    );
+    assert!(!result.code.contains(": string"), "TS annotation must be stripped on .tsx");
+    assert!(
+        !result.code.contains("React.createElement"),
+        "JSX must not be transformed to call form, got: {}",
+        result.code
+    );
+}
+
+#[test]
+fn ts_direct_js_file_passes_through_unchanged() {
+    let src = "const x = 1;\nconsole.log(x);\n";
+    let result = instrument(src, "app.js", &ts_opts()).expect("instrument");
+    assert!(result.code.contains("const x ="));
+    assert_eq!(result.coverage_map.statement_map.len(), 2);
+}

--- a/crates/oxc-coverage-instrument/tests/typescript_direct_test.rs
+++ b/crates/oxc-coverage-instrument/tests/typescript_direct_test.rs
@@ -140,3 +140,27 @@ fn ts_direct_js_file_passes_through_unchanged() {
     assert!(result.code.contains("const x ="));
     assert_eq!(result.coverage_map.statement_map.len(), 2);
 }
+
+#[test]
+fn ts_direct_enum_counter_spans_original_source() {
+    // TypeScript `enum` declarations are converted to an IIFE by the
+    // transformer. Verify the resulting statement counters point at the
+    // original source byte offsets, not synthetic (0, 0) spans.
+    let src = "enum Color { Red, Green, Blue }\nconst c: Color = Color.Red;\n";
+    let result = instrument(src, "app.ts", &ts_opts()).expect("instrument");
+    assert!(result.coverage_map.statement_map.len() >= 4);
+
+    let enum_stmt = &result.coverage_map.statement_map["0"];
+    assert_eq!(enum_stmt.start.line, 1, "enum statement should anchor at line 1");
+    assert!(
+        enum_stmt.end.column > enum_stmt.start.column,
+        "enum statement span must be non-degenerate: {enum_stmt:?}"
+    );
+
+    let member_lines: Vec<u32> =
+        result.coverage_map.statement_map.values().map(|loc| loc.start.line).collect();
+    assert!(
+        member_lines.iter().all(|&l| l > 0),
+        "no statement counter should land on synthetic line 0: {member_lines:?}"
+    );
+}

--- a/crates/oxc-coverage-instrument/tests/typescript_direct_test.rs
+++ b/crates/oxc-coverage-instrument/tests/typescript_direct_test.rs
@@ -1,0 +1,117 @@
+//! Tests for `InstrumentOptions::strip_typescript`. Verifies that raw
+//! TypeScript source can be instrumented in one shot: the output is valid
+//! JavaScript (type annotations removed), and statementMap / branchMap
+//! positions still refer to the original TypeScript source offsets.
+
+use oxc_coverage_instrument::{InstrumentError, InstrumentOptions, instrument};
+
+fn ts_opts() -> InstrumentOptions {
+    InstrumentOptions { source_map: true, strip_typescript: true, ..InstrumentOptions::default() }
+}
+
+#[test]
+fn ts_direct_output_is_valid_js() {
+    let src = "const x: number = 1;\nconsole.log(x);\n";
+    let result = instrument(src, "app.ts", &ts_opts()).expect("instrument");
+    assert!(
+        !result.code.contains(": number"),
+        "type annotation must be stripped, got: {}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("interface "),
+        "interface declarations must be stripped, got: {}",
+        result.code
+    );
+    assert!(
+        result.code.contains("const x ="),
+        "executable JS variable declaration expected, got: {}",
+        result.code
+    );
+}
+
+#[test]
+fn ts_direct_statement_map_positions_are_ts_positions() {
+    let src = "const x: number = 1;\nconst y: string = \"hi\";\nconsole.log(x, y);\n";
+    let result = instrument(src, "app.ts", &ts_opts()).expect("instrument");
+    let map = &result.coverage_map.statement_map;
+    assert_eq!(map.len(), 3, "expected 3 statements, got {}: {map:#?}", map.len());
+
+    let s0 = &map["0"];
+    assert_eq!(s0.start.line, 1, "statement 0 should be on line 1, got {s0:?}");
+    let s1 = &map["1"];
+    assert_eq!(s1.start.line, 2, "statement 1 should be on line 2, got {s1:?}");
+    let s2 = &map["2"];
+    assert_eq!(s2.start.line, 3, "statement 2 should be on line 3, got {s2:?}");
+}
+
+#[test]
+fn ts_direct_source_map_sources_and_content() {
+    let src = "const x: number = 1;\n";
+    let result = instrument(src, "app.ts", &ts_opts()).expect("instrument");
+    let sm: serde_json::Value =
+        serde_json::from_str(result.source_map.as_deref().expect("source map")).expect("json");
+    assert_eq!(sm["sources"][0], "app.ts");
+    let content = sm["sourcesContent"][0].as_str().expect("sourcesContent[0]");
+    assert!(
+        content.contains(": number"),
+        "sourcesContent must retain TS annotations, got: {content}"
+    );
+}
+
+#[test]
+fn ts_direct_type_only_nodes_produce_no_counters() {
+    let src = "interface Foo { a: number; }\ntype Bar = string;\ndeclare const baz: number;\n";
+    let result = instrument(src, "app.ts", &ts_opts()).expect("instrument");
+    assert_eq!(
+        result.coverage_map.statement_map.len(),
+        0,
+        "type-only nodes must not produce statement counters: {:#?}",
+        result.coverage_map.statement_map
+    );
+    assert_eq!(result.coverage_map.fn_map.len(), 0);
+    assert_eq!(result.coverage_map.branch_map.len(), 0);
+}
+
+#[test]
+fn ts_direct_interface_is_skipped_in_position_map() {
+    let src = "const x: number = 1;\nconst y: string = \"hi\";\ninterface Foo { a: number }\nconsole.log(x, y);\n";
+    let result = instrument(src, "app.ts", &ts_opts()).expect("instrument");
+    let lines: Vec<u32> =
+        result.coverage_map.statement_map.values().map(|loc| loc.start.line).collect();
+    assert!(!lines.contains(&3), "interface on line 3 must not appear in statement_map: {lines:?}");
+    assert!(lines.contains(&1));
+    assert!(lines.contains(&2));
+    assert!(lines.contains(&4));
+}
+
+#[test]
+fn ts_direct_typescript_function_gets_counter() {
+    let src = "function add(a: number, b: number): number {\n  return a + b;\n}\nadd(1, 2);\n";
+    let result = instrument(src, "app.ts", &ts_opts()).expect("instrument");
+    assert!(!result.code.contains(": number"), "param annotations stripped");
+    assert_eq!(result.coverage_map.fn_map.len(), 1, "function counter expected");
+    let f = &result.coverage_map.fn_map["0"];
+    assert_eq!(f.name, "add");
+    assert_eq!(f.decl.start.line, 1);
+}
+
+#[test]
+fn ts_direct_parse_error_returns_parse_error() {
+    let src = "const x: = ;\n";
+    let err = instrument(src, "app.ts", &ts_opts()).expect_err("parse must fail");
+    assert!(matches!(err, InstrumentError::ParseError(_)), "expected ParseError, got {err:?}");
+}
+
+#[test]
+fn ts_direct_default_off_preserves_existing_behavior() {
+    let src = "const x: number = 1;\n";
+    let opts = InstrumentOptions::default();
+    assert!(!opts.strip_typescript);
+    let result = instrument(src, "app.ts", &opts).expect("instrument");
+    assert!(
+        result.code.contains(": number"),
+        "with strip_typescript=false the TS annotation must remain, got: {}",
+        result.code
+    );
+}


### PR DESCRIPTION
## Summary

Adds `InstrumentOptions::strip_typescript` (default `false`). When enabled, `instrument()` runs `oxc_transformer`'s TypeScript-strip pass on the parsed AST before `CoverageTransform`. The output is executable JS with type annotations removed; `statementMap` and `branchMap` positions still refer to the original TypeScript source offsets because surviving nodes retain their `Span`.

Refs #47. Part 1 of 5; does NOT close #47 on its own.

## What changed

- `oxc_transformer = "0.126"` added to `crates/oxc-coverage-instrument/Cargo.toml`
- New `strip_typescript: bool` field on `InstrumentOptions` (default `false`, additive)
- New private `strip_typescript_pass()` helper runs the transformer between parse and `CoverageTransform`
  - `JsxOptions::disable()` pinned explicitly (default is `enable()` which would rewrite `<div>` to `React.createElement` on `.tsx`)
- `InstrumentError` is now `#[non_exhaustive]` and has a new `TransformError(Vec<String>)` variant (Vec so callers can surface individual transformer diagnostics rather than string-scraping a joined message)
- napi adapter exposes `stripTypescript?: boolean`; JavaScript callers can opt in immediately (the vitest.js auto-detect heuristic still lands in PR 3)
- 11 new Rust tests in `tests/typescript_direct_test.rs`, 2 new napi tests in `napi/test.mjs`
- Field doc comment documents the silent failure mode (`strip_typescript: false` on raw TS produces non-executable instrumented TS), JSX preservation contract, and the legacy decorator limitation tracked at #73

## Binary size impact

`oxc_transformer` adds ~302 KiB to the release napi dylib (2.8 MB → 3.1 MB). Well under the 2 MB delta threshold; no Cargo feature gate is added.

## Roadmap

- PR 2: equivalence fixture (TS-direct vs transpile-first → same covered line set), transformer-error path test
- PR 3: `vitest.js` auto-detect (`.ts` / `.tsx` AND no `inputSourceMap`) + README usage section
- PR 4: `examples/vitest-typescript/` CI smoke-test, end-to-end validation
- PR 5: v0.6.0 release

## Follow-up

- #73 — legacy `experimentalDecorators` support (NestJS / Angular / class-validator codebases). Defaults to `false`; users hitting the limitation get `InstrumentError::TransformError` until the follow-up lands.

## Reviewed by

- `feature-dev:code-reviewer` agent caught the JsxOptions default bug (commit 419d6f1)
- `user-panel` agent surfaced four fix-before-shipping items: napi wiring, `TransformError(Vec<String>)`, doc comment strengthening, enum regression test (commit 16e54cd)

## Test plan

- [x] `cargo test --workspace` green (existing tests + 11 new Rust TS-direct tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check`, `typos .` clean
- [x] Smoke probe: `instrument(ts_source, "app.ts", { strip_typescript: true, source_map: true })` returns executable JS, `statementMap` positions are TS line numbers, source map has `sources=["app.ts"]` and `sourcesContent` with TS annotations preserved
- [x] Empirical verification: enum statement counters preserve original source span (1, 0-31) not synthetic (0, 0)
- [ ] CI green on all three platforms

N/A on closing keyword for this PR; #47 closes on PR 5 of the series.