### PR TITLE
test(instrument): TS-direct equivalence fixture (PR 2/5 of #47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions: {}
 

--- a/crates/oxc-coverage-instrument/tests/fixtures/typescript-direct-simple.ts
+++ b/crates/oxc-coverage-instrument/tests/fixtures/typescript-direct-simple.ts
@@ -1,0 +1,15 @@
+interface User {
+    name: string;
+    age: number;
+}
+type Status = "active" | "pending";
+
+function greet(user: User, status: Status): string {
+    if (status === "active") {
+        return `Hello, ${user.name}`;
+    }
+    return "Please wait";
+}
+
+const u: User = { name: "Alice", age: 30 };
+console.log(greet(u, "active"));

--- a/crates/oxc-coverage-instrument/tests/typescript_equivalence_test.rs
+++ b/crates/oxc-coverage-instrument/tests/typescript_equivalence_test.rs
@@ -84,6 +84,48 @@ fn ts_direct_statement_count_matches_js_equivalent() {
 }
 
 #[test]
+fn ts_direct_emits_executable_js_without_type_annotations() {
+    // Regression-strength assertion: the equivalence tests above compare line
+    // sets, which the underlying CoverageTransform would produce identically
+    // whether or not the strip pass ran (Span values survive either way).
+    // This test asserts on the EMITTED CODE STRING: with strip_typescript on,
+    // the output must NOT contain TS-only syntax. Mentally reverting
+    // strip_typescript_pass to a no-op makes this test fail because the
+    // codegen would emit the original TS annotations verbatim.
+    let ts_opts = InstrumentOptions { strip_typescript: true, ..InstrumentOptions::default() };
+    let result = instrument(TS_SOURCE, "app.ts", &ts_opts).expect("instrument TS");
+
+    assert!(
+        !result.code.contains(": string"),
+        "type annotations must be stripped from output code: {}",
+        result.code
+    );
+    assert!(
+        !result.code.contains(": number"),
+        "type annotations must be stripped from output code: {}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("interface "),
+        "interface declarations must be stripped from output code: {}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("type Status"),
+        "type alias declarations must be stripped from output code: {}",
+        result.code
+    );
+
+    let no_strip_opts = InstrumentOptions::default();
+    let no_strip_result = instrument(TS_SOURCE, "app.ts", &no_strip_opts).expect("instrument TS");
+    assert!(
+        no_strip_result.code.contains(": string"),
+        "without strip_typescript the TS annotation must survive in output: {}",
+        no_strip_result.code
+    );
+}
+
+#[test]
 fn transform_error_display_format() {
     use oxc_coverage_instrument::InstrumentError;
     let err = InstrumentError::TransformError(vec![

--- a/crates/oxc-coverage-instrument/tests/typescript_equivalence_test.rs
+++ b/crates/oxc-coverage-instrument/tests/typescript_equivalence_test.rs
@@ -1,0 +1,106 @@
+//! Equivalence test for the `strip_typescript` path.
+//!
+//! Asserts that instrumenting a TypeScript source directly (with
+//! `strip_typescript: true`) produces the same set of covered source
+//! line numbers as instrumenting the JavaScript equivalent (with
+//! `strip_typescript: false`). The pair is line-aligned: the JS
+//! equivalent uses blank lines for the type-only declarations so the
+//! executable statements live on the same line numbers in both inputs.
+//!
+//! Statement IDs typically differ between the two paths (synthesis
+//! order is not stable across the strip pass), so we compare the
+//! sorted set of line numbers, not IDs.
+
+use oxc_coverage_instrument::{InstrumentOptions, instrument};
+use std::collections::BTreeSet;
+
+const TS_SOURCE: &str = include_str!("fixtures/typescript-direct-simple.ts");
+
+// JS equivalent of `typescript-direct-simple.ts`. Line-aligned: the first
+// six lines are blank so the function declaration lives on line 7 in
+// both files, matching the TS source's interface/type-alias placement.
+const JS_EQUIVALENT: &str = "\n\n\n\n\n\nfunction greet(user, status) {\n    if (status === \"active\") {\n        return `Hello, ${user.name}`;\n    }\n    return \"Please wait\";\n}\n\nconst u = { name: \"Alice\", age: 30 };\nconsole.log(greet(u, \"active\"));\n";
+
+fn covered_lines(coverage_map: &oxc_coverage_types::FileCoverage) -> BTreeSet<u32> {
+    let mut lines = BTreeSet::new();
+    for loc in coverage_map.statement_map.values() {
+        lines.insert(loc.start.line);
+    }
+    for entry in coverage_map.fn_map.values() {
+        lines.insert(entry.loc.start.line);
+    }
+    for entry in coverage_map.branch_map.values() {
+        lines.insert(entry.loc.start.line);
+    }
+    lines
+}
+
+#[test]
+fn ts_direct_and_js_equivalent_cover_same_lines() {
+    let ts_opts = InstrumentOptions { strip_typescript: true, ..InstrumentOptions::default() };
+    let js_opts = InstrumentOptions::default();
+
+    let ts_result = instrument(TS_SOURCE, "app.ts", &ts_opts).expect("instrument TS");
+    let js_result = instrument(JS_EQUIVALENT, "app.js", &js_opts).expect("instrument JS");
+
+    let ts_lines = covered_lines(&ts_result.coverage_map);
+    let js_lines = covered_lines(&js_result.coverage_map);
+
+    assert_eq!(
+        ts_lines, js_lines,
+        "TS-direct path and JS-equivalent path must cover the same set of source lines\nTS lines: {ts_lines:?}\nJS lines: {js_lines:?}\nTS source: {TS_SOURCE}\nJS source: {JS_EQUIVALENT}"
+    );
+
+    assert!(
+        ts_lines.contains(&7),
+        "function declaration on line 7 must be covered, got {ts_lines:?}"
+    );
+    assert!(ts_lines.contains(&8), "if statement on line 8 must be covered, got {ts_lines:?}");
+}
+
+#[test]
+fn ts_direct_statement_count_matches_js_equivalent() {
+    let ts_opts = InstrumentOptions { strip_typescript: true, ..InstrumentOptions::default() };
+    let js_opts = InstrumentOptions::default();
+
+    let ts_result = instrument(TS_SOURCE, "app.ts", &ts_opts).expect("instrument TS");
+    let js_result = instrument(JS_EQUIVALENT, "app.js", &js_opts).expect("instrument JS");
+
+    assert_eq!(
+        ts_result.coverage_map.statement_map.len(),
+        js_result.coverage_map.statement_map.len(),
+        "statement counter count must match between TS-direct and JS-equivalent paths"
+    );
+    assert_eq!(
+        ts_result.coverage_map.fn_map.len(),
+        js_result.coverage_map.fn_map.len(),
+        "function counter count must match"
+    );
+    assert_eq!(
+        ts_result.coverage_map.branch_map.len(),
+        js_result.coverage_map.branch_map.len(),
+        "branch counter count must match"
+    );
+}
+
+#[test]
+fn transform_error_display_format() {
+    use oxc_coverage_instrument::InstrumentError;
+    let err = InstrumentError::TransformError(vec![
+        "unsupported syntax at line 5".to_string(),
+        "missing semicolon at line 8".to_string(),
+    ]);
+    let rendered = format!("{err}");
+    assert!(rendered.starts_with("transform error: "), "got: {rendered}");
+    assert!(rendered.contains("unsupported syntax at line 5"), "got: {rendered}");
+    assert!(rendered.contains("missing semicolon at line 8"), "got: {rendered}");
+    assert!(rendered.contains("; "), "diagnostics must be joined with '; ', got: {rendered}");
+}
+
+#[test]
+fn transform_error_single_diagnostic_displays_without_separator() {
+    use oxc_coverage_instrument::InstrumentError;
+    let err = InstrumentError::TransformError(vec!["only one diagnostic".to_string()]);
+    let rendered = format!("{err}");
+    assert_eq!(rendered, "transform error: only one diagnostic");
+}


### PR DESCRIPTION
## Summary

Stacked on top of PR #72. Adds the equivalence fixture and tests promised by PR 2 of the #47 series: when you instrument a TypeScript source with `strip_typescript: true`, the resulting coverage map covers the same source lines as instrumenting the line-aligned JavaScript equivalent with `strip_typescript: false`.

Refs #47. Part 2 of 5; does NOT close #47 on its own.

## Base

Targets `feat/47-ts-direct` (PR #72), NOT `main`. Per the repo's stacked-PR convention, the base will be retargeted to `main` once PR #72 merges; do not merge this one first.

## What changed

- New fixture `tests/fixtures/typescript-direct-simple.ts`: small realistic TS program with interface, type alias, function with parameter types, if-else branch, top-level statements.
- New `tests/typescript_equivalence_test.rs` with four tests:
  - `ts_direct_and_js_equivalent_cover_same_lines`: sorted set of statement/fn/branch source-line numbers matches between TS-direct and JS-equivalent paths.
  - `ts_direct_statement_count_matches_js_equivalent`: counter cardinality matches across the three maps.
  - `transform_error_display_format`: constructed `TransformError(vec![...])` formats with the expected prefix and joiner.
  - `transform_error_single_diagnostic_displays_without_separator`: single-element variant has no joiner artifact.

## Why no natural transformer-error trigger test

Empirical probe of 9 candidate inputs (namespace, module syntax, const enum, legacy decorators, declare global, import equals, export equals, constructor parameter properties, deep decorators) all returned `Ok` with default `TransformOptions`. The `TransformError` variant is forward-compat for future option permutations (e.g. `allow_namespaces: false`); tests 3 + 4 cover the Display contract for the variant directly. If a natural trigger surfaces in PR 3 (vitest auto-detect may expose edge cases), a real-source test will land there.

## Roadmap

- PR 3: `vitest.js` auto-detect (`.ts`/`.tsx` AND no `inputSourceMap`) + README usage section
- PR 4: `examples/vitest-typescript/` CI smoke-test, end-to-end validation
- PR 5: v0.6.0 release (closes #47)

## Test plan

- [x] `cargo test --workspace` green (4 new tests + existing 11 from PR 72 + all prior tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check`, `typos .` clean
- [ ] CI green on all three platforms

N/A on closing keyword for this PR; #47 closes on PR 5 of the series.