### PR TITLE
feat(source-maps): RemapOptions { drop_unmapped } for remap helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,23 @@ let remapped = remap_coverage_with_loader(&fc, |path| {
 
 For runners (Jest with `transform`, plugins that hand maps in incrementally) that want continuous remapping during collection, `SourceMapStore` accumulates per-file maps via `add_map` and applies them via `transform_coverage`.
 
+By default, positions whose source-map lookup returns `None` are silently kept at their generated-output coordinates (matching the legacy Mode A flow). Pass `RemapOptions { drop_unmapped: true }` (or `{ dropUnmapped: true }` from JS) to drop statement / function / branch entries that fail to remap, along with their matching `s` / `f` / `b` / `bT` slots. Drop semantics align with `istanbul-lib-source-maps`'s `transformer.js`: statements drop when start or end fails, functions drop when any of `decl` / `loc` start or end fails, and branch arms drop per arm (the whole branch drops only when no arms survive or the umbrella `loc` fails to remap). Use this when instrumenting compiler-emitted boilerplate that has no original-source mapping (e.g. the `?vue&type=script` chunk produced by `@vitejs/plugin-vue`) to keep downstream Istanbul reporters from rendering chunk-line positions against `.vue` paths.
+
+```rust
+use oxc_coverage_instrument::{remap_coverage_map_with_options, RemapOptions};
+
+let remapped =
+    remap_coverage_map_with_options(&coverage_map, RemapOptions { drop_unmapped: true });
+```
+
+```js
+import { remapCoverageMap } from 'oxc-coverage-instrument';
+
+const remapped = JSON.parse(
+    remapCoverageMap(JSON.stringify(coverageMap), { dropUnmapped: true }),
+);
+```
+
 ### Converting V8 byte-range coverage to Istanbul
 
 `v8_to_istanbul` accepts the same shape Node's inspector and `@vitest/coverage-v8` emit. With block coverage enabled, statement/function/branch counts are populated by intersecting V8 ranges with locations recovered from a visit-only AST pass. Inline `//# sourceMappingURL=data:...` trailers are decoded automatically; external map references resolve through the optional loader on `v8_to_istanbul_with_loader`.

--- a/crates/oxc-coverage-instrument-napi/src/lib.rs
+++ b/crates/oxc-coverage-instrument-napi/src/lib.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 
 use napi_derive::napi;
-use oxc_coverage_instrument::DecoratorMode;
+use oxc_coverage_instrument::{DecoratorMode, RemapOptions as CoreRemapOptions};
 use oxc_coverage_types::FileCoverage;
 
 /// Build a friendlier `napi::Error` for the case where the caller passed a
@@ -114,6 +114,30 @@ pub struct InstrumentOptions {
     pub function_identity_overlay: Option<bool>,
 }
 
+/// Options for `remapCoverageMap` and `remapCoverageMapWithLoader`.
+///
+/// Defaults to the legacy keep-generated-position behaviour, so callers that
+/// omit this argument see no change.
+#[napi(object)]
+pub struct RemapOptions {
+    /// When `true`, statement / function / branch entries whose positions
+    /// cannot be looked up in the source map are pruned, along with their
+    /// matching `s` / `f` / `b` / `bT` hit-count slots.
+    ///
+    /// Drop semantics mirror `istanbul-lib-source-maps`'s `transformer.js`:
+    /// statements drop when start or end fails to remap; functions drop when
+    /// any of `decl` / `loc` start or end fails; branch arms drop per arm,
+    /// and the whole branch drops when no arms survive or when the umbrella
+    /// `loc` start/end fails to remap.
+    ///
+    /// Defaults to `false`.
+    pub drop_unmapped: Option<bool>,
+}
+
+fn core_remap_options_from(options: Option<RemapOptions>) -> CoreRemapOptions {
+    CoreRemapOptions { drop_unmapped: options.and_then(|o| o.drop_unmapped).unwrap_or(false) }
+}
+
 /// A coverage pragma comment that was found but not handled.
 #[napi(object)]
 pub struct UnhandledPragma {
@@ -199,11 +223,20 @@ pub fn instrument(
 /// the Vitest istanbul reporter path. For nyc's disk-read flow (Mode A
 /// fallback) use [`remap_coverage_map_with_loader`] and supply a
 /// `Record<string, string>` of preloaded maps keyed by FileCoverage path.
+///
+/// Pass `{ dropUnmapped: true }` to align with `istanbul-lib-source-maps`'s
+/// `transformer.js` and drop entries whose positions cannot be looked up in
+/// the source map (instead of silently keeping their generated-output
+/// coordinates). See [`RemapOptions`] for the full per-kind drop semantics.
 #[napi]
-pub fn remap_coverage_map(coverage_json: String) -> napi::Result<String> {
+pub fn remap_coverage_map(
+    coverage_json: String,
+    options: Option<RemapOptions>,
+) -> napi::Result<String> {
     let parsed = oxc_coverage_instrument::parse_coverage_map(&coverage_json)
         .map_err(|e| invalid_coverage_json_error(&coverage_json, e))?;
-    let remapped = oxc_coverage_instrument::remap_coverage_map(&parsed);
+    let core_options = core_remap_options_from(options);
+    let remapped = oxc_coverage_instrument::remap_coverage_map_with_options(&parsed, core_options);
     serde_json::to_string(&remapped)
         .map_err(|e| napi::Error::new(napi::Status::GenericFailure, e.to_string()))
 }
@@ -224,12 +257,16 @@ pub fn remap_coverage_map(coverage_json: String) -> napi::Result<String> {
 pub fn remap_coverage_map_with_loader(
     coverage_json: String,
     source_maps: HashMap<String, String>,
+    options: Option<RemapOptions>,
 ) -> napi::Result<String> {
     let parsed = oxc_coverage_instrument::parse_coverage_map(&coverage_json)
         .map_err(|e| invalid_coverage_json_error(&coverage_json, e))?;
-    let remapped = oxc_coverage_instrument::remap_coverage_map_with_loader(&parsed, |path| {
-        source_maps.get(path).cloned()
-    });
+    let core_options = core_remap_options_from(options);
+    let remapped = oxc_coverage_instrument::remap_coverage_map_with_loader_and_options(
+        &parsed,
+        |path| source_maps.get(path).cloned(),
+        core_options,
+    );
     serde_json::to_string(&remapped)
         .map_err(|e| napi::Error::new(napi::Status::GenericFailure, e.to_string()))
 }

--- a/crates/oxc-coverage-instrument-napi/test.mjs
+++ b/crates/oxc-coverage-instrument-napi/test.mjs
@@ -1065,4 +1065,85 @@ function runInstrumented(result, filename, callExpression) {
   console.log('  [PASS] remapCoverageMap hints at wrong-shape input');
 }
 
+// Test: remapCoverageMap drop_unmapped prunes entries on unmapped lines (issue #92)
+{
+  // Single-line identity map: line 1 of the generated file maps to line 1 of
+  // src/app.ts; everything on line 2+ is unmapped. Without `dropUnmapped`,
+  // unmapped positions keep their generated-output coordinates (line 2); with
+  // `dropUnmapped: true`, those entries (and their matching s/f/b slots) are
+  // pruned from the FileCoverage, matching istanbul-lib-source-maps's
+  // transformer.js behaviour.
+  const inputSourceMap = {
+    version: 3,
+    sources: ['src/app.ts'],
+    sourcesContent: ['const x: number = 1;\n'],
+    mappings: 'AAAA',
+    names: [],
+  };
+  const intermediateJs = 'const x = 1;\nconst y = 2;\n';
+  const result = instrument(intermediateJs, 'intermediate.js', {
+    inputSourceMap: JSON.stringify(inputSourceMap),
+  });
+  const coverageMap = { 'intermediate.js': JSON.parse(result.coverageMap) };
+  const inputJson = JSON.stringify(coverageMap);
+
+  const kept = JSON.parse(remapCoverageMap(inputJson));
+  const pruned = JSON.parse(remapCoverageMap(inputJson, { dropUnmapped: true }));
+
+  const keptStatements = Object.keys(kept['src/app.ts'].statementMap).length;
+  const prunedStatements = Object.keys(pruned['src/app.ts'].statementMap).length;
+  assert(
+    keptStatements > prunedStatements,
+    `dropUnmapped must prune at least one statement (kept=${keptStatements}, pruned=${prunedStatements})`,
+  );
+  // Every surviving entry must sit on the mapped line.
+  for (const loc of Object.values(pruned['src/app.ts'].statementMap)) {
+    assert.equal(loc.start.line, 1, `surviving statement must be on the mapped line, got ${loc.start.line}`);
+  }
+  // `s` slot keys stay aligned with `statementMap` keys.
+  assert.deepEqual(
+    Object.keys(pruned['src/app.ts'].s).sort(),
+    Object.keys(pruned['src/app.ts'].statementMap).sort(),
+    'surviving `s` keys must match `statementMap` keys',
+  );
+
+  // Default (omitted options) is unchanged.
+  const defaultRemap = JSON.parse(remapCoverageMap(inputJson));
+  assert.equal(
+    Object.keys(defaultRemap['src/app.ts'].statementMap).length,
+    keptStatements,
+    'omitting options must behave identically to the prior API',
+  );
+
+  console.log('  [PASS] remapCoverageMap dropUnmapped prunes unmapped entries');
+}
+
+// Test: remapCoverageMapWithLoader respects dropUnmapped
+{
+  const inputSourceMap = JSON.stringify({
+    version: 3,
+    sources: ['src/app.ts'],
+    sourcesContent: ['const x: number = 1;\n'],
+    mappings: 'AAAA',
+    names: [],
+  });
+  const intermediateJs = 'const x = 1;\nconst y = 2;\n';
+  const result = instrument(intermediateJs, 'intermediate.js');
+  const coverageMap = { 'intermediate.js': JSON.parse(result.coverageMap) };
+  const inputJson = JSON.stringify(coverageMap);
+  const loader = { 'intermediate.js': inputSourceMap };
+
+  const kept = JSON.parse(remapCoverageMapWithLoader(inputJson, loader));
+  const pruned = JSON.parse(remapCoverageMapWithLoader(inputJson, loader, { dropUnmapped: true }));
+
+  const keptStatements = Object.keys(kept['src/app.ts'].statementMap).length;
+  const prunedStatements = Object.keys(pruned['src/app.ts'].statementMap).length;
+  assert(
+    keptStatements > prunedStatements,
+    `loader form: dropUnmapped must prune at least one statement (kept=${keptStatements}, pruned=${prunedStatements})`,
+  );
+
+  console.log('  [PASS] remapCoverageMapWithLoader respects dropUnmapped');
+}
+
 console.log('\nAll tests passed!');

--- a/crates/oxc-coverage-instrument/src/lib.rs
+++ b/crates/oxc-coverage-instrument/src/lib.rs
@@ -38,8 +38,10 @@ pub use instrument::{
     DecoratorMode, InstrumentError, InstrumentOptions, InstrumentResult, instrument,
 };
 pub use oxc_coverage_source_maps::{
-    SourceMapStore, remap_coverage, remap_coverage_map, remap_coverage_map_with_loader,
-    remap_coverage_with_loader,
+    RemapOptions, SourceMapStore, remap_coverage, remap_coverage_map,
+    remap_coverage_map_with_loader, remap_coverage_map_with_loader_and_options,
+    remap_coverage_map_with_options, remap_coverage_with_loader,
+    remap_coverage_with_loader_and_options, remap_coverage_with_options,
 };
 pub use oxc_coverage_types::{
     BranchEntry, FileCoverage, FnEntry, Location, Position, UnhandledPragma, parse_coverage_map,

--- a/crates/oxc-coverage-source-maps/src/lib.rs
+++ b/crates/oxc-coverage-source-maps/src/lib.rs
@@ -30,6 +30,30 @@ use std::collections::BTreeMap;
 
 use oxc_coverage_types::{BranchEntry, FileCoverage, FnEntry, Location, Position};
 
+/// Options for the remap helpers. The default value preserves the legacy
+/// keep-generated-position behaviour for positions whose source-map lookup
+/// returns `None`, so existing callers that pass [`RemapOptions::default`] (or
+/// rely on the parameterless [`remap_coverage`] / [`remap_coverage_map`]
+/// helpers) see no change.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RemapOptions {
+    /// When `true`, statement / function / branch entries whose positions
+    /// cannot be looked up in the source map are pruned, along with their
+    /// matching `s` / `f` / `b` / `bT` hit-count slots.
+    ///
+    /// Drop semantics mirror `istanbul-lib-source-maps`'s
+    /// `transformer.js`:
+    /// - **statement**: dropped when either `start` or `end` fails to remap.
+    /// - **function**: dropped when any of `decl.start`, `decl.end`,
+    ///   `loc.start`, `loc.end` fails to remap.
+    /// - **branch**: per-arm prune when either arm endpoint fails to remap;
+    ///   the whole branch is dropped when no arms survive, or when the
+    ///   umbrella `loc` start/end fails to remap.
+    ///
+    /// Defaults to `false` so existing callers see no change.
+    pub drop_unmapped: bool,
+}
+
 /// Remap a single `FileCoverage` through its embedded `inputSourceMap`.
 ///
 /// Returns `None` when the entry has no `inputSourceMap`, when that map fails
@@ -40,7 +64,16 @@ use oxc_coverage_types::{BranchEntry, FileCoverage, FnEntry, Location, Position}
 /// `sourceRoot` joined with the first entry in `sources` (matching
 /// `istanbul-lib-source-maps` semantics).
 pub fn remap_coverage(coverage: &FileCoverage) -> Option<FileCoverage> {
-    remap_coverage_with_loader(coverage, |_| None)
+    remap_coverage_with_loader_and_options(coverage, |_| None, RemapOptions::default())
+}
+
+/// Like [`remap_coverage`], but with a [`RemapOptions`] argument. See
+/// [`RemapOptions::drop_unmapped`] for the pruning semantics.
+pub fn remap_coverage_with_options(
+    coverage: &FileCoverage,
+    options: RemapOptions,
+) -> Option<FileCoverage> {
+    remap_coverage_with_loader_and_options(coverage, |_| None, options)
 }
 
 /// Like [`remap_coverage`], but when the entry has no embedded
@@ -56,12 +89,25 @@ pub fn remap_coverage_with_loader<L>(coverage: &FileCoverage, loader: L) -> Opti
 where
     L: Fn(&str) -> Option<String>,
 {
+    remap_coverage_with_loader_and_options(coverage, loader, RemapOptions::default())
+}
+
+/// Like [`remap_coverage_with_loader`], with a [`RemapOptions`] argument. See
+/// [`RemapOptions::drop_unmapped`] for the pruning semantics.
+pub fn remap_coverage_with_loader_and_options<L>(
+    coverage: &FileCoverage,
+    loader: L,
+    options: RemapOptions,
+) -> Option<FileCoverage>
+where
+    L: Fn(&str) -> Option<String>,
+{
     let input_sm_json = match coverage.input_source_map.as_ref() {
         Some(value) => serde_json::to_string(value).ok()?,
         None => loader(&coverage.path)?,
     };
     let sm = srcmap_sourcemap::SourceMap::from_json(&input_sm_json).ok()?;
-    apply_source_map(coverage, &sm)
+    apply_source_map(coverage, &sm, options)
 }
 
 /// Remap every `FileCoverage` in a coverage map. Entries without an
@@ -76,7 +122,16 @@ where
 pub fn remap_coverage_map(
     coverage_map: &BTreeMap<String, FileCoverage>,
 ) -> BTreeMap<String, FileCoverage> {
-    remap_coverage_map_with_loader(coverage_map, |_| None)
+    remap_coverage_map_with_loader_and_options(coverage_map, |_| None, RemapOptions::default())
+}
+
+/// Like [`remap_coverage_map`], with a [`RemapOptions`] argument. See
+/// [`RemapOptions::drop_unmapped`] for the pruning semantics.
+pub fn remap_coverage_map_with_options(
+    coverage_map: &BTreeMap<String, FileCoverage>,
+    options: RemapOptions,
+) -> BTreeMap<String, FileCoverage> {
+    remap_coverage_map_with_loader_and_options(coverage_map, |_| None, options)
 }
 
 /// Like [`remap_coverage_map`], but with a disk-read fallback for entries
@@ -89,9 +144,22 @@ pub fn remap_coverage_map_with_loader<L>(
 where
     L: Fn(&str) -> Option<String>,
 {
+    remap_coverage_map_with_loader_and_options(coverage_map, loader, RemapOptions::default())
+}
+
+/// Like [`remap_coverage_map_with_loader`], with a [`RemapOptions`] argument.
+/// See [`RemapOptions::drop_unmapped`] for the pruning semantics.
+pub fn remap_coverage_map_with_loader_and_options<L>(
+    coverage_map: &BTreeMap<String, FileCoverage>,
+    loader: L,
+    options: RemapOptions,
+) -> BTreeMap<String, FileCoverage>
+where
+    L: Fn(&str) -> Option<String>,
+{
     let mut out = BTreeMap::new();
     for (path, fc) in coverage_map {
-        match remap_coverage_with_loader(fc, &loader) {
+        match remap_coverage_with_loader_and_options(fc, &loader, options) {
             Some(remapped) => {
                 out.insert(remapped.path.clone(), remapped);
             }
@@ -108,6 +176,7 @@ where
 fn apply_source_map(
     coverage: &FileCoverage,
     sm: &srcmap_sourcemap::SourceMap,
+    options: RemapOptions,
 ) -> Option<FileCoverage> {
     let primary_source = resolve_primary_source(sm)?;
 
@@ -115,17 +184,118 @@ fn apply_source_map(
     out.path = primary_source;
     out.input_source_map = None;
 
-    for loc in out.statement_map.values_mut() {
-        remap_location(loc, sm);
-    }
-    for fn_entry in out.fn_map.values_mut() {
-        remap_fn_entry(fn_entry, sm);
-    }
-    for branch_entry in out.branch_map.values_mut() {
-        remap_branch_entry(branch_entry, sm);
+    if options.drop_unmapped {
+        prune_unmapped(&mut out, sm);
+    } else {
+        for loc in out.statement_map.values_mut() {
+            remap_location(loc, sm);
+        }
+        for fn_entry in out.fn_map.values_mut() {
+            remap_fn_entry(fn_entry, sm);
+        }
+        for branch_entry in out.branch_map.values_mut() {
+            remap_branch_entry(branch_entry, sm);
+        }
     }
 
     Some(out)
+}
+
+/// Drop statement / function / branch entries whose positions cannot be looked
+/// up in the source map, taking matching `s` / `f` / `b` / `bT` slots with
+/// them. Mirrors `istanbul-lib-source-maps`'s `transformer.js`. See
+/// [`RemapOptions::drop_unmapped`] for the exact per-kind rules.
+fn prune_unmapped(coverage: &mut FileCoverage, sm: &srcmap_sourcemap::SourceMap) {
+    // Statements: drop when either start or end fails to remap.
+    let mut dropped_statements: Vec<String> = Vec::new();
+    coverage.statement_map.retain(|key, loc| {
+        if try_remap_location(loc, sm) {
+            true
+        } else {
+            dropped_statements.push(key.clone());
+            false
+        }
+    });
+    for key in &dropped_statements {
+        coverage.s.remove(key);
+    }
+
+    // Functions: drop when any of decl.start, decl.end, loc.start, loc.end
+    // fails to remap. `FnEntry::line` is refreshed from the remapped
+    // `loc.start.line` on the surviving entries.
+    let mut dropped_fns: Vec<String> = Vec::new();
+    coverage.fn_map.retain(|key, fn_entry| {
+        let decl_ok = try_remap_location(&mut fn_entry.decl, sm);
+        let loc_ok = try_remap_location(&mut fn_entry.loc, sm);
+        if decl_ok && loc_ok {
+            fn_entry.line = fn_entry.loc.start.line;
+            true
+        } else {
+            dropped_fns.push(key.clone());
+            false
+        }
+    });
+    for key in &dropped_fns {
+        coverage.f.remove(key);
+    }
+
+    // Branches: per-arm prune when either arm endpoint fails to remap; drop
+    // the whole branch when no arms survive OR when the umbrella `loc`
+    // start/end fails to remap. The `b` / `bT` arm vectors track surviving
+    // arms by position so their hit counts stay aligned.
+    let mut dropped_branches: Vec<String> = Vec::new();
+    let mut surviving_arms: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    coverage.branch_map.retain(|key, branch_entry| {
+        let loc_ok = try_remap_location(&mut branch_entry.loc, sm);
+        if !loc_ok {
+            dropped_branches.push(key.clone());
+            return false;
+        }
+
+        let mut kept_indices: Vec<usize> = Vec::new();
+        let mut kept_locations: Vec<Location> = Vec::new();
+        for (idx, arm) in branch_entry.locations.iter_mut().enumerate() {
+            if try_remap_location(arm, sm) {
+                kept_indices.push(idx);
+                kept_locations.push(arm.clone());
+            }
+        }
+        if kept_locations.is_empty() {
+            dropped_branches.push(key.clone());
+            return false;
+        }
+
+        branch_entry.locations = kept_locations;
+        branch_entry.line = branch_entry.loc.start.line;
+        surviving_arms.insert(key.clone(), kept_indices);
+        true
+    });
+    for key in &dropped_branches {
+        coverage.b.remove(key);
+        if let Some(b_t) = coverage.b_t.as_mut() {
+            b_t.remove(key);
+        }
+    }
+    realign_arm_vec_map(&mut coverage.b, &surviving_arms);
+    if let Some(b_t) = coverage.b_t.as_mut() {
+        realign_arm_vec_map(b_t, &surviving_arms);
+    }
+}
+
+/// Project each surviving-arm hit-count vector down to the kept indices.
+/// Branches that disappeared from the map (already removed via `b.remove`)
+/// are not in `surviving_arms` and are left untouched here.
+fn realign_arm_vec_map(
+    arm_counts: &mut BTreeMap<String, Vec<u32>>,
+    surviving_arms: &BTreeMap<String, Vec<usize>>,
+) {
+    for (key, indices) in surviving_arms {
+        let Some(existing) = arm_counts.get_mut(key) else {
+            continue;
+        };
+        let trimmed = indices.iter().map(|&i| existing.get(i).copied().unwrap_or(0)).collect();
+        *existing = trimmed;
+    }
 }
 
 /// Stateful map store for the Mode B "continuous remap during collection"
@@ -201,12 +371,24 @@ impl SourceMapStore {
     /// usable map, matching [`remap_coverage`]'s fallback semantics.
     #[must_use]
     pub fn transform_coverage(&self, coverage: &FileCoverage) -> Option<FileCoverage> {
+        self.transform_coverage_with_options(coverage, RemapOptions::default())
+    }
+
+    /// Like [`SourceMapStore::transform_coverage`], but with a
+    /// [`RemapOptions`] argument. See [`RemapOptions::drop_unmapped`] for the
+    /// pruning semantics.
+    #[must_use]
+    pub fn transform_coverage_with_options(
+        &self,
+        coverage: &FileCoverage,
+        options: RemapOptions,
+    ) -> Option<FileCoverage> {
         if let Some(value) = self.maps.get(&coverage.path) {
             let json = serde_json::to_string(value).ok()?;
             let sm = srcmap_sourcemap::SourceMap::from_json(&json).ok()?;
-            return apply_source_map(coverage, &sm);
+            return apply_source_map(coverage, &sm, options);
         }
-        remap_coverage(coverage)
+        remap_coverage_with_options(coverage, options)
     }
 
     /// Remap every entry of a coverage map using the store. Entries whose
@@ -217,9 +399,21 @@ impl SourceMapStore {
         &self,
         coverage_map: &BTreeMap<String, FileCoverage>,
     ) -> BTreeMap<String, FileCoverage> {
+        self.transform_coverage_map_with_options(coverage_map, RemapOptions::default())
+    }
+
+    /// Like [`SourceMapStore::transform_coverage_map`], but with a
+    /// [`RemapOptions`] argument. See [`RemapOptions::drop_unmapped`] for the
+    /// pruning semantics.
+    #[must_use]
+    pub fn transform_coverage_map_with_options(
+        &self,
+        coverage_map: &BTreeMap<String, FileCoverage>,
+        options: RemapOptions,
+    ) -> BTreeMap<String, FileCoverage> {
         let mut out = BTreeMap::new();
         for (path, fc) in coverage_map {
-            match self.transform_coverage(fc) {
+            match self.transform_coverage_with_options(fc, options) {
                 Some(remapped) => {
                     out.insert(remapped.path.clone(), remapped);
                 }
@@ -266,9 +460,38 @@ fn remap_position(pos: &mut Position, sm: &srcmap_sourcemap::SourceMap) {
     }
 }
 
+/// Strict variant of [`remap_position`]: returns `true` when the position was
+/// rewritten through the source map (or was the `line: 0` "unknown" sentinel,
+/// which istanbul treats as a successful no-op), and `false` when the lookup
+/// returned `None`. Used by [`prune_unmapped`] to decide which entries to
+/// drop in `drop_unmapped` mode.
+fn try_remap_position(pos: &mut Position, sm: &srcmap_sourcemap::SourceMap) -> bool {
+    if pos.line == 0 {
+        return true;
+    }
+    let gen_line = pos.line - 1;
+    let Some(orig) = sm.original_position_for(gen_line, pos.column) else {
+        return false;
+    };
+    pos.line = orig.line + 1;
+    pos.column = orig.column;
+    true
+}
+
 fn remap_location(loc: &mut Location, sm: &srcmap_sourcemap::SourceMap) {
     remap_position(&mut loc.start, sm);
     remap_position(&mut loc.end, sm);
+}
+
+/// Strict variant of [`remap_location`]: returns `true` only when both
+/// endpoints remap successfully (or were the `line: 0` "unknown" sentinel).
+/// The location is rewritten in place regardless so partial-success diagnostic
+/// inspection stays available to the caller; pruning paths discard the entry
+/// when this returns `false`.
+fn try_remap_location(loc: &mut Location, sm: &srcmap_sourcemap::SourceMap) -> bool {
+    let start = try_remap_position(&mut loc.start, sm);
+    let end = try_remap_position(&mut loc.end, sm);
+    start && end
 }
 
 fn remap_fn_entry(fn_entry: &mut FnEntry, sm: &srcmap_sourcemap::SourceMap) {

--- a/crates/oxc-coverage-source-maps/tests/lib_edges.rs
+++ b/crates/oxc-coverage-source-maps/tests/lib_edges.rs
@@ -11,7 +11,8 @@
 use std::collections::BTreeMap;
 
 use oxc_coverage_source_maps::{
-    SourceMapStore, remap_coverage, remap_coverage_map_with_loader, remap_coverage_with_loader,
+    RemapOptions, SourceMapStore, remap_coverage, remap_coverage_map_with_loader,
+    remap_coverage_map_with_options, remap_coverage_with_loader, remap_coverage_with_options,
 };
 use oxc_coverage_types::{
     BranchEntry, FileCoverage, FnEntry, Location, Position, parse_coverage_map,
@@ -220,6 +221,250 @@ fn remap_skips_positions_with_unknown_line() {
     let blank = &remapped.statement_map["blank"];
     assert_eq!(blank.start.line, 0, "unknown line stays unknown");
     assert_eq!(blank.end.line, 0);
+}
+
+/// Single-line identity map: line 1 of the generated file maps to line 1 of
+/// `src/app.ts`. Positions on line 2+ have no mapping and
+/// `original_position_for` returns `None` for them, which is the trigger we
+/// need to exercise `RemapOptions::drop_unmapped`.
+fn one_line_identity_map() -> serde_json::Value {
+    serde_json::from_str(&format!(
+        r#"{{"version":3,"sources":["{SRC_PATH}"],"mappings":"AAAA","names":[]}}"#,
+    ))
+    .unwrap()
+}
+
+/// `FileCoverage` whose statement / function / branch entries straddle a
+/// "mapped line 1 / unmapped line 2+" boundary so the `drop_unmapped` tests
+/// can assert which entries survive and which get pruned.
+///
+/// Statement `keep` sits at line 1 (mapped), `drop` at line 2 (unmapped).
+/// Function `keep` has both `decl` and `loc` on line 1; function `drop` has
+/// `decl` on line 1 but `loc` on line 2, exercising the "any of decl/loc
+/// fails" rule. Branch `keep` has its umbrella `loc` on line 1 with two arms,
+/// one on line 1 (kept) and one on line 2 (pruned); branch `drop_no_arms`
+/// has its umbrella `loc` on line 1 but every arm on line 2 (drop because
+/// no arms survive); branch `drop_outer` has its umbrella `loc` on line 2
+/// (drop even though arms map).
+fn mixed_mapped_file_coverage() -> FileCoverage {
+    let pos = |line: u32, col: u32| Position { line, column: col };
+    let loc =
+        |sl: u32, sc: u32, el: u32, ec: u32| Location { start: pos(sl, sc), end: pos(el, ec) };
+
+    let mut statement_map = BTreeMap::new();
+    statement_map.insert("keep".to_string(), loc(1, 0, 1, 10));
+    statement_map.insert("drop".to_string(), loc(2, 0, 2, 10));
+
+    let mut fn_map = BTreeMap::new();
+    fn_map.insert(
+        "keep".to_string(),
+        FnEntry { name: "k".to_string(), line: 1, decl: loc(1, 0, 1, 1), loc: loc(1, 0, 1, 10) },
+    );
+    fn_map.insert(
+        "drop".to_string(),
+        FnEntry { name: "d".to_string(), line: 1, decl: loc(1, 0, 1, 1), loc: loc(2, 0, 2, 10) },
+    );
+
+    let mut branch_map = BTreeMap::new();
+    branch_map.insert(
+        "keep".to_string(),
+        BranchEntry {
+            loc: loc(1, 0, 1, 8),
+            line: 1,
+            branch_type: "if".to_string(),
+            // arm 0 maps (line 1); arm 1 does not (line 2).
+            locations: vec![loc(1, 4, 1, 5), loc(2, 6, 2, 7)],
+        },
+    );
+    branch_map.insert(
+        "drop_no_arms".to_string(),
+        BranchEntry {
+            loc: loc(1, 0, 1, 8),
+            line: 1,
+            branch_type: "if".to_string(),
+            // every arm unmapped.
+            locations: vec![loc(2, 4, 2, 5), loc(2, 6, 2, 7)],
+        },
+    );
+    branch_map.insert(
+        "drop_outer".to_string(),
+        BranchEntry {
+            loc: loc(2, 0, 2, 8),
+            line: 2,
+            branch_type: "if".to_string(),
+            // arms are technically mappable, but umbrella loc is not.
+            locations: vec![loc(1, 4, 1, 5), loc(1, 6, 1, 7)],
+        },
+    );
+
+    let mut s = BTreeMap::new();
+    s.insert("keep".to_string(), 7);
+    s.insert("drop".to_string(), 13);
+    let mut f = BTreeMap::new();
+    f.insert("keep".to_string(), 2);
+    f.insert("drop".to_string(), 3);
+    let mut b = BTreeMap::new();
+    b.insert("keep".to_string(), vec![4, 5]);
+    b.insert("drop_no_arms".to_string(), vec![6, 7]);
+    b.insert("drop_outer".to_string(), vec![8, 9]);
+    let mut b_t = BTreeMap::new();
+    b_t.insert("keep".to_string(), vec![10, 11]);
+    b_t.insert("drop_no_arms".to_string(), vec![12, 13]);
+    b_t.insert("drop_outer".to_string(), vec![14, 15]);
+
+    FileCoverage {
+        path: "intermediate.js".to_string(),
+        statement_map,
+        fn_map,
+        branch_map,
+        s,
+        f,
+        b,
+        b_t: Some(b_t),
+        input_source_map: Some(one_line_identity_map()),
+        x_fallow_function_map: None,
+    }
+}
+
+#[test]
+fn drop_unmapped_default_keeps_generated_positions() {
+    // Default options preserve current behaviour: nothing gets dropped, and
+    // unmapped positions keep their generated-output coordinates.
+    let fc = mixed_mapped_file_coverage();
+    let remapped =
+        remap_coverage(&fc).expect("remap with embedded map and default options succeeds");
+
+    assert_eq!(remapped.statement_map.len(), 2, "default keeps both statements");
+    assert_eq!(remapped.fn_map.len(), 2, "default keeps both functions");
+    assert_eq!(remapped.branch_map.len(), 3, "default keeps all branches");
+    assert_eq!(remapped.branch_map["keep"].locations.len(), 2, "default keeps both arms");
+}
+
+#[test]
+fn drop_unmapped_prunes_statements_and_aligned_counters() {
+    let fc = mixed_mapped_file_coverage();
+    let opts = RemapOptions { drop_unmapped: true };
+    let remapped = remap_coverage_with_options(&fc, opts).expect("drop_unmapped remap succeeds");
+
+    assert!(remapped.statement_map.contains_key("keep"));
+    assert!(!remapped.statement_map.contains_key("drop"));
+    assert!(remapped.s.contains_key("keep"), "matching `s` slot survives");
+    assert_eq!(remapped.s["keep"], 7);
+    assert!(!remapped.s.contains_key("drop"), "matching `s` slot drops with the statement");
+}
+
+#[test]
+fn drop_unmapped_prunes_functions_when_decl_or_loc_fails() {
+    let fc = mixed_mapped_file_coverage();
+    let opts = RemapOptions { drop_unmapped: true };
+    let remapped = remap_coverage_with_options(&fc, opts).expect("drop_unmapped remap succeeds");
+
+    assert!(remapped.fn_map.contains_key("keep"));
+    assert!(!remapped.fn_map.contains_key("drop"), "function with unmapped loc drops");
+    assert!(remapped.f.contains_key("keep"));
+    assert!(!remapped.f.contains_key("drop"));
+    let kept = &remapped.fn_map["keep"];
+    assert_eq!(kept.line, kept.loc.start.line, "FnEntry.line tracks loc.start.line after remap");
+}
+
+#[test]
+fn drop_unmapped_prunes_branch_arms_and_realigns_counters() {
+    let fc = mixed_mapped_file_coverage();
+    let opts = RemapOptions { drop_unmapped: true };
+    let remapped = remap_coverage_with_options(&fc, opts).expect("drop_unmapped remap succeeds");
+
+    // Per-arm prune: arm 0 (line 1) survives, arm 1 (line 2) drops.
+    let kept =
+        remapped.branch_map.get("keep").expect("branch with at least one mapped arm survives");
+    assert_eq!(kept.locations.len(), 1, "only the mapped arm survives");
+    assert_eq!(kept.locations[0].start.line, 1, "the surviving arm maps to line 1");
+
+    // Counter vectors realign so positions still line up with the kept arms.
+    assert_eq!(remapped.b["keep"], vec![4], "b realigns to the kept arm");
+    let b_t = remapped.b_t.as_ref().expect("bT survives when drop preserves the branch");
+    assert_eq!(b_t["keep"], vec![10], "bT realigns to the kept arm");
+}
+
+#[test]
+fn drop_unmapped_drops_whole_branch_when_no_arms_survive() {
+    let fc = mixed_mapped_file_coverage();
+    let opts = RemapOptions { drop_unmapped: true };
+    let remapped = remap_coverage_with_options(&fc, opts).expect("drop_unmapped remap succeeds");
+
+    assert!(
+        !remapped.branch_map.contains_key("drop_no_arms"),
+        "branch drops when every arm fails to remap",
+    );
+    assert!(!remapped.b.contains_key("drop_no_arms"), "matching `b` slot drops with the branch");
+    let b_t = remapped.b_t.as_ref().expect("bT exists for the surviving branches");
+    assert!(!b_t.contains_key("drop_no_arms"), "matching `bT` slot drops with the branch");
+}
+
+#[test]
+fn drop_unmapped_drops_branch_when_outer_loc_fails() {
+    let fc = mixed_mapped_file_coverage();
+    let opts = RemapOptions { drop_unmapped: true };
+    let remapped = remap_coverage_with_options(&fc, opts).expect("drop_unmapped remap succeeds");
+
+    assert!(
+        !remapped.branch_map.contains_key("drop_outer"),
+        "branch drops when the umbrella `loc` fails to remap, even if arms would map",
+    );
+    assert!(!remapped.b.contains_key("drop_outer"));
+    let b_t = remapped.b_t.as_ref().expect("bT exists for the surviving branches");
+    assert!(!b_t.contains_key("drop_outer"));
+}
+
+#[test]
+fn drop_unmapped_keeps_unknown_line_zero_positions() {
+    // Istanbul uses `line: 0` as the "unknown" sentinel; the drop path must
+    // treat it as a successful no-op rather than pruning it.
+    let mut fc = mixed_mapped_file_coverage();
+    fc.statement_map.insert(
+        "blank".to_string(),
+        Location { start: Position { line: 0, column: 0 }, end: Position { line: 0, column: 0 } },
+    );
+    fc.s.insert("blank".to_string(), 0);
+
+    let opts = RemapOptions { drop_unmapped: true };
+    let remapped = remap_coverage_with_options(&fc, opts).expect("drop_unmapped remap succeeds");
+    assert!(
+        remapped.statement_map.contains_key("blank"),
+        "`line: 0` sentinel positions survive `drop_unmapped`",
+    );
+}
+
+#[test]
+fn drop_unmapped_applies_to_coverage_map_helper() {
+    let fc = mixed_mapped_file_coverage();
+    let mut coverage_map = BTreeMap::new();
+    coverage_map.insert("intermediate.js".to_string(), fc);
+
+    let opts = RemapOptions { drop_unmapped: true };
+    let remapped = remap_coverage_map_with_options(&coverage_map, opts);
+    let entry = remapped.get(SRC_PATH).expect("entry is rekeyed by source path");
+    assert_eq!(entry.statement_map.len(), 1, "drop_unmapped flows through coverage-map helper");
+    assert!(entry.fn_map.contains_key("keep"));
+    assert!(!entry.fn_map.contains_key("drop"));
+}
+
+#[test]
+fn drop_unmapped_applies_through_store() {
+    let fc = mixed_mapped_file_coverage();
+    let mut store = SourceMapStore::new();
+    store.add_map("intermediate.js", one_line_identity_map());
+
+    let opts = RemapOptions { drop_unmapped: true };
+    let remapped = store
+        .transform_coverage_with_options(&fc, opts)
+        .expect("store-driven drop_unmapped remap succeeds");
+    assert_eq!(remapped.statement_map.len(), 1);
+
+    let mut coverage_map = BTreeMap::new();
+    coverage_map.insert("intermediate.js".to_string(), fc);
+    let remapped_map = store.transform_coverage_map_with_options(&coverage_map, opts);
+    let entry = remapped_map.get(SRC_PATH).expect("store map-level helper rekeys by source path");
+    assert_eq!(entry.statement_map.len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds an opt-in `RemapOptions { drop_unmapped }` flag to `remap_coverage{,_map}{,_with_loader}` and `SourceMapStore::transform_coverage{,_map}`.
- Surfaced via napi as an optional trailing `options?: { dropUnmapped?: boolean }` argument on `remapCoverageMap` and `remapCoverageMapWithLoader`.
- Drop semantics align with `istanbul-lib-source-maps`'s `transformer.js`: statement drops when start or end fails to remap; function drops when any of `decl` / `loc` start or end fails; branch arms drop per arm, and the whole branch drops only when no arms survive or the umbrella `loc` start/end fails. Matching `s` / `f` / `b` / `bT` hit-count slots track the survivors.

## Motivation (from #92)
OXC instruments compiler-emitted boilerplate in the `?vue&type=script` chunk produced by `@vitejs/plugin-vue` that has no mapping back to the `.vue` source. With the previous behaviour, unmapped positions silently keep their generated-output coordinates and `istanbul-reports` renders them against the `.vue` path on lines that belong to `<template>` markup or CSS rules. `dropUnmapped` opts into the istanbul-aligned prune so those entries disappear from the report instead.

## Backwards compatibility
- Existing Rust fns are kept as zero-overhead wrappers around the `*_with_options` variants; signatures unchanged.
- The new napi argument is optional, so `remapCoverageMap(coverageJson)` and `remapCoverageMapWithLoader(coverageJson, sourceMaps)` keep working with byte-identical output.
- Default `drop_unmapped: false` preserves the legacy keep-generated-position behaviour.

## Test plan
- [x] `cargo test --workspace --all-targets` (10 new unit tests in `oxc-coverage-source-maps`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `cargo fmt --all -- --check`.
- [x] `cargo doc --workspace --no-deps --document-private-items` (no warnings).
- [x] `node test.mjs` after `napi build` (2 new napi smoke tests: `dropUnmapped` on both embedded and loader paths).
- [x] `typos` clean across the diff.

Closes #92