### PR TITLE
feat(napi): vitest adapter auto-detects stripTypescript (PR 3/5 of #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ export default defineConfig({
 
 The factory forwards `coverageVariable` and `ignoreClassMethods` to the native instrumenter. Everything else in the Istanbul provider (collection, merging, reporting) keeps working unchanged.
 
+By default the adapter auto-detects raw TypeScript: when the filename ends in `.ts` / `.tsx` (also `.mts` / `.cts`) AND no `inputSourceMap` was supplied (the source has not already been transformed by Vite / Babel / tsc), it runs an in-process TypeScript-strip pass so the output is executable JavaScript and the coverage map points at the original `.ts` source. No `@babel/preset-typescript` or upstream tsc step is required. Set `stripTypescript: false` on `createOxcInstrumenter({ ... })` to disable the auto-detect when running under a toolchain that pre-transforms TypeScript without emitting an `inputSourceMap` (`@vitejs/plugin-react-swc` in some configurations, Bun's native TS runner, Node 23+ with `--experimental-strip-types`). Set `stripTypescript: true` to force the strip pass regardless of filename or `inputSourceMap` presence.
+
 ### vite-plugin-istanbul integration
 
 Requires `vite-plugin-istanbul` **>= 9.0.0** (`instrumenter` option).

--- a/crates/oxc-coverage-instrument-napi/test.mjs
+++ b/crates/oxc-coverage-instrument-napi/test.mjs
@@ -760,15 +760,75 @@ function runInstrumented(result, filename, callExpression) {
   console.log('  [PASS] vitest adapter honors explicit stripTypescript: false on .ts');
 }
 
-// Test: explicit stripTypescript: true forces strip on .js (where auto-detect would skip)
+// Test: explicit stripTypescript: true overrides the auto-detect skip on .ts
+// when inputSourceMap is present. Auto-detect would NOT strip (inputSourceMap
+// signals "already transformed upstream"), but explicit true forces the strip
+// pass anyway. Observable via the TS annotation disappearing from the output.
 {
   const { createOxcInstrumenter } = await import('./vitest.js');
   const inst = createOxcInstrumenter({ stripTypescript: true });
-  // .js with TS annotations would be a parse error, so use a TS file with .js
-  // extension to test forced strip. Use bare JS to avoid testing the parser.
-  const code = inst.instrumentSync('const x = 1;\nconsole.log(x);\n', 'forced.js');
-  assert(code.includes('const x ='), 'forced strip on plain JS still yields valid output');
-  console.log('  [PASS] vitest adapter honors explicit stripTypescript: true on .js');
+  const fakeMap = { version: 3, sources: ['orig.ts'], mappings: '', names: [] };
+  const code = inst.instrumentSync('const x: number = 1;\n', 'app.ts', fakeMap);
+  assert(
+    !code.includes(': number'),
+    'explicit stripTypescript: true must force strip even when inputSourceMap is present',
+  );
+  console.log('  [PASS] vitest adapter honors explicit stripTypescript: true override');
+}
+
+// Test: non-boolean stripTypescript throws TypeError instead of silently
+// coercing. Catches the 'auto' string case (a prior tri-state design shape)
+// that Boolean coercion would turn into force-strip.
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  let caught = null;
+  try {
+    createOxcInstrumenter({ stripTypescript: 'auto' });
+  } catch (e) {
+    caught = e;
+  }
+  assert(caught instanceof TypeError, `expected TypeError, got ${caught}`);
+  assert(
+    caught.message.includes('stripTypescript'),
+    `error message must name the offending option, got: ${caught.message}`,
+  );
+  console.log('  [PASS] vitest adapter rejects non-boolean stripTypescript with TypeError');
+}
+
+// Test: TS_EXTENSION_REGEX rejects non-TypeScript extensions that look similar.
+// The narrow form /\.([mc]ts|tsx?)$/i must not match .ts.bak (where .bak is
+// the actual extension) or .mtsx (not a real Node / TS extension).
+// Strategy: feed TS source to a non-matching filename. Auto-detect must skip
+// the strip; the parser then rejects the TS syntax because the filename
+// extension (.bak / .mtsx) means SourceType::from_path falls back to JS.
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  const inst = createOxcInstrumenter();
+  // .ts.bak: actual extension is .bak; strip must not auto-engage.
+  let caughtBak = null;
+  try {
+    inst.instrumentSync('const x: number = 1;\n', 'app.ts.bak');
+  } catch (e) {
+    caughtBak = e;
+  }
+  assert(
+    caughtBak !== null && /parse error/.test(caughtBak.message),
+    'app.ts.bak must not auto-strip; parser must reject TS syntax',
+  );
+  // .mtsx: not a real extension (only .mts / .cts / .ts / .tsx are valid).
+  let caughtMtsx = null;
+  try {
+    inst.instrumentSync('const x: number = 1;\n', 'app.mtsx');
+  } catch (e) {
+    caughtMtsx = e;
+  }
+  assert(
+    caughtMtsx !== null && /parse error/.test(caughtMtsx.message),
+    'app.mtsx must not auto-strip; .mtsx is not a real TypeScript extension',
+  );
+  console.log(
+    '  [PASS] vitest adapter regex rejects .ts.bak and .mtsx (non-TS extensions)',
+  );
 }
 
 console.log('\nAll tests passed!');

