### PR TITLE
feat(types): opt-in x_fallow_functionMap identity overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ let fc = v8_to_istanbul_with_loader(source, "app.js", &functions, 0, |url| {
 | **Branches** | `if`/`else`, ternary, `switch`, `&&`/`\|\|`/`??`, `??=`/`\|\|=`/`&&=`, `default-arg` |
 | **Pragmas** | `istanbul`/`v8`/`c8 ignore next/if/else/file/start/stop` |
 
+### Function identity overlay (Fallow extension)
+
+Set `functionIdentityOverlay: true` on the `instrument` call (or `function_identity_overlay: true` in Rust) to attach an optional `x_fallow_functionMap` to the resulting coverage map. The overlay carries a stable `fallow:fn:<hex>` identity per function, keyed by the same ids as `fnMap`, derived from `(path, name, decl span, loc span)`. Two runs over byte-identical source produce identical ids; renames, body edits, and line shifts all change the id.
+
+This is a non-Istanbul extension consumed by downstream code-quality tools (Fallow et al.) that need a long-lived join key across AST inventories, runtime coverage, and source-mapped positions. Standard Istanbul consumers ignore the `x_`-prefixed field, so default output (option off) stays byte-identical to what nyc / Vitest / Jest / Codecov expect. When `inputSourceMap` is consumed, the overlay still references the pre-remap positions; consumers that remap downstream must recompute identity against the post-remap positions.
+
 ## Istanbul conformance
 
 Verified against `istanbul-lib-instrument` on 27 shared fixtures covering all branch types, function forms, Unicode columns, pragma boundaries, and edge cases. 189 automated conformance checks validate:

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Set `functionIdentityOverlay: true` on the `instrument` call or `createOxcInstru
 
 This is a non-Istanbul extension consumed by downstream code-quality tools (Fallow et al.) that need a long-lived join key across AST inventories, runtime coverage, and source-mapped positions. Standard Istanbul consumers ignore the `x_`-prefixed field, so default output (option off) stays byte-identical to what nyc / Vitest / Jest / Codecov expect. When `inputSourceMap` is consumed, the overlay still references the pre-remap positions; consumers that remap downstream must recompute identity against the post-remap positions.
 
+The path enters the hash verbatim from the `filename` argument, so callers that need stable ids across different tools must normalise paths before instrumentation (`./app.js`, `app.js`, and `/abs/repo/app.js` all hash differently). Pick one canonical form per project, typically a workspace-root-relative POSIX path.
+
 ## Istanbul conformance
 
 Verified against `istanbul-lib-instrument` on 27 shared fixtures covering all branch types, function forms, Unicode columns, pragma boundaries, and edge cases. 189 automated conformance checks validate:

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ let fc = v8_to_istanbul_with_loader(source, "app.js", &functions, 0, |url| {
 
 ### Function identity overlay (Fallow extension)
 
-Set `functionIdentityOverlay: true` on the `instrument` call (or `function_identity_overlay: true` in Rust) to attach an optional `x_fallow_functionMap` to the resulting coverage map. The overlay carries a stable `fallow:fn:<hex>` identity per function, keyed by the same ids as `fnMap`, derived from `(path, name, decl span, loc span)`. Two runs over byte-identical source produce identical ids; renames, body edits, and line shifts all change the id.
+Set `functionIdentityOverlay: true` on the `instrument` call or `createOxcInstrumenter` Vitest adapter (or `function_identity_overlay: true` in Rust) to attach an optional `x_fallow_functionMap` to the resulting coverage map. The overlay carries a stable `fallow:fn:<hex>` identity per function, keyed by the same ids as `fnMap`, derived from `(path, name, decl span, loc span)`. Two runs over byte-identical source produce identical ids; renames, body edits, and line shifts all change the id.
 
 This is a non-Istanbul extension consumed by downstream code-quality tools (Fallow et al.) that need a long-lived join key across AST inventories, runtime coverage, and source-mapped positions. Standard Istanbul consumers ignore the `x_`-prefixed field, so default output (option off) stays byte-identical to what nyc / Vitest / Jest / Codecov expect. When `inputSourceMap` is consumed, the overlay still references the pre-remap positions; consumers that remap downstream must recompute identity against the post-remap positions.
 

--- a/crates/oxc-coverage-instrument-napi/src/lib.rs
+++ b/crates/oxc-coverage-instrument-napi/src/lib.rs
@@ -83,6 +83,16 @@ pub struct InstrumentOptions {
     ///
     /// Has no effect unless `stripTypescript` is also true. Defaults to false.
     pub emit_decorator_metadata: Option<bool>,
+    /// When true, attach an optional `x_fallow_functionMap` overlay to the
+    /// returned coverage map. The overlay carries a stable
+    /// `fallow:fn:<hex>` identity per function, keyed by the same ids as
+    /// `fnMap`, derived from `(path, name, decl span, loc span)`. Standard
+    /// Istanbul consumers ignore the `x_`-prefixed field; downstream code
+    /// quality tools (Fallow et al.) use it as a long-lived join key.
+    ///
+    /// Defaults to false. The default JSON output stays byte-identical to
+    /// what Istanbul consumers expect.
+    pub function_identity_overlay: Option<bool>,
 }
 
 /// A coverage pragma comment that was found but not handled.
@@ -136,6 +146,7 @@ pub fn instrument(
                 ignore_class_methods: o.ignore_class_methods.unwrap_or_default(),
                 strip_typescript: o.strip_typescript.unwrap_or(false),
                 decorator_mode,
+                function_identity_overlay: o.function_identity_overlay.unwrap_or(false),
             }
         }
     };

--- a/crates/oxc-coverage-instrument-napi/test.mjs
+++ b/crates/oxc-coverage-instrument-napi/test.mjs
@@ -949,4 +949,50 @@ function runInstrumented(result, filename, callExpression) {
   console.log('  [PASS] napi adapter: decorators pass through by default');
 }
 
+// Test: functionIdentityOverlay surfaces a stable fallow:fn:<hex> per
+// function under the x_fallow_functionMap key on the parsed coverage map,
+// keyed by the same ids as fnMap. Default (option off) must NOT include the
+// key; standard Istanbul consumers see byte-identical shape.
+{
+  const src = 'function add(a, b) { return a + b; }\nfunction sub(a, b) { return a - b; }\n';
+
+  const defaultResult = instrument(src, 'app.js');
+  const defaultMap = JSON.parse(defaultResult.coverageMap);
+  assert(
+    defaultMap.x_fallow_functionMap === undefined,
+    'default output must omit x_fallow_functionMap',
+  );
+
+  const overlayResult = instrument(src, 'app.js', { functionIdentityOverlay: true });
+  const overlayMap = JSON.parse(overlayResult.coverageMap);
+  const overlay = overlayMap.x_fallow_functionMap;
+  assert(overlay !== undefined, 'overlay must be present when functionIdentityOverlay is true');
+  const fnKeys = Object.keys(overlayMap.fnMap).sort();
+  const overlayKeys = Object.keys(overlay).sort();
+  assert(
+    JSON.stringify(fnKeys) === JSON.stringify(overlayKeys),
+    `overlay keys must align with fnMap keys, fnMap=${fnKeys} overlay=${overlayKeys}`,
+  );
+  for (const k of fnKeys) {
+    assert(
+      typeof overlay[k].id === 'string' && overlay[k].id.startsWith('fallow:fn:'),
+      `overlay[${k}].id must be fallow:fn:<hex>, got ${JSON.stringify(overlay[k])}`,
+    );
+    assert(overlay[k].path === 'app.js', `overlay[${k}].path must mirror file path`);
+  }
+
+  // Determinism: re-instrument the same source, ids must match.
+  const repeat = JSON.parse(
+    instrument(src, 'app.js', { functionIdentityOverlay: true }).coverageMap,
+  ).x_fallow_functionMap;
+  for (const k of fnKeys) {
+    assert(
+      overlay[k].id === repeat[k].id,
+      `id must be deterministic across runs; key ${k} drifted`,
+    );
+  }
+
+  console.log('  [PASS] napi adapter: functionIdentityOverlay attaches x_fallow_functionMap');
+}
+
 console.log('\nAll tests passed!');

--- a/crates/oxc-coverage-instrument-napi/test.mjs
+++ b/crates/oxc-coverage-instrument-napi/test.mjs
@@ -995,4 +995,31 @@ function runInstrumented(result, filename, callExpression) {
   console.log('  [PASS] napi adapter: functionIdentityOverlay attaches x_fallow_functionMap');
 }
 
+// Test: createOxcInstrumenter forwards functionIdentityOverlay to the native
+// instrumenter so Vitest users can opt into the same downstream identity data.
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  const inst = createOxcInstrumenter({ functionIdentityOverlay: true });
+  inst.instrumentSync('function handler() { return 1; }\n', 'app.js');
+  const fc = inst.lastFileCoverage();
+  assert(
+    fc.x_fallow_functionMap !== undefined,
+    'vitest adapter must forward functionIdentityOverlay to native instrumenter',
+  );
+  assert.deepEqual(Object.keys(fc.x_fallow_functionMap).sort(), Object.keys(fc.fnMap).sort());
+  assert(
+    fc.x_fallow_functionMap['0'].id.startsWith('fallow:fn:'),
+    'vitest adapter overlay must carry fallow:fn:<hex> ids',
+  );
+
+  const defaultInst = createOxcInstrumenter();
+  defaultInst.instrumentSync('function handler() { return 1; }\n', 'app.js');
+  assert(
+    defaultInst.lastFileCoverage().x_fallow_functionMap === undefined,
+    'vitest adapter default output must omit x_fallow_functionMap',
+  );
+
+  console.log('  [PASS] vitest adapter forwards functionIdentityOverlay');
+}
+
 console.log('\nAll tests passed!');

--- a/crates/oxc-coverage-instrument-napi/vitest.d.ts
+++ b/crates/oxc-coverage-instrument-napi/vitest.d.ts
@@ -12,6 +12,11 @@ export interface OxcInstrumenterOptions {
   /** When true, adds truthy-value tracking (bT) for logical expressions. */
   reportLogic?: boolean
   /**
+   * Attach the optional `x_fallow_functionMap` extension to the last file
+   * coverage object. Defaults to false.
+   */
+  functionIdentityOverlay?: boolean
+  /**
    * Run the TypeScript-strip pass before instrumentation. When omitted
    * (default), the adapter auto-detects: it strips when the filename matches
    * `/\.([mc]ts|tsx?)$/i` AND no `inputSourceMap` was supplied (i.e., the

--- a/crates/oxc-coverage-instrument-napi/vitest.js
+++ b/crates/oxc-coverage-instrument-napi/vitest.js
@@ -67,6 +67,8 @@ const TS_EXTENSION_REGEX = /\.([mc]ts|tsx?)$/i;
  *   this layer, matching tsconfig.json semantics. The bare `instrument()`
  *   napi entry point rejects the same combination with an Error; the vitest
  *   adapter preserves the tsconfig-style ergonomics for the vitest UX.
+ * @param {boolean} [options.functionIdentityOverlay] Attach the optional
+ *   `x_fallow_functionMap` extension to the last file coverage object.
  * @returns {{ instrumentSync, lastSourceMap, lastFileCoverage }}
  */
 function createOxcInstrumenter(options) {
@@ -74,6 +76,12 @@ function createOxcInstrumenter(options) {
   const coverageVariable = options.coverageVariable || '__coverage__';
   const ignoreClassMethods = options.ignoreClassMethods || [];
   const reportLogic = options.reportLogic || false;
+  const functionIdentityOverlay = options.functionIdentityOverlay || false;
+  if (typeof functionIdentityOverlay !== 'boolean') {
+    throw new TypeError(
+      `oxc-coverage-instrument: createOxcInstrumenter({ functionIdentityOverlay }) must be a boolean or undefined, got ${typeof options.functionIdentityOverlay}`,
+    );
+  }
   const stripTypescriptOverride = options.stripTypescript;
   if (stripTypescriptOverride !== undefined && typeof stripTypescriptOverride !== 'boolean') {
     throw new TypeError(
@@ -138,6 +146,7 @@ function createOxcInstrumenter(options) {
         stripTypescript,
         experimentalDecorators,
         emitDecoratorMetadata,
+        functionIdentityOverlay,
       });
 
       // Store raw JSON — defer parsing until actually needed.

--- a/crates/oxc-coverage-instrument/src/coverage_builder.rs
+++ b/crates/oxc-coverage-instrument/src/coverage_builder.rs
@@ -8,7 +8,9 @@
 
 use std::collections::BTreeMap;
 
-use oxc_coverage_types::{BranchEntry, FileCoverage, FnEntry, Location};
+use oxc_coverage_types::{BranchEntry, FileCoverage, FnEntry, FunctionIdentity, Location};
+
+use crate::transform::djb31_hex;
 
 /// Inputs to [`build_file_coverage`], grouped so callers thread one value
 /// instead of five.
@@ -75,5 +77,61 @@ pub(crate) fn build_file_coverage(maps: CoverageMaps) -> FileCoverage {
         )
     };
 
-    FileCoverage { path, statement_map, fn_map, branch_map, s, f, b, b_t, input_source_map: None }
+    FileCoverage {
+        path,
+        statement_map,
+        fn_map,
+        branch_map,
+        s,
+        f,
+        b,
+        b_t,
+        input_source_map: None,
+        x_fallow_function_map: None,
+    }
+}
+
+/// Compute the optional `x_fallow_functionMap` overlay from a populated
+/// `fn_map`. Each entry's id is a stable hash of `(path, name, decl span,
+/// loc span)`, formatted as `fallow:fn:<hex>`. Field separator is `|` so a
+/// rename, body edit, or line shift changes the hash but a re-run on
+/// byte-identical source does not.
+///
+/// Keyed by the same string ids as `fn_map`; consumers join via the key.
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "crate-internal helper intentionally; the explicit pub(crate) documents that this is not part of the public API even though the parent module is already private"
+)]
+pub(crate) fn build_function_identity_map(
+    path: &str,
+    fn_map: &BTreeMap<String, FnEntry>,
+) -> BTreeMap<String, FunctionIdentity> {
+    fn_map
+        .iter()
+        .map(|(key, entry)| {
+            let input = format!(
+                "{path}|{name}|{dsl}|{dsc}|{del}|{dec}|{lsl}|{lsc}|{lel}|{lec}",
+                name = entry.name,
+                dsl = entry.decl.start.line,
+                dsc = entry.decl.start.column,
+                del = entry.decl.end.line,
+                dec = entry.decl.end.column,
+                lsl = entry.loc.start.line,
+                lsc = entry.loc.start.column,
+                lel = entry.loc.end.line,
+                lec = entry.loc.end.column,
+            );
+            let id = format!("fallow:fn:{}", djb31_hex(&input));
+            (
+                key.clone(),
+                FunctionIdentity {
+                    id,
+                    name: entry.name.clone(),
+                    path: path.to_string(),
+                    decl: entry.decl.clone(),
+                    loc: entry.loc.clone(),
+                },
+            )
+        })
+        .collect()
 }

--- a/crates/oxc-coverage-instrument/src/coverage_builder.rs
+++ b/crates/oxc-coverage-instrument/src/coverage_builder.rs
@@ -93,11 +93,16 @@ pub(crate) fn build_file_coverage(maps: CoverageMaps) -> FileCoverage {
 
 /// Compute the optional `x_fallow_functionMap` overlay from a populated
 /// `fn_map`. Each entry's id is a stable hash of `(path, name, decl span,
-/// loc span)`, formatted as `fallow:fn:<hex>`. Field separator is `|` so a
-/// rename, body edit, or line shift changes the hash but a re-run on
-/// byte-identical source does not.
+/// loc span)`, formatted as `fallow:fn:<hex>`. A rename, body edit, or
+/// line shift changes the hash but a re-run on byte-identical source does
+/// not.
 ///
-/// Keyed by the same string ids as `fn_map`; consumers join via the key.
+/// Hash input is the JSON-encoded form of the parts array. JSON encoding
+/// makes the field boundaries unambiguous so a computed-key method like
+/// `class C { ['x|y']() {} }` (which lands in `fn_map[].name` as `"x|y"`)
+/// cannot collide with any sibling whose parts happen to align under a
+/// flat string separator. Keyed by the same string ids as `fn_map`;
+/// consumers join via the key.
 #[expect(
     clippy::redundant_pub_crate,
     reason = "crate-internal helper intentionally; the explicit pub(crate) documents that this is not part of the public API even though the parent module is already private"
@@ -109,23 +114,10 @@ pub(crate) fn build_function_identity_map(
     fn_map
         .iter()
         .map(|(key, entry)| {
-            let input = format!(
-                "{path}|{name}|{dsl}|{dsc}|{del}|{dec}|{lsl}|{lsc}|{lel}|{lec}",
-                name = entry.name,
-                dsl = entry.decl.start.line,
-                dsc = entry.decl.start.column,
-                del = entry.decl.end.line,
-                dec = entry.decl.end.column,
-                lsl = entry.loc.start.line,
-                lsc = entry.loc.start.column,
-                lel = entry.loc.end.line,
-                lec = entry.loc.end.column,
-            );
-            let id = format!("fallow:fn:{}", djb31_hex(&input));
             (
                 key.clone(),
                 FunctionIdentity {
-                    id,
+                    id: function_identity_id(path, entry),
                     name: entry.name.clone(),
                     path: path.to_string(),
                     decl: entry.decl.clone(),
@@ -134,4 +126,61 @@ pub(crate) fn build_function_identity_map(
             )
         })
         .collect()
+}
+
+/// Compute the `fallow:fn:<hex>` id for a single `(path, FnEntry)` pair.
+/// Split out from [`build_function_identity_map`] so the collision-resistance
+/// invariant can be unit-tested in isolation without round-tripping through
+/// the full instrumenter.
+fn function_identity_id(path: &str, entry: &FnEntry) -> String {
+    // Each part is its own JSON value, so escaping handles every
+    // ambiguous character (delimiters, quotes, NUL, unicode). The
+    // .expect is documentary: every input here is a JSON-serializable
+    // primitive (string / u32), so serde_json::to_string cannot fail.
+    let input = serde_json::to_string(&serde_json::json!([
+        path,
+        entry.name,
+        entry.decl.start.line,
+        entry.decl.start.column,
+        entry.decl.end.line,
+        entry.decl.end.column,
+        entry.loc.start.line,
+        entry.loc.start.column,
+        entry.loc.end.line,
+        entry.loc.end.column,
+    ]))
+    .expect("FunctionIdentity hash input serializes to JSON infallibly");
+    format!("fallow:fn:{}", djb31_hex(&input))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::function_identity_id;
+    use oxc_coverage_types::{FnEntry, Location, Position};
+
+    fn entry(name: &str) -> FnEntry {
+        let pos = |line, column| Position { line, column };
+        FnEntry {
+            name: name.to_string(),
+            line: 1,
+            decl: Location { start: pos(1, 0), end: pos(1, 10) },
+            loc: Location { start: pos(1, 0), end: pos(1, 10) },
+        }
+    }
+
+    /// Regression test for the JSON-encoded hash input. A naive
+    /// `format!("{path}|{name}|{lines...}")` shape collides on
+    /// `(path="a", name="b|c")` vs `(path="a|b", name="c")` because both
+    /// produce the same flat string `"a|b|c|..."`. The JSON-encoded form
+    /// quotes each string so the field boundary survives any character.
+    #[test]
+    fn function_identity_id_is_collision_resistant_against_pipe_in_name() {
+        let a = function_identity_id("a", &entry("b|c"));
+        let b = function_identity_id("a|b", &entry("c"));
+        assert_ne!(
+            a, b,
+            "JSON-encoded hash input must keep (path, name) boundaries unambiguous; \
+             got collision: {a}",
+        );
+    }
 }

--- a/crates/oxc-coverage-instrument/src/instrument.rs
+++ b/crates/oxc-coverage-instrument/src/instrument.rs
@@ -15,7 +15,7 @@ use oxc_traverse::traverse_mut;
 
 use std::collections::BTreeMap;
 
-use crate::coverage_builder::{CoverageMaps, build_file_coverage};
+use crate::coverage_builder::{CoverageMaps, build_file_coverage, build_function_identity_map};
 use crate::pragma::PragmaMap;
 use crate::transform::{
     CoverageState, CoverageTransform, PreambleInputs, TransformInit, djb31_hex,
@@ -75,6 +75,19 @@ pub struct InstrumentOptions {
     /// Defaults to [`DecoratorMode::PassThrough`]: decorator syntax flows
     /// through verbatim and a downstream tool is responsible for lowering it.
     pub decorator_mode: DecoratorMode,
+    /// When true, attach an optional `x_fallow_functionMap` overlay to the
+    /// resulting `FileCoverage`. The overlay carries a stable
+    /// `fallow:fn:<hex>` identity per function, keyed by the same ids as
+    /// `fnMap`, derived from `(path, name, decl span, loc span)`. Standard
+    /// Istanbul consumers ignore the `x_`-prefixed field; downstream
+    /// code-quality tools (Fallow et al.) use it to join AST inventories,
+    /// runtime coverage, and source-mapped positions across runs without
+    /// reconstructing identity from `(path, name, line, column)` after the
+    /// fact.
+    ///
+    /// Defaults to false. The default JSON output stays byte-identical to
+    /// what Istanbul consumers expect.
+    pub function_identity_overlay: bool,
 }
 
 /// How `strip_typescript` handles decorator syntax.
@@ -145,6 +158,7 @@ impl Default for InstrumentOptions {
             ignore_class_methods: Vec::new(),
             strip_typescript: false,
             decorator_mode: DecoratorMode::PassThrough,
+            function_identity_overlay: false,
         }
     }
 }
@@ -252,7 +266,12 @@ pub fn instrument(
     let state = CoverageState { pragmas };
     let scoping = traverse_mut(&mut transform, &allocator, &mut parsed.program, scoping, state);
 
-    let coverage_map = build_coverage_map(filename, transform, options.input_source_map.as_deref());
+    let mut coverage_map =
+        build_coverage_map(filename, transform, options.input_source_map.as_deref());
+    if options.function_identity_overlay {
+        coverage_map.x_fallow_function_map =
+            Some(build_function_identity_map(&coverage_map.path, &coverage_map.fn_map));
+    }
 
     // Serialize the coverage map once and reuse it for both the hash guard and
     // the preamble's coverageData literal. Istanbul refreshes stale coverage

--- a/crates/oxc-coverage-instrument/tests/function_identity_overlay_test.rs
+++ b/crates/oxc-coverage-instrument/tests/function_identity_overlay_test.rs
@@ -1,0 +1,171 @@
+//! Tests for `InstrumentOptions::function_identity_overlay`. Validates that
+//! the opt-in `x_fallow_functionMap` overlay carries stable, deterministic
+//! ids covering every function shape (named, anonymous, same-line, class
+//! method, object literal method, arrow) and that the TS-direct strip path
+//! preserves the original TypeScript positions in the identity inputs.
+
+use oxc_coverage_instrument::{InstrumentOptions, instrument};
+
+fn opts_with_overlay() -> InstrumentOptions {
+    InstrumentOptions { function_identity_overlay: true, ..InstrumentOptions::default() }
+}
+
+#[test]
+fn overlay_absent_by_default() {
+    let src = "function add(a, b) { return a + b; }\n";
+    let result = instrument(src, "app.js", &InstrumentOptions::default()).expect("instrument");
+    assert!(
+        result.coverage_map.x_fallow_function_map.is_none(),
+        "default output must not carry the overlay; Istanbul consumers see byte-identical shape"
+    );
+    assert!(
+        !result.coverage_map_json.contains("x_fallow_functionMap"),
+        "the JSON form must also omit the overlay key by default"
+    );
+}
+
+#[test]
+fn overlay_keys_align_with_fn_map() {
+    let src = "function add(a, b) { return a + b; }\n\
+              function sub(a, b) { return a - b; }\n";
+    let result = instrument(src, "app.js", &opts_with_overlay()).expect("instrument");
+    let overlay = result.coverage_map.x_fallow_function_map.expect("overlay present");
+    assert_eq!(overlay.len(), result.coverage_map.fn_map.len());
+    for key in result.coverage_map.fn_map.keys() {
+        assert!(overlay.contains_key(key), "overlay missing key {key} present in fn_map");
+    }
+}
+
+#[test]
+fn overlay_id_is_deterministic_across_runs() {
+    let src = "function handler(req) { return req.body; }\n";
+    let r1 = instrument(src, "app.js", &opts_with_overlay()).expect("instrument 1");
+    let r2 = instrument(src, "app.js", &opts_with_overlay()).expect("instrument 2");
+    let id1 = &r1.coverage_map.x_fallow_function_map.as_ref().unwrap()["0"].id;
+    let id2 = &r2.coverage_map.x_fallow_function_map.as_ref().unwrap()["0"].id;
+    assert_eq!(id1, id2, "identical source must produce identical ids");
+    assert!(id1.starts_with("fallow:fn:"), "id format must be fallow:fn:<hex>, got {id1}");
+}
+
+#[test]
+fn overlay_id_changes_on_body_or_position_edit() {
+    let original =
+        instrument("function handler(req) { return req.body; }\n", "app.js", &opts_with_overlay())
+            .expect("instrument original")
+            .coverage_map
+            .x_fallow_function_map
+            .unwrap()["0"]
+            .id
+            .clone();
+
+    // Insert a blank line before the function so positions shift.
+    let shifted = instrument(
+        "\nfunction handler(req) { return req.body; }\n",
+        "app.js",
+        &opts_with_overlay(),
+    )
+    .expect("instrument shifted")
+    .coverage_map
+    .x_fallow_function_map
+    .unwrap()["0"]
+        .id
+        .clone();
+
+    assert_ne!(
+        original, shifted,
+        "shifting the function down a line must change the identity hash"
+    );
+}
+
+#[test]
+fn overlay_same_line_functions_get_distinct_ids() {
+    let src = "function a() {}; function b() {}\n";
+    let result = instrument(src, "app.js", &opts_with_overlay()).expect("instrument");
+    let overlay = result.coverage_map.x_fallow_function_map.expect("overlay");
+    assert_eq!(overlay.len(), 2, "expected two functions on one line");
+    let id_a = &overlay["0"].id;
+    let id_b = &overlay["1"].id;
+    assert_ne!(id_a, id_b, "two same-line functions must hash to distinct ids");
+}
+
+#[test]
+fn overlay_covers_class_methods_and_arrow_and_object_method() {
+    let src = "class C { foo() { return 1; } }\n\
+              const obj = { bar() { return 2; } };\n\
+              const baz = (x) => x + 1;\n";
+    let result = instrument(src, "app.js", &opts_with_overlay()).expect("instrument");
+    let overlay = result.coverage_map.x_fallow_function_map.expect("overlay");
+    // The fn_map carries one entry per function form; the overlay must mirror it 1:1.
+    assert_eq!(overlay.len(), result.coverage_map.fn_map.len());
+    let names: Vec<&str> = overlay.values().map(|e| e.name.as_str()).collect();
+    assert!(names.contains(&"foo"), "class method named foo must surface, got {names:?}");
+    assert!(names.contains(&"bar"), "object literal method named bar must surface, got {names:?}");
+    assert!(names.contains(&"baz"), "named arrow baz must surface, got {names:?}");
+    for entry in overlay.values() {
+        assert!(entry.id.starts_with("fallow:fn:"));
+        assert_eq!(entry.path, "app.js");
+    }
+}
+
+#[test]
+fn overlay_anonymous_function_gets_id() {
+    let src = "const handler = function () { return 1; };\n";
+    let result = instrument(src, "app.js", &opts_with_overlay()).expect("instrument");
+    let overlay = result.coverage_map.x_fallow_function_map.expect("overlay");
+    assert_eq!(overlay.len(), 1);
+    let entry = overlay.values().next().unwrap();
+    assert!(entry.id.starts_with("fallow:fn:"), "anonymous function must still get a stable id");
+}
+
+#[test]
+fn overlay_ts_direct_preserves_original_positions() {
+    let src = "function add(a: number, b: number): number {\n  return a + b;\n}\n";
+    let opts = InstrumentOptions {
+        strip_typescript: true,
+        function_identity_overlay: true,
+        ..InstrumentOptions::default()
+    };
+    let result = instrument(src, "app.ts", &opts).expect("instrument");
+    let overlay = result.coverage_map.x_fallow_function_map.expect("overlay");
+    let entry = &overlay["0"];
+    assert_eq!(entry.path, "app.ts");
+    assert_eq!(entry.decl.start.line, 1, "decl must anchor on the original TS source line");
+    assert!(
+        entry.id.starts_with("fallow:fn:"),
+        "id must be present even when the strip pass rewrites the AST"
+    );
+}
+
+#[test]
+fn overlay_path_change_changes_id() {
+    let src = "function handler() { return 1; }\n";
+    let id1 = instrument(src, "app.js", &opts_with_overlay())
+        .unwrap()
+        .coverage_map
+        .x_fallow_function_map
+        .unwrap()["0"]
+        .id
+        .clone();
+    let id2 = instrument(src, "other.js", &opts_with_overlay())
+        .unwrap()
+        .coverage_map
+        .x_fallow_function_map
+        .unwrap()["0"]
+        .id
+        .clone();
+    assert_ne!(id1, id2, "different paths must hash to distinct ids");
+}
+
+#[test]
+fn overlay_serializes_under_x_fallow_key() {
+    let src = "function handler() { return 1; }\n";
+    let result = instrument(src, "app.js", &opts_with_overlay()).expect("instrument");
+    assert!(
+        result.coverage_map_json.contains("\"x_fallow_functionMap\""),
+        "serialized JSON must use the x_fallow_functionMap key so Istanbul consumers ignore it"
+    );
+    assert!(
+        result.coverage_map_json.contains("fallow:fn:"),
+        "serialized JSON must carry the fallow:fn: id prefix"
+    );
+}

--- a/crates/oxc-coverage-instrument/tests/function_identity_overlay_test.rs
+++ b/crates/oxc-coverage-instrument/tests/function_identity_overlay_test.rs
@@ -157,6 +157,26 @@ fn overlay_path_change_changes_id() {
 }
 
 #[test]
+fn overlay_handles_computed_key_method_with_special_chars_in_name() {
+    // Smoke test for the end-to-end path: a computed-key method whose
+    // name contains characters that would be ambiguous under a flat
+    // string separator must still produce a valid `fallow:fn:<hex>` id.
+    // The true collision-resistance regression test lives in the unit
+    // tests under `crates/oxc-coverage-instrument/src/coverage_builder.rs`
+    // where two synthetic FnEntry inputs are constructed to align under
+    // the prior `|`-concat shape and prove they hash differently under
+    // the JSON-encoded one. This integration test only proves "weird
+    // names don't crash the integration".
+    let src = "class C { ['x|y']() { return 1; } }\n";
+    let result = instrument(src, "app.js", &opts_with_overlay()).expect("instrument");
+    let overlay = result.coverage_map.x_fallow_function_map.expect("overlay");
+    assert_eq!(overlay.len(), 1);
+    let entry = overlay.values().next().unwrap();
+    assert_eq!(entry.name, "x|y", "computed-key name must surface verbatim");
+    assert!(entry.id.starts_with("fallow:fn:"), "id must be present for weird names");
+}
+
+#[test]
 fn overlay_serializes_under_x_fallow_key() {
     let src = "function handler() { return 1; }\n";
     let result = instrument(src, "app.js", &opts_with_overlay()).expect("instrument");

--- a/crates/oxc-coverage-source-maps/tests/lib_edges.rs
+++ b/crates/oxc-coverage-source-maps/tests/lib_edges.rs
@@ -72,6 +72,7 @@ fn full_shape_file_coverage(input_source_map: Option<serde_json::Value>) -> File
         b,
         b_t: None,
         input_source_map,
+        x_fallow_function_map: None,
     }
 }
 

--- a/crates/oxc-coverage-types/src/lib.rs
+++ b/crates/oxc-coverage-types/src/lib.rs
@@ -78,6 +78,43 @@ pub struct FileCoverage {
     /// Only present when the instrumenter received an `inputSourceMap`.
     #[serde(rename = "inputSourceMap", skip_serializing_if = "Option::is_none")]
     pub input_source_map: Option<serde_json::Value>,
+    /// Optional non-Istanbul extension: stable function identity overlay for
+    /// downstream code-quality tools (Fallow et al.). Keyed by the same IDs
+    /// as `fn_map`; ignored by standard Istanbul consumers because the field
+    /// name is prefixed with `x_`. Present only when the instrumenter was
+    /// invoked with `InstrumentOptions::function_identity_overlay = true`.
+    /// See the crate-level README's "X-Fallow function identity" section.
+    #[serde(rename = "x_fallow_functionMap", default, skip_serializing_if = "Option::is_none")]
+    pub x_fallow_function_map: Option<BTreeMap<String, FunctionIdentity>>,
+}
+
+/// Stable function identity record. Non-Istanbul extension consumed by
+/// downstream code-quality tools to join AST inventories, runtime coverage,
+/// and source-mapped positions across runs without reconstructing identity
+/// from `(path, name, line, column)` after the fact.
+///
+/// The `id` field is a stable string of the form `fallow:fn:<hex>` derived
+/// from `(path, name, decl span, loc span)`. Two runs over byte-identical
+/// source produce identical ids; renames, body edits, or moving the
+/// function to a different line all change the id.
+///
+/// Positions follow the same source as `FnEntry` in `fn_map` (original TS
+/// when `strip_typescript` is on; instrumented JS otherwise). Consumers that
+/// remap through `inputSourceMap` must recompute identity against the
+/// post-remap positions, the overlay is not rewritten by the remap pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionIdentity {
+    /// Stable identity string: `fallow:fn:<hex>`.
+    pub id: String,
+    /// Function name. Mirrors `FnEntry::name` (anonymous functions use
+    /// `"(anonymous_N)"`).
+    pub name: String,
+    /// File path as passed to `instrument()`. Mirrors `FileCoverage::path`.
+    pub path: String,
+    /// Declaration span. Mirrors `FnEntry::decl`.
+    pub decl: Location,
+    /// Body span (including braces). Mirrors `FnEntry::loc`.
+    pub loc: Location,
 }
 
 /// A source location span with start and end positions.

--- a/crates/oxc-coverage-types/src/lib.rs
+++ b/crates/oxc-coverage-types/src/lib.rs
@@ -102,6 +102,12 @@ pub struct FileCoverage {
 /// when `strip_typescript` is on; instrumented JS otherwise). Consumers that
 /// remap through `inputSourceMap` must recompute identity against the
 /// post-remap positions, the overlay is not rewritten by the remap pipeline.
+///
+/// The path enters the hash verbatim from the `filename` argument passed
+/// to `instrument()`, so callers that need stable ids across tools must
+/// normalise paths first (`./app.js`, `app.js`, and `/abs/repo/app.js` all
+/// produce distinct ids). Pick one canonical form per project, typically a
+/// workspace-root-relative POSIX path.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FunctionIdentity {
     /// Stable identity string: `fallow:fn:<hex>`.

--- a/crates/oxc-coverage-v8/tests/api_edges.rs
+++ b/crates/oxc-coverage-v8/tests/api_edges.rs
@@ -130,6 +130,7 @@ fn arm_tiebreaker_prefers_tighter_v8_range_at_equal_distance() {
         b: BTreeMap::new(),
         b_t: None,
         input_source_map: None,
+        x_fallow_function_map: None,
     };
     fc.branch_map.insert(
         "0".to_string(),


### PR DESCRIPTION
## Summary

- Adds an opt-in non-Istanbul extension on `FileCoverage`: `x_fallow_functionMap`, keyed by the same ids as `fnMap`, carrying a stable `fallow:fn:<hex>` identity per function derived from `(path, name, decl span, loc span)`.
- New `InstrumentOptions::function_identity_overlay: bool` (Rust, default false) and `functionIdentityOverlay?: boolean` (napi) gate the overlay. Default output stays byte-identical to what Istanbul consumers expect; the `x_`-prefixed field is a no-op for spec-compliant parsers when present.
- Designed for downstream code-quality tools (Fallow et al.) that need a long-lived join key across AST inventories, runtime coverage beacons, and source-mapped positions, without reconstructing identity from `(path, name, line, column)` after the fact.

## Shape

```json
"x_fallow_functionMap": {
  "0": {
    "id": "fallow:fn:<hex>",
    "name": "handler",
    "path": "src/app.ts",
    "decl": { "start": { "line": 10, "column": 7 }, "end": { ... } },
    "loc": { "start": { ... }, "end": { ... } }
  }
}
```

Two runs over byte-identical source produce identical ids. Renames, body edits, and line shifts all change the id. Path also enters the hash, so the same source under a different filename hashes differently.

## Source-map remap behavior

When `inputSourceMap` is consumed, the overlay still references the pre-remap positions (same as `fnMap` today). Consumers that remap through the input map must recompute identity against the post-remap positions. Documented on the `FunctionIdentity` rustdoc + the README's "Function identity overlay (Fallow extension)" section.

## Test plan

- [x] `cargo test --workspace` clean (10 new overlay tests + existing 27 binaries)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` clean
- [x] napi `npm test` clean (new test asserts overlay shape + determinism via JSON.parse)
- [x] `examples/vitest-typescript`: `npm run coverage` and `npm run verify` 100% statements/branches/functions/lines
- [x] Overlay covers: named function, anonymous function, two same-line functions get distinct ids, class methods, object literal methods, arrow functions, TS-direct strip preserves original TypeScript positions
- [x] Default (option off) emits no `x_fallow_functionMap` key in JSON; Istanbul consumers see byte-identical shape

Closes #78