### PR TITLE
feat(napi): add wasm32-wasi build target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,65 @@ jobs:
       - name: Run upstream Istanbul spec subset
         run: node scripts/istanbul-upstream-specs.mjs
 
+  napi-wasm:
+    # Build the napi binding for wasm32-wasip1-threads and run the full test
+    # suite under NAPI_RS_FORCE_WASI=error so the WASI binding is exercised
+    # end-to-end on every PR (the `error` value fails fast if the WASI binding
+    # cannot be loaded, instead of silently falling back to the native one).
+    # Catches regressions that compile against native libc but not against the
+    # wasm32 emulated environment.
+    name: Napi Test (wasm32-wasi)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache-key: napi-wasm
+          targets: wasm32-wasip1-threads
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: npm ci || npm install
+
+      - name: Build wasm32-wasi binding
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: npx napi build --release --platform --target wasm32-wasip1-threads
+
+      - name: Run napi tests against wasm binding
+        working-directory: crates/oxc-coverage-instrument-napi
+        env:
+          NAPI_RS_FORCE_WASI: error
+        run: node test.mjs
+
+      - name: Report wasm size and enforce ceiling
+        working-directory: crates/oxc-coverage-instrument-napi
+        # Issue #46 acceptance target: WASM artifact size <2 MB compressed.
+        # The ceiling is gated on brotli (the best compressor of the three);
+        # baseline at branch-cut was 0.58 MB, leaving ~3.5x headroom for
+        # dependency drift before the gate fires.
+        env:
+          MAX_BROTLI_BYTES: 2097152
+        run: |
+          ls -lh *.wasm
+          raw=$(wc -c < coverage-instrument.wasm32-wasi.wasm)
+          gz=$(gzip -9 -c coverage-instrument.wasm32-wasi.wasm | wc -c)
+          br=$(brotli -q 11 -c coverage-instrument.wasm32-wasi.wasm | wc -c)
+          printf '%-12s%10d  %.2f MB\n' 'raw'    "$raw" "$(echo "scale=2; $raw/1048576" | bc)"
+          printf '%-12s%10d  %.2f MB\n' 'gzip -9' "$gz"  "$(echo "scale=2; $gz/1048576"  | bc)"
+          printf '%-12s%10d  %.2f MB\n' 'brotli'  "$br"  "$(echo "scale=2; $br/1048576"  | bc)"
+          if [ "$br" -gt "$MAX_BROTLI_BYTES" ]; then
+            echo "::error::Brotli-compressed wasm size $br exceeds ceiling $MAX_BROTLI_BYTES (~2 MB). Issue #46 acceptance target violated."
+            exit 1
+          fi
+
   istanbul-diff:
     # Byte-for-byte diff against istanbul-lib-instrument on the shared
     # conformance fixtures after filtering documented intentional divergences.
@@ -273,6 +332,7 @@ jobs:
       - shear
       - zizmor
       - napi
+      - napi-wasm
       - istanbul-diff
       - vitest-typescript-example
     runs-on: ubuntu-latest

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -56,6 +56,18 @@ jobs:
             target: aarch64-pc-windows-msvc
             build: npx napi build --release --platform --target aarch64-pc-windows-msvc
 
+          # Hotfix bypass: to ship a native-only emergency release when the
+          # WASM build is broken (e.g. an oxc_transformer or napi-rs change
+          # that regresses wasm32 compilation), remove this matrix entry
+          # AND the "Restore wasm shim files to root package" publish step
+          # below. The seven native bindings can be published independently;
+          # the wasm shim files in the root package.json `files` field will
+          # be absent from the tarball, breaking the browser export only
+          # for that one release. Track the wasm regression separately.
+          - os: ubuntu-latest
+            target: wasm32-wasip1-threads
+            build: npx napi build --release --platform --target wasm32-wasip1-threads
+
     steps:
       - name: Configure git long paths (Windows)
         if: contains(matrix.os, 'windows')
