### PR TITLE
ci(examples): vitest-typescript end-to-end smoke (PR 4/5 of #47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,3 +150,36 @@ jobs:
           name: istanbul-diff-log
           path: istanbul-diff.log
           if-no-files-found: warn
+
+  vitest-typescript-example:
+    # End-to-end smoke for the Vitest TypeScript example: builds the napi
+    # binding, runs vitest with the createOxcInstrumenter adapter on a small
+    # TypeScript project with zero pre-transform, then verifies the resulting
+    # coverage-final.json is keyed by the .ts source path and statementMap
+    # entries point at .ts line numbers.
+    name: Vitest TypeScript example
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Install napi binding deps
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: npm ci || npm install
+      - name: Build napi binding
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: npx napi build --release --platform
+      - name: Install example deps
+        working-directory: examples/vitest-typescript
+        run: npm install
+      - name: Run vitest with coverage
+        working-directory: examples/vitest-typescript
+        run: npm run coverage
+      - name: Verify coverage targets .ts source
+        working-directory: examples/vitest-typescript
+        run: npm run verify

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ node_modules/
 # default --output-dir for `report --format html` runs from the workspace root
 /coverage/
 crates/*/coverage/
+examples/*/coverage/
+examples/*/node_modules/
+examples/*/package-lock.json
 
 # napi build artifacts
 *.node

--- a/examples/vitest-typescript/README.md
+++ b/examples/vitest-typescript/README.md
@@ -1,0 +1,34 @@
+# Vitest + TypeScript example
+
+End-to-end example showing how to use `oxc-coverage-instrument` as a drop-in Istanbul instrumenter for Vitest with **zero TypeScript pre-transform**. Coverage reports point directly at `.ts` source lines.
+
+## What this demonstrates
+
+- `vitest.config.ts` wires `coverage.instrumenter` to `createOxcInstrumenter` from `oxc-coverage-instrument/vitest`.
+- The adapter auto-detects raw TypeScript on `.ts` / `.tsx` filenames when no `inputSourceMap` is provided, so no separate Babel / tsc pre-transform step is needed.
+- `coverage-final.json` is keyed by the `.ts` source path (`src/math.ts`), and `statementMap` / `fnMap` / `branchMap` entries reference `.ts` line numbers.
+
+## Run
+
+```bash
+cd examples/vitest-typescript
+npm install
+npm run coverage
+npm run verify
+```
+
+`npm run coverage` runs Vitest with the Istanbul provider; `npm run verify` checks the resulting `coverage/coverage-final.json` for the assertions above and exits non-zero on any mismatch. CI runs both steps in the `Vitest TypeScript example` job.
+
+## Layout
+
+```
+examples/vitest-typescript/
+  package.json
+  tsconfig.json
+  vitest.config.ts
+  src/
+    math.ts        # typed function under test
+    math.test.ts   # vitest test invoking compute()
+  scripts/
+    verify-coverage.mjs
+```

--- a/examples/vitest-typescript/package.json
+++ b/examples/vitest-typescript/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "oxc-coverage-instrument-vitest-typescript-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "coverage": "vitest run --coverage",
+    "verify": "node scripts/verify-coverage.mjs"
+  },
+  "devDependencies": {
+    "@vitest/coverage-istanbul": "^4.1.5",
+    "oxc-coverage-instrument": "file:../../crates/oxc-coverage-instrument-napi",
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/examples/vitest-typescript/scripts/verify-coverage.mjs
+++ b/examples/vitest-typescript/scripts/verify-coverage.mjs
@@ -1,0 +1,83 @@
+// Verifies the Vitest istanbul coverage output points at the original .ts
+// source, not at an intermediate transpiled JS file. The vitest.config.ts in
+// this example wires `coverage.instrumenter` to `createOxcInstrumenter`, which
+// auto-detects raw TypeScript when the filename ends in .ts / .tsx and no
+// inputSourceMap is present.
+//
+// Asserts:
+//   1. coverage-final.json contains a key whose path ends with math.ts
+//      (NOT math.js, i.e., the TS source is the wire-format key)
+//   2. statementMap entries point at line numbers that exist in the .ts source
+//   3. compute() function counter and at least one branch counter are populated
+//
+// Exit codes: 0 on success, non-zero on failure with a descriptive message.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const coveragePath = resolve(repoRoot, 'coverage', 'coverage-final.json');
+
+if (!existsSync(coveragePath)) {
+    console.error(`FAIL: coverage-final.json not found at ${coveragePath}`);
+    console.error('Run `npm run coverage` first.');
+    process.exit(1);
+}
+
+const coverage = JSON.parse(readFileSync(coveragePath, 'utf8'));
+const keys = Object.keys(coverage);
+
+const mathKey = keys.find((k) => k.endsWith('math.ts'));
+if (!mathKey) {
+    console.error(
+        `FAIL: no coverage entry for math.ts. Got keys:\n${keys.map((k) => `  - ${k}`).join('\n')}`,
+    );
+    console.error('Expected at least one key ending in `math.ts`, not `math.js` or a transpiled path.');
+    process.exit(1);
+}
+
+const fc = coverage[mathKey];
+if (!fc.statementMap || Object.keys(fc.statementMap).length === 0) {
+    console.error(`FAIL: math.ts statementMap is empty: ${JSON.stringify(fc.statementMap)}`);
+    process.exit(1);
+}
+
+const tsSourcePath = resolve(repoRoot, 'src', 'math.ts');
+const tsSource = readFileSync(tsSourcePath, 'utf8');
+const tsLines = tsSource.split('\n').length;
+
+for (const [id, loc] of Object.entries(fc.statementMap)) {
+    if (loc.start.line < 1 || loc.start.line > tsLines) {
+        console.error(
+            `FAIL: statementMap[${id}].start.line = ${loc.start.line} is out of range for math.ts (${tsLines} lines)`,
+        );
+        process.exit(1);
+    }
+}
+
+const fnNames = Object.values(fc.fnMap).map((f) => f.name);
+if (!fnNames.includes('compute')) {
+    console.error(`FAIL: compute() function not found in fnMap. Got names: ${JSON.stringify(fnNames)}`);
+    process.exit(1);
+}
+
+if (Object.keys(fc.branchMap).length === 0) {
+    console.error('FAIL: branchMap is empty; expected at least one branch counter for the if-else in compute().');
+    process.exit(1);
+}
+
+const computeHits = Object.entries(fc.fnMap)
+    .filter(([, f]) => f.name === 'compute')
+    .map(([id]) => fc.f[id]);
+if (!computeHits.some((h) => h > 0)) {
+    console.error(`FAIL: compute() function counter is zero. Tests must have invoked it. Got: ${JSON.stringify(computeHits)}`);
+    process.exit(1);
+}
+
+console.log(`OK: ${basename(mathKey)} coverage points at .ts source lines.`);
+console.log(`  statements: ${Object.keys(fc.statementMap).length}`);
+console.log(`  functions:  ${Object.keys(fc.fnMap).length}`);
+console.log(`  branches:   ${Object.keys(fc.branchMap).length}`);
+console.log(`  compute() hits: ${computeHits[0]}`);

--- a/examples/vitest-typescript/src/math.test.ts
+++ b/examples/vitest-typescript/src/math.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { compute, type Operand } from './math.ts';
+
+describe('compute', () => {
+    const a: Operand = { value: 5 };
+    const b: Operand = { value: 3 };
+
+    it('adds operands', () => {
+        expect(compute(a, b, 'add')).toBe(8);
+    });
+
+    it('subtracts operands', () => {
+        expect(compute(a, b, 'sub')).toBe(2);
+    });
+});

--- a/examples/vitest-typescript/src/math.ts
+++ b/examples/vitest-typescript/src/math.ts
@@ -1,0 +1,22 @@
+// Minimal TypeScript module exercising:
+//   - typed function declaration with parameter and return annotations
+//   - interface (type-only, no counter)
+//   - type alias (type-only, no counter)
+//   - if-else branch
+//   - early return
+//
+// Coverage must point at THESE line numbers (1-based), not at any intermediate
+// JS produced by a Babel/tsc transform.
+
+export interface Operand {
+    value: number;
+}
+
+export type Op = 'add' | 'sub';
+
+export function compute(a: Operand, b: Operand, op: Op): number {
+    if (op === 'add') {
+        return a.value + b.value;
+    }
+    return a.value - b.value;
+}

--- a/examples/vitest-typescript/tsconfig.json
+++ b/examples/vitest-typescript/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.mjs", "vitest.config.ts"]
+}