--- a/crates/oxc-coverage-instrument-napi/test.mjs
+++ b/crates/oxc-coverage-instrument-napi/test.mjs
@@ -698,4 +698,77 @@ function runInstrumented(result, filename, callExpression) {
   console.log('  [PASS] stripTypescript defaults to false');
 }
 
+// Test: createOxcInstrumenter auto-detects .ts as raw TypeScript when no inputSourceMap
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  const inst = createOxcInstrumenter();
+  const code = inst.instrumentSync('const x: number = 1;\nconsole.log(x);\n', 'app.ts');
+  assert(!code.includes(': number'), 'auto-detect must strip TS on .ts without inputSourceMap');
+  assert(code.includes('const x ='), 'auto-detect must emit executable JS');
+  console.log('  [PASS] vitest adapter auto-detects .ts without inputSourceMap');
+}
+
+// Test: createOxcInstrumenter auto-detects .tsx and preserves JSX
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  const inst = createOxcInstrumenter();
+  const code = inst.instrumentSync(
+    'const el: JSX.Element = <div>hi</div>;\nconsole.log(el);\n',
+    'app.tsx',
+  );
+  assert(!code.includes(': JSX.Element'), 'auto-detect must strip TS on .tsx');
+  assert(code.includes('<div>'), 'auto-detect must preserve JSX on .tsx');
+  console.log('  [PASS] vitest adapter auto-detects .tsx and preserves JSX');
+}
+
+// Test: createOxcInstrumenter does NOT auto-strip when inputSourceMap is provided
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  const inst = createOxcInstrumenter();
+  // Pass raw TS source WITH an inputSourceMap. In real Vite/Vitest usage the
+  // source would already be transformed JS by this point, but feeding raw TS
+  // is the cleanest way to OBSERVE whether the strip pass ran. Auto-detect
+  // must treat the inputSourceMap presence as "already transformed upstream"
+  // and skip the strip; the TS annotation in the output proves it.
+  const fakeMap = { version: 3, sources: ['orig.ts'], mappings: '', names: [] };
+  const code = inst.instrumentSync('const x: number = 1;\n', 'app.ts', fakeMap);
+  assert(
+    code.includes(': number'),
+    'with inputSourceMap the strip pass must not run, TS annotation must survive',
+  );
+  console.log('  [PASS] vitest adapter does not strip when inputSourceMap is present');
+}
+
+// Test: createOxcInstrumenter does NOT auto-strip .js files
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  const inst = createOxcInstrumenter();
+  const code = inst.instrumentSync('const x = 1;\nconsole.log(x);\n', 'app.js');
+  assert(code.includes('const x ='), '.js must pass through as executable JS');
+  console.log('  [PASS] vitest adapter does not auto-strip .js files');
+}
+
+// Test: explicit stripTypescript: false overrides auto-detect on .ts
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  const inst = createOxcInstrumenter({ stripTypescript: false });
+  const code = inst.instrumentSync('const x: number = 1;\n', 'app.ts');
+  assert(
+    code.includes(': number'),
+    'explicit stripTypescript: false must keep TS annotations on .ts',
+  );
+  console.log('  [PASS] vitest adapter honors explicit stripTypescript: false on .ts');
+}
+
+// Test: explicit stripTypescript: true forces strip on .js (where auto-detect would skip)
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  const inst = createOxcInstrumenter({ stripTypescript: true });
+  // .js with TS annotations would be a parse error, so use a TS file with .js
+  // extension to test forced strip. Use bare JS to avoid testing the parser.
+  const code = inst.instrumentSync('const x = 1;\nconsole.log(x);\n', 'forced.js');
+  assert(code.includes('const x ='), 'forced strip on plain JS still yields valid output');
+  console.log('  [PASS] vitest adapter honors explicit stripTypescript: true on .js');
+}
+
 console.log('\nAll tests passed!');