@@ -112,10 +124,23 @@ jobs:
           # is identical across build targets, so including it here lets the publish
           # job pick one up without running the build again. The wrapper files are
           # gitignored (regenerated on every build) so they must travel via artifacts.
+          #
+          # The wasm32-wasip1-threads target emits a .wasm binary plus several
+          # JS/MJS shims (coverage-instrument.wasi.cjs, coverage-instrument.wasi-browser.js,
+          # wasi-worker.mjs, wasi-worker-browser.mjs, browser.js). upload-artifact
+          # evaluates if-no-files-found across the whole artifact, so listing
+          # wasm-only globs alongside .node globs is safe (unmatched patterns are
+          # silent as long as at least one file is captured).
           path: |
             crates/oxc-coverage-instrument-napi/*.node
+            crates/oxc-coverage-instrument-napi/*.wasm
             crates/oxc-coverage-instrument-napi/index.js
             crates/oxc-coverage-instrument-napi/index.d.ts
+            crates/oxc-coverage-instrument-napi/browser.js
+            crates/oxc-coverage-instrument-napi/coverage-instrument.wasi.cjs
+            crates/oxc-coverage-instrument-napi/coverage-instrument.wasi-browser.js
+            crates/oxc-coverage-instrument-napi/wasi-worker.mjs
+            crates/oxc-coverage-instrument-napi/wasi-worker-browser.mjs
           if-no-files-found: error
 
   publish-crate:
@@ -197,8 +222,13 @@ jobs:
           path: crates/oxc-coverage-instrument-napi/artifacts
 
       - name: Move artifacts into npm dirs
+        # `--build-output-dir` tells `napi artifacts` where to find the wasi
+        # shim files (coverage-instrument.wasi.cjs, *-browser.js, wasi-worker*.mjs)
+        # that `napi build` emits alongside the .wasm binary. Without it,
+        # napi-rs looks at the package root and fails ENOENT during the
+        # wasm32-wasi npm-dir population step.
         working-directory: crates/oxc-coverage-instrument-napi
-        run: npx napi artifacts --output-dir artifacts
+        run: npx napi artifacts --output-dir artifacts --build-output-dir artifacts/bindings-wasm32-wasip1-threads
 
       - name: Restore JS/TS wrapper from build artifacts
         # The JS/TS wrapper files (index.js, index.d.ts) are gitignored because
@@ -218,6 +248,34 @@ jobs:
             fi
           done
           test -f index.js && test -f index.d.ts
+
+      - name: Restore wasm shim files to root package
+        # The wasm32-wasi binding emits a browser entry (browser.js) plus four
+        # WASI shim files that the root package's `files` field references:
+        #   browser.js                          (browser export target)
+        #   coverage-instrument.wasi.cjs        (Node WASI loader)
+        #   coverage-instrument.wasi-browser.js (browser WASI loader)
+        #   wasi-worker.mjs                     (Node worker)
+        #   wasi-worker-browser.mjs             (browser worker)
+        # `napi artifacts` only places these under `npm/wasm32-wasi/`, not at the
+        # root, so without this copy the root tarball ships an `exports` map that
+        # references missing files. Source: the bindings-wasm32-wasip1-threads
+        # artifact uploaded by the matrix build.
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: |
+          src=artifacts/bindings-wasm32-wasip1-threads
+          if [ ! -d "$src" ]; then
+            echo "::error::$src missing, wasm matrix entry did not produce an artifact"
+            exit 1
+          fi
+          for f in browser.js coverage-instrument.wasi.cjs coverage-instrument.wasi-browser.js wasi-worker.mjs wasi-worker-browser.mjs; do
+            if [ ! -f "$src/$f" ]; then
+              echo "::error::$src/$f missing, wasm build produced incomplete shim set"
+              exit 1
+            fi
+            cp "$src/$f" "$f"
+          done
+          echo "Restored wasm shims from $src"
 
       - name: Update versions from tag
         working-directory: crates/oxc-coverage-instrument-napi

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,14 @@ examples/*/package-lock.json
 
 # napi build artifacts
 *.node