--- a/examples/vitest-typescript/vitest.config.ts
+++ b/examples/vitest-typescript/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import { createOxcInstrumenter } from 'oxc-coverage-instrument/vitest';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'istanbul',
+      instrumenter: (options) => createOxcInstrumenter(options),
+      include: ['src/**/*.ts'],
+      exclude: ['**/*.test.ts'],
+      reporter: ['json', 'text'],
+      reportsDirectory: './coverage',
+      reportOnFailure: true,
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Stacked on top of PR #75 (which is stacked on PR #72). Adds the end-to-end Vitest TypeScript example promised by PR 4 of the #47 series: a real Vitest 4.1.x project that consumes `createOxcInstrumenter` from the napi adapter, runs against a small typed module with zero Babel/tsc pre-transform, and verifies the resulting `coverage-final.json` is keyed by the `.ts` source.

Refs #47. Part 4 of 5; does NOT close #47 on its own.

## Base

Targets `feat/47-ts-direct-pr3` (PR #75), NOT `main`. The example uses PR 3's auto-detect heuristic (`createOxcInstrumenter()` with no `stripTypescript` override). Per the stacked-PR convention, the base will be retargeted as the chain merges; do not merge this before PR 1 (#72) and PR 3 (#75).

## What changed

- `examples/vitest-typescript/`: new minimal example
  - `package.json`: pins Vitest 4.1.5+, `@vitest/coverage-istanbul`, references the napi binding via `file:..` (so smoke runs against the locally-built bits)
  - `vitest.config.ts`: wires `createOxcInstrumenter` as the istanbul instrumenter
  - `tsconfig.json`: strict TS with `verbatimModuleSyntax` (so type imports must be `type`-prefixed; verifies the strip pass handles them)
  - `src/math.ts`: typed function `compute(a, b, op)` with interface, type alias, if-else branch, early return
  - `src/math.test.ts`: invokes `compute()` with both branches
  - `scripts/verify-coverage.mjs`: asserts (a) `coverage-final.json` is keyed by `math.ts`, (b) `statementMap` entries reference `.ts` line numbers within source range, (c) `compute()` function counter is non-zero, (d) at least one branch counter exists
  - `README.md`: usage instructions
- `.github/workflows/ci.yml`: new `Vitest TypeScript example` job that builds the napi binding from source, npm-installs the example, runs `npm run coverage`, and runs `npm run verify`
- `.gitignore`: skip `examples/*/coverage/`, `examples/*/node_modules/`, `examples/*/package-lock.json` so install/run artifacts don't pollute git

## Local smoke result

```
Coverage enabled with istanbul
Test Files  1 passed (1)
Tests       2 passed (2)
Duration    130ms

Statements   : 100% ( 3/3 )
Branches     : 100% ( 2/2 )
Functions    : 100% ( 1/1 )
Lines        : 100% ( 3/3 )

OK: math.ts coverage points at .ts source lines.
  statements: 3
  functions:  1
  branches:   1
  compute() hits: 2
```

Zero Babel/tsc pre-transform; the adapter's auto-detect heuristic (filename ends in `.ts`, no `inputSourceMap`) engages the in-process strip pass.

## Roadmap

- PR 5: v0.6.0 release via `/oxc-coverage-release` (closes #47)

## Test plan

- [x] Local `npm run coverage`: passes both tests, 100% coverage
- [x] Local `npm run verify`: asserts pass on math.ts wire shape
- [x] `cargo check --workspace`, `cargo fmt --check`, `typos .` all clean
- [ ] CI job green on ubuntu-latest

N/A on closing keyword; #47 closes on PR 5.