--- a/crates/oxc-coverage-instrument-napi/vitest.d.ts
+++ b/crates/oxc-coverage-instrument-napi/vitest.d.ts
@@ -11,6 +11,15 @@ export interface OxcInstrumenterOptions {
   ignoreClassMethods?: string[]
   /** When true, adds truthy-value tracking (bT) for logical expressions. */
   reportLogic?: boolean
+  /**
+   * Run the TypeScript-strip pass before instrumentation. When omitted
+   * (default), the adapter auto-detects: it strips when the filename matches
+   * `/\.[mc]?tsx?$/i` AND no `inputSourceMap` was supplied (i.e., the source
+   * has not already been transformed by Vite / Babel / tsc). Set to `false`
+   * to disable auto-detect under toolchains that pre-transform TypeScript
+   * but do not produce an `inputSourceMap`. Set to `true` to force strip.
+   */
+  stripTypescript?: boolean
 }
 
 /**

--- a/crates/oxc-coverage-instrument-napi/vitest.d.ts
+++ b/crates/oxc-coverage-instrument-napi/vitest.d.ts
@@ -14,10 +14,11 @@ export interface OxcInstrumenterOptions {
   /**
    * Run the TypeScript-strip pass before instrumentation. When omitted
    * (default), the adapter auto-detects: it strips when the filename matches
-   * `/\.[mc]?tsx?$/i` AND no `inputSourceMap` was supplied (i.e., the source
-   * has not already been transformed by Vite / Babel / tsc). Set to `false`
-   * to disable auto-detect under toolchains that pre-transform TypeScript
-   * but do not produce an `inputSourceMap`. Set to `true` to force strip.
+   * `/\.([mc]ts|tsx?)$/i` AND no `inputSourceMap` was supplied (i.e., the
+   * source has not already been transformed by Vite / Babel / tsc). Set to
+   * `false` to disable auto-detect under toolchains that pre-transform
+   * TypeScript but do not produce an `inputSourceMap`. Set to `true` to force
+   * strip. Non-boolean values throw `TypeError`.
    */
   stripTypescript?: boolean
 }

--- a/crates/oxc-coverage-instrument-napi/vitest.js
+++ b/crates/oxc-coverage-instrument-napi/vitest.js
@@ -19,6 +19,11 @@
 
 const { instrument } = require('./index.js');
 
+// Filename pattern matching .ts, .tsx, .mts, .mtsx, .cts, .ctsx (the set of
+// extensions where TypeScript syntax may legally appear). Used for auto-detect;
+// explicit user opt-in/out via the `stripTypescript` option always wins.
+const TS_EXTENSION_REGEX = /\.[mc]?tsx?$/i;
+
 /**
  * Creates an instrumenter that implements the istanbul-lib-instrument
  * Instrumenter interface, backed by oxc-coverage-instrument.
@@ -28,10 +33,19 @@ const { instrument } = require('./index.js');
  * These are forwarded to the native instrumenter automatically.
  *
  * @param {object} [options]
- * @param {string} [options.coverageVariable] - Global variable for coverage data.
+ * @param {string} [options.coverageVariable] Global variable for coverage data.
  *   Vitest passes its internal `__VITEST_COVERAGE__`; defaults to `__coverage__`.
- * @param {string[]} [options.ignoreClassMethods] - Class method names to skip.
- * @param {boolean} [options.reportLogic] - Enable truthy-value tracking (bT).
+ * @param {string[]} [options.ignoreClassMethods] Class method names to skip.
+ * @param {boolean} [options.reportLogic] Enable truthy-value tracking (bT).
+ * @param {boolean} [options.stripTypescript] Run the TypeScript-strip pass
+ *   before instrumentation. When omitted (default), the adapter auto-detects:
+ *   it strips when the filename matches `/\.[mc]?tsx?$/i` AND no
+ *   `inputSourceMap` was supplied (i.e., the source has not already been
+ *   transformed by Vite / Babel / tsc). Set to `false` to disable auto-detect
+ *   under toolchains that pre-transform TypeScript but do not produce an
+ *   `inputSourceMap` (`@vitejs/plugin-react-swc` in some configurations, Bun's
+ *   native TS runner, Node 23+ with `--experimental-strip-types`). Set to
+ *   `true` to force strip regardless of filename or `inputSourceMap` presence.
  * @returns {{ instrumentSync, lastSourceMap, lastFileCoverage }}
  */
 function createOxcInstrumenter(options) {
@@ -39,6 +53,7 @@ function createOxcInstrumenter(options) {
   const coverageVariable = options.coverageVariable || '__coverage__';
   const ignoreClassMethods = options.ignoreClassMethods || [];
   const reportLogic = options.reportLogic || false;
+  const stripTypescriptOverride = options.stripTypescript;
 
   // Raw JSON strings from the last instrument call — parsed lazily on first access.
   let _lastCoverageMapJson = null;
@@ -66,12 +81,17 @@ function createOxcInstrumenter(options) {
 
   return {
     instrumentSync(code, filename, inputSourceMap) {
+      const stripTypescript =
+        stripTypescriptOverride === undefined
+          ? TS_EXTENSION_REGEX.test(filename) && !inputSourceMap
+          : Boolean(stripTypescriptOverride);
       const result = instrument(code, filename, {
         coverageVariable,
         sourceMap: true,
         inputSourceMap: inputSourceMap ? JSON.stringify(inputSourceMap) : undefined,
         reportLogic,
         ignoreClassMethods,
+        stripTypescript,
       });
 
       // Store raw JSON — defer parsing until actually needed.

--- a/crates/oxc-coverage-instrument-napi/vitest.js
+++ b/crates/oxc-coverage-instrument-napi/vitest.js
@@ -19,10 +19,12 @@
 
 const { instrument } = require('./index.js');
 
-// Filename pattern matching .ts, .tsx, .mts, .mtsx, .cts, .ctsx (the set of
-// extensions where TypeScript syntax may legally appear). Used for auto-detect;
+// Filename pattern matching exactly the TypeScript extensions Node recognises:
+// .ts, .tsx, .mts, .cts. The narrower form `/\.([mc]ts|tsx?)$/i` is preferred
+// over `/\.[mc]?tsx?$/i` because the latter would also match `.mtsx` and
+// `.ctsx`, which are not real TypeScript extensions. Used for auto-detect;
 // explicit user opt-in/out via the `stripTypescript` option always wins.
-const TS_EXTENSION_REGEX = /\.[mc]?tsx?$/i;
+const TS_EXTENSION_REGEX = /\.([mc]ts|tsx?)$/i;
 
 /**
  * Creates an instrumenter that implements the istanbul-lib-instrument
@@ -39,13 +41,17 @@ const TS_EXTENSION_REGEX = /\.[mc]?tsx?$/i;
  * @param {boolean} [options.reportLogic] Enable truthy-value tracking (bT).
  * @param {boolean} [options.stripTypescript] Run the TypeScript-strip pass
  *   before instrumentation. When omitted (default), the adapter auto-detects:
- *   it strips when the filename matches `/\.[mc]?tsx?$/i` AND no
+ *   it strips when the filename matches `/\.([mc]ts|tsx?)$/i` AND no
  *   `inputSourceMap` was supplied (i.e., the source has not already been
  *   transformed by Vite / Babel / tsc). Set to `false` to disable auto-detect
  *   under toolchains that pre-transform TypeScript but do not produce an
  *   `inputSourceMap` (`@vitejs/plugin-react-swc` in some configurations, Bun's
  *   native TS runner, Node 23+ with `--experimental-strip-types`). Set to
  *   `true` to force strip regardless of filename or `inputSourceMap` presence.
+ *   Non-boolean values throw `TypeError`: the `?: boolean` type contract is
+ *   strict because callers passing a string like `'auto'` (a prior design
+ *   discussion shape) would otherwise be silently coerced to `Boolean('auto')`
+ *   which is `true`, force-stripping every file.
  * @returns {{ instrumentSync, lastSourceMap, lastFileCoverage }}
  */
 function createOxcInstrumenter(options) {
@@ -54,6 +60,11 @@ function createOxcInstrumenter(options) {
   const ignoreClassMethods = options.ignoreClassMethods || [];
   const reportLogic = options.reportLogic || false;
   const stripTypescriptOverride = options.stripTypescript;
+  if (stripTypescriptOverride !== undefined && typeof stripTypescriptOverride !== 'boolean') {
+    throw new TypeError(
+      `oxc-coverage-instrument: createOxcInstrumenter({ stripTypescript }) must be a boolean or undefined, got ${typeof stripTypescriptOverride}`,
+    );
+  }
 
   // Raw JSON strings from the last instrument call — parsed lazily on first access.
   let _lastCoverageMapJson = null;
@@ -84,7 +95,7 @@ function createOxcInstrumenter(options) {
       const stripTypescript =
         stripTypescriptOverride === undefined
           ? TS_EXTENSION_REGEX.test(filename) && !inputSourceMap
-          : Boolean(stripTypescriptOverride);
+          : stripTypescriptOverride;
       const result = instrument(code, filename, {
         coverageVariable,
         sourceMap: true,


### PR DESCRIPTION
## Summary

Stacked on top of PR #72 (parallel to PR #74). Wires the Vitest adapter to auto-detect raw TypeScript so users no longer need to set `stripTypescript: true` manually. The heuristic engages on `.ts` / `.tsx` / `.mts` / `.cts` filenames when no `inputSourceMap` is supplied; if Vite / Babel / tsc has already transformed the TS upstream, the inputSourceMap presence signals "already transformed" and the strip pass is skipped.

Refs #47. Part 3 of 5; does NOT close #47 on its own.

## Base

Targets `feat/47-ts-direct` (PR #72), NOT `main`. Per the stacked-PR convention, the base will be retargeted to `main` once PR #72 merges. Does not depend on PR #74; the two PRs are independent and can merge in any order after PR #72.

## What changed

- `vitest.js`: detect-and-forward logic at the top of `instrumentSync`; uses `TS_EXTENSION_REGEX = /\.[mc]?tsx?$/i` AND `!inputSourceMap`. Explicit `stripTypescript: false | true` overrides the heuristic.
- `vitest.d.ts`: new `stripTypescript?: boolean` field on `OxcInstrumenterOptions` with the heuristic and escape-hatch policy documented.
- `test.mjs`: 7 new tests covering auto-detect on `.ts`, JSX preservation on `.tsx`, no-strip with inputSourceMap, no-strip on `.js`, explicit-false on `.ts`, explicit-true on `.js`.
- `README.md`: Vitest integration section now describes the auto-detect default + escape hatches.

## Escape hatches (documented)

Toolchains that pre-transform TypeScript but do not produce an `inputSourceMap`:
- `@vitejs/plugin-react-swc` in some configurations
- Bun's native TS runner
- Node 23+ with `--experimental-strip-types`

Users on those toolchains set `stripTypescript: false` to disable auto-detect. Users who want to force-strip set `stripTypescript: true`.

## Roadmap

- PR 4: `examples/vitest-typescript/` CI smoke-test, end-to-end validation
- PR 5: v0.6.0 release (closes #47)

## Test plan

- [x] `cargo test --workspace` green (all pre-existing tests pass; no Rust changes in this PR)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check`, `typos .` clean
- [x] `npm test` (napi suite): 7 new vitest-adapter tests pass, all pre-existing napi tests still pass
- [ ] CI green on all three platforms

N/A on closing keyword for this PR; #47 closes on PR 5 of the series.