+*.wasm
 crates/oxc-coverage-instrument-napi/index.js
 crates/oxc-coverage-instrument-napi/index.d.ts
+crates/oxc-coverage-instrument-napi/browser.js
+crates/oxc-coverage-instrument-napi/coverage-instrument.wasi.cjs
+crates/oxc-coverage-instrument-napi/coverage-instrument.wasi-browser.js
+crates/oxc-coverage-instrument-napi/wasi-worker.mjs
+crates/oxc-coverage-instrument-napi/wasi-worker-browser.mjs
 crates/oxc-coverage-instrument-napi/node_modules/
 crates/oxc-coverage-instrument-napi/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,33 @@ The `html` format writes a self-contained directory tree (`--output-dir`, defaul
 - **Istanbul**: `coverage-final.json` v3+ format
 - **Node.js**: 18+ (via napi-rs)
 
+### Runtime matrix
+
+`oxc-coverage-instrument` ships prebuilt native bindings for seven platforms plus a WebAssembly fallback (`@oxc-coverage-instrument/binding-wasm32-wasi`, ~2.8 MB raw / ~0.6 MB brotli). The wasm binding is selected automatically when no matching native binary is available, or explicitly via `NAPI_RS_FORCE_WASI` (see [Forcing the WASM binding](#forcing-the-wasm-binding) below).
+
+| Runtime | Status | Notes |
+|:--------|:-------|:------|
+| Node 18+ (darwin/linux/win32, x64/arm64) | native | Preferred when a matching `.node` is installed. |
+| Node 22 LTS (any arch) | wasm fallback | Loads via `node:wasi`; emits an experimental-feature warning. |
+| Deno 2.x | wasm | Uses Deno's `node:wasi` polyfill. Live deploy smoke tracked in [#88](https://github.com/fallow-rs/oxc-coverage-instrument/issues/88). |
+| Browser (with COOP/COEP) | wasm | Imports the `browser` export. Requires `SharedArrayBuffer` (set `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` on the host page) AND an ESM bundler with top-level await support (Vite 2+, webpack 5 with `experiments.topLevelAwait: true`, esbuild, rollup with `output.format: 'esm'`). webpack 4 and Parcel 1 are not supported. |
+| Bun (supported targets) | native | Bun's `node:wasi` is incomplete ([oven-sh/bun#16156](https://github.com/oven-sh/bun/issues/16156)); falls back to the native binding. |
+| Cloudflare Workers | not yet | Workers lacks `SharedArrayBuffer`. Single-threaded `wasm32-wasip1` build tracked in [#87](https://github.com/fallow-rs/oxc-coverage-instrument/issues/87). |
+| StackBlitz / WebContainer | partial | Newer WebContainer images load the wasm binding; older ones may fall through. Live smoke tracked in [#88](https://github.com/fallow-rs/oxc-coverage-instrument/issues/88). |
+
+See `examples/wasm-node/` for a complete end-to-end smoke that exercises both bindings.
+
+#### Forcing the WASM binding
+
+Set `NAPI_RS_FORCE_WASI` to opt out of the native binding even when one is available. Useful for verifying parity locally or for CI gates that must exercise the WASM code path.
+
+| Value | Behavior | When to use |
+|:------|:---------|:------------|
+| `1` (or any truthy non-`error` value) | Force the WASM binding. If the WASM binding cannot be loaded, fall back to the native binding without raising. | Local debugging; pre-release verification on a developer machine. |
+| `error` | Force the WASM binding. If the WASM binding cannot be loaded, throw with a diagnostic error and do not fall back. | CI jobs that gate on the WASM path; release verification that must fail loudly if the WASM build is broken. |
+
+The variable is read directly by the napi-rs 3 loader, so changing or replacing it would require forking the wrapper. Documented for completeness; most users will never need to set it.
+
 ## License
 
 MIT

--- a/crates/oxc-coverage-instrument-napi/npm/wasm32-wasi/README.md
+++ b/crates/oxc-coverage-instrument-napi/npm/wasm32-wasi/README.md
@@ -1,0 +1,10 @@
+# `@oxc-coverage-instrument/binding-wasm32-wasi`
+
+This is the **wasm32-wasip1-threads** binding for `@oxc-coverage-instrument/binding`. It is selected automatically by the host package `oxc-coverage-instrument` when:
+
+- the host runtime has no matching native binding (e.g., browsers with `SharedArrayBuffer` enabled, Deno using the `node:wasi` shim), OR
+- the consumer sets `NAPI_RS_FORCE_WASI=1` explicitly to bypass the native binding.
+
+**Currently unsupported runtimes**: Cloudflare Workers lacks `SharedArrayBuffer`, which `wasm32-wasip1-threads` requires. Bun's `node:wasi` is incomplete (no `wasi.initialize()`), so the wasm binding does not load there; Bun on its officially-supported platforms uses the native binding instead.
+
+See the main package's README for the full runtime support matrix.

--- a/crates/oxc-coverage-instrument-napi/npm/wasm32-wasi/package.json
+++ b/crates/oxc-coverage-instrument-napi/npm/wasm32-wasi/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@oxc-coverage-instrument/binding-wasm32-wasi",
+  "version": "0.6.1",
+  "main": "coverage-instrument.wasi.cjs",
+  "browser": "coverage-instrument.wasi-browser.js",
+  "files": [
+    "coverage-instrument.wasm32-wasi.wasm",
+    "coverage-instrument.wasi.cjs",
+    "coverage-instrument.wasi-browser.js",
+    "wasi-worker.mjs",
+    "wasi-worker-browser.mjs"
+  ],
+  "description": "Istanbul-compatible JavaScript/TypeScript coverage instrumentation using the Oxc AST. 8-48x faster than istanbul-lib-instrument.",
+  "keywords": [
+    "oxc",
+    "istanbul",
+    "coverage",
+    "javascript",
+    "typescript",
+    "instrumentation",
+    "code-coverage",
+    "wasm",
+    "wasi"
+  ],
+  "homepage": "https://github.com/fallow-rs/oxc-coverage-instrument",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fallow-rs/oxc-coverage-instrument.git",
+    "directory": "napi"
+  },
+  "bugs": "https://github.com/fallow-rs/oxc-coverage-instrument/issues",
+  "dependencies": {
+    "@napi-rs/wasm-runtime": "^1.1.4"
+  }
+}

--- a/crates/oxc-coverage-instrument-napi/package.json
+++ b/crates/oxc-coverage-instrument-napi/package.json
@@ -3,10 +3,12 @@
   "version": "0.6.1",
   "description": "Istanbul-compatible JavaScript/TypeScript coverage instrumentation using the Oxc AST. 8-48x faster than istanbul-lib-instrument.",
   "main": "index.js",
+  "browser": "browser.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "types": "./index.d.ts",
+      "browser": "./browser.js",
       "default": "./index.js"
     },
     "./vitest": {
@@ -17,6 +19,11 @@
   "files": [
     "index.js",
     "index.d.ts",
+    "browser.js",
+    "coverage-instrument.wasi.cjs",
+    "coverage-instrument.wasi-browser.js",
+    "wasi-worker.mjs",
+    "wasi-worker-browser.mjs",
     "vitest.js",
     "vitest.d.ts"
   ],
@@ -47,8 +54,12 @@
       "aarch64-unknown-linux-gnu",
       "x86_64-unknown-linux-musl",
       "x86_64-pc-windows-msvc",
-      "aarch64-pc-windows-msvc"
+      "aarch64-pc-windows-msvc",
+      "wasm32-wasip1-threads"
     ]
+  },
+  "dependencies": {
+    "@napi-rs/wasm-runtime": "^1.1.4"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.0",
@@ -68,6 +79,7 @@
     "@oxc-coverage-instrument/binding-linux-x64-gnu": "0.6.1",
     "@oxc-coverage-instrument/binding-linux-x64-musl": "0.6.1",
     "@oxc-coverage-instrument/binding-win32-arm64-msvc": "0.6.1",
-    "@oxc-coverage-instrument/binding-win32-x64-msvc": "0.6.1"
+    "@oxc-coverage-instrument/binding-win32-x64-msvc": "0.6.1",
+    "@oxc-coverage-instrument/binding-wasm32-wasi": "0.6.1"
   }
 }

--- a/examples/wasm-node/README.md
+++ b/examples/wasm-node/README.md
@@ -1,0 +1,30 @@
+# WASM (Node) example
+
+End-to-end smoke for the `wasm32-wasip1-threads` binding under Node. The same `instrument()` API call works with either the native `.node` binding (preferred when available) or the WASI binding (automatic fallback on platforms without a prebuilt native binary, or forced via `NAPI_RS_FORCE_WASI=1`).
+
+## What this demonstrates
+
+- `oxc-coverage-instrument` works identically against both the native and WASM bindings. No code change is required to opt into WASM; the loader picks the right binary at runtime.
+- The WASM build is a single ~2.8 MB artifact (~0.6 MB compressed) that covers every environment with a working `node:wasi` runtime.
+
+## Run
+
+```bash
+cd examples/wasm-node
+npm install
+npm run smoke       # uses the native binding (or wasm if no native is available)
+npm run smoke:wasi  # forces the wasm32-wasi binding via NAPI_RS_FORCE_WASI=error
+```
+
+`smoke:wasi` will fail with a clear error if the WASI binding cannot be loaded, so it doubles as a regression gate that the WASM path stays healthy.
+
+## Platform support
+
+| Runtime | Native binding | WASM binding | Notes |
+|:--------|:---------------|:-------------|:------|
+| Node 22 LTS on darwin/linux/win32 | yes | yes (via `node:wasi`) | Native preferred automatically. |
+| Deno 2.x | no | yes (Deno's `node:wasi` shim) | Untested in CI; community feedback welcome. |
+| Bun (any version) | yes | no | Bun's `node:wasi` lacks `wasi.initialize()` ([bun#16156](https://github.com/oven-sh/bun/issues/16156)). Native binding works on all supported Bun platforms. |
+| Browser (with COOP/COEP) | no | yes (via `browser` export + `fetch`) | Requires `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` for `SharedArrayBuffer`. |
+| Cloudflare Workers | no | no | Workers lacks `SharedArrayBuffer`, which `wasm32-wasip1-threads` requires. Single-threaded WASI build is tracked as a follow-up. |
+| StackBlitz / WebContainer | no | partial | Falls under the browser case above; WebContainer's `node:wasi` polyfill is incomplete in older releases. |

--- a/examples/wasm-node/package.json
+++ b/examples/wasm-node/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "oxc-coverage-instrument-wasm-node-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "smoke": "node scripts/smoke.mjs",
+    "smoke:wasi": "NAPI_RS_FORCE_WASI=error node scripts/smoke.mjs"
+  },
+  "devDependencies": {
+    "oxc-coverage-instrument": "file:../../crates/oxc-coverage-instrument-napi"
+  }
+}

--- a/examples/wasm-node/scripts/smoke.mjs
+++ b/examples/wasm-node/scripts/smoke.mjs
@@ -1,0 +1,30 @@
+import { strict as assert } from 'node:assert'
+import { instrument } from 'oxc-coverage-instrument'
+
+const source = `
+export function classify(n) {
+  if (n < 0) {
+    return 'negative'
+  } else if (n === 0) {
+    return 'zero'
+  } else {
+    return 'positive'
+  }
+}
+`
+
+const result = instrument(source, 'classify.js', { sourceMap: true })
+const coverage = JSON.parse(result.coverageMap)
+
+assert.ok(result.code.includes('__coverage__'), 'expected __coverage__ preamble in instrumented code')
+assert.ok(Object.keys(coverage.statementMap).length > 0, 'expected at least one statement entry')
+assert.ok(Object.keys(coverage.fnMap).length > 0, 'expected at least one function entry')
+assert.ok(Object.keys(coverage.branchMap).length > 0, 'expected at least one branch entry')
+assert.ok(typeof result.sourceMap === 'string', 'expected a source map when sourceMap: true')
+
+const stmts = Object.keys(coverage.statementMap).length
+const fns = Object.keys(coverage.fnMap).length
+const branches = Object.keys(coverage.branchMap).length
+
+const wasi = process.env.NAPI_RS_FORCE_WASI ? ' (wasm binding)' : ''
+console.log(`smoke OK${wasi}: ${stmts} statements, ${fns} functions, ${branches} branch groups`)


### PR DESCRIPTION
## Summary

Adds a WebAssembly build target (`wasm32-wasip1-threads`) so `oxc-coverage-instrument` works on runtimes without a matching native binding: Deno, browsers with COOP/COEP, and the in-browser Node-on-WASM environments (StackBlitz / WebContainer).

- New build target ships as `@oxc-coverage-instrument/binding-wasm32-wasi` (~2.8 MB raw / 0.58 MB brotli, ~80% headroom under the issue's <2 MB compressed ceiling).
- Selected automatically by the napi-rs 3 loader when no native binding matches, or forced via `NAPI_RS_FORCE_WASI=1` (debug) / `NAPI_RS_FORCE_WASI=error` (CI hard-fail).
- New CI job (`napi-wasm`) runs the full napi suite under `NAPI_RS_FORCE_WASI=error` on every PR and enforces a hard 2 MB brotli ceiling.
- Release workflow extended with the new matrix entry plus an explicit "Restore wasm shim files to root package" step (the default napi-rs publish flow only restores `index.js` / `index.d.ts`, which would have shipped a broken browser export).
- Verified end-to-end: native and wasm produce byte-identical output on a 600+ LOC TS file (`cov_sha256=c6750652ec871c3b` for both); full napi suite passes under both bindings.

Phase 1-4 of the rollout. Live deploys to Deno Deploy and Cloudflare Workers, the COOP/COEP `SharedArrayBuffer` guard in the browser shim, and the native-vs-wasm parity gate in `istanbul-diff` are tracked as follow-ups.

## Runtime support matrix

| Runtime | Status |
|:--------|:-------|
| Node 18+ (darwin/linux/win32 x64/arm64) | native |
| Node 22 LTS (any arch) | wasm fallback |
| Deno 2.x | wasm |
| Browser (with COOP/COEP + TLA-capable bundler) | wasm |
| Bun (supported targets) | native (Bun's `node:wasi` is incomplete, see [bun#16156](https://github.com/oven-sh/bun/issues/16156)) |
| Cloudflare Workers | not yet (see #87) |
| StackBlitz / WebContainer | partial (see #88) |

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` green
- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items` clean
- [x] Full napi suite passes under native binding
- [x] Full napi suite passes under `NAPI_RS_FORCE_WASI=error`
- [x] Native vs wasm produce byte-identical output on a non-trivial real TS file
- [x] `npm pack --dry-run` simulation produces a tarball containing all declared files (`index.js`, `index.d.ts`, `browser.js`, `coverage-instrument.wasi.cjs`, `coverage-instrument.wasi-browser.js`, `wasi-worker.mjs`, `wasi-worker-browser.mjs`, `vitest.js`, `vitest.d.ts`)
- [x] `examples/wasm-node/` smoke passes under both native and wasi
- [x] Size baseline measured: 2.8 MB raw / 0.88 MB gzip / 0.58 MB brotli / 0.62 MB zstd
- [x] Live napi-wasm CI job exercises the build on Linux x86_64
- [ ] Live release workflow exercises the new restore step (will run on the v0.7.0 tag push)

## Follow-ups

Closes #46. Refs #87, #88, #89, #90.

- #87 - Single-threaded `wasm32-wasip1` build for Cloudflare Workers
- #88 - Live Deno Deploy + StackBlitz / WebContainer smoke
- #89 - Browser shim `SharedArrayBuffer` guard (needs napi-rs codegen patching)
- #90 - Native-vs-wasm parity gate in `istanbul-diff` CI + wire `examples/wasm-node/` into CI