### PR TITLE
feat(napi): guard SharedArrayBuffer before WASM instantiation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,13 @@ jobs:
         working-directory: crates/oxc-coverage-instrument-napi
         run: npx napi build --release --platform --target wasm32-wasip1-threads
 
+      # Inject the SharedArrayBuffer guard into the regenerated browser shim
+      # (issue #89). The shim is rewritten by `napi build`, so the patch must
+      # run after every wasm build that emits it.
+      - name: Patch wasi-browser shim with SharedArrayBuffer guard
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-wasi-browser-shim.mjs
+
       # The optionalDependency `@oxc-coverage-instrument/binding-wasm32-wasi`
       # is pinned at the previously published version; the loader in
       # `coverage-instrument.wasi.cjs` would silently fall back to that

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -111,6 +111,14 @@ jobs:
         working-directory: crates/oxc-coverage-instrument-napi
         run: ${{ matrix.build }}
 
+      # Inject the SharedArrayBuffer guard into the regenerated browser shim
+      # (issue #89). The shim is only emitted by the wasm32-wasip1-threads
+      # matrix entry; the patch script is a no-op when the shim is absent,
+      # so it is safe to run unconditionally across the matrix.
+      - name: Patch wasi-browser shim with SharedArrayBuffer guard
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-wasi-browser-shim.mjs
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/crates/oxc-coverage-instrument-napi/package.json
+++ b/crates/oxc-coverage-instrument-napi/package.json
@@ -66,11 +66,12 @@
     "istanbul-lib-instrument": "^6.0.3"
   },
   "scripts": {
-    "build": "napi build --release --platform",
-    "build:debug": "napi build --platform",
+    "build": "napi build --release --platform && node scripts/patch-wasi-browser-shim.mjs",
+    "build:debug": "napi build --platform && node scripts/patch-wasi-browser-shim.mjs",
+    "patch-shim": "node scripts/patch-wasi-browser-shim.mjs",
     "prepublishOnly": "napi prepublish -t npm",
     "artifacts": "napi artifacts",
-    "test": "node test.mjs"
+    "test": "node test.mjs && node scripts/patch-wasi-browser-shim.test.mjs"
   },
   "optionalDependencies": {
     "@oxc-coverage-instrument/binding-darwin-arm64": "0.7.2",

--- a/crates/oxc-coverage-instrument-napi/scripts/patch-wasi-browser-shim.mjs
+++ b/crates/oxc-coverage-instrument-napi/scripts/patch-wasi-browser-shim.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Post-build patch for `coverage-instrument.wasi-browser.js`.
+//
+// `napi build --target wasm32-wasip1-threads` emits a browser shim that
+// allocates `new WebAssembly.Memory({ ..., shared: true })` at module top
+// level. Without cross-origin isolation (COOP `same-origin` + COEP
+// `require-corp`) the host page lacks `SharedArrayBuffer` and the shim
+// throws an opaque `TypeError` from inside napi-rs runtime code with no
+// hint that the fix lives on the host page rather than in the bundler or
+// the package.
+//
+// This script injects a guard at the top of the generated shim so the
+// failure surfaces a precise diagnostic. The shim is regenerated on every
+// `napi build`; this script must run after each build (wired into
+// `package.json` `scripts.build` and the release workflow).
+//
+// Idempotent: the guard carries a sentinel comment and re-runs become
+// no-ops once the sentinel is present. Safe to invoke when the shim file
+// is absent (non-wasm builds): exits 0 with a notice.
+//
+// Tracks issue #89.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SENTINEL = '// oxc-coverage-instrument: SharedArrayBuffer guard (issue #89)';
+const GUARD = `${SENTINEL}
+if (typeof SharedArrayBuffer === 'undefined') {
+  throw new Error(
+    'oxc-coverage-instrument: the browser WASM binding requires SharedArrayBuffer. ' +
+      'Enable Cross-Origin-Opener-Policy: same-origin and ' +
+      'Cross-Origin-Embedder-Policy: require-corp on your host page so the ' +
+      'browser is cross-origin isolated. See ' +
+      'https://github.com/fallow-rs/oxc-coverage-instrument#runtime-matrix',
+  );
+}
+`;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const shimPath = join(__dirname, '..', 'coverage-instrument.wasi-browser.js');
+
+if (!existsSync(shimPath)) {
+  console.log(
+    `[patch-wasi-browser-shim] ${shimPath} not present; skipping (non-wasm build).`,
+  );
+  process.exit(0);
+}
+
+const original = readFileSync(shimPath, 'utf8');
+
+if (original.includes(SENTINEL)) {
+  console.log('[patch-wasi-browser-shim] guard already present; nothing to do.');
+  process.exit(0);
+}
+
+// napi-rs emits a single import block at the top, then a blank line, then
+// the WASI / memory allocation. Inject after the last `import ... from '...'`
+// statement so the guard runs before any `WebAssembly.Memory({ shared: true })`.
+const importRegex = /(^import[\s\S]*?from\s+['"][^'"]+['"];?\s*\n)+/m;
+const match = original.match(importRegex);
+if (!match) {
+  console.error(
+    '[patch-wasi-browser-shim] could not locate napi-rs import block in shim; aborting.',
+  );
+  process.exit(1);
+}
+const insertAt = match.index + match[0].length;
+const patched = `${original.slice(0, insertAt)}\n${GUARD}\n${original.slice(insertAt)}`;
+
+writeFileSync(shimPath, patched);
+console.log(`[patch-wasi-browser-shim] injected SharedArrayBuffer guard into ${shimPath}.`);

--- a/crates/oxc-coverage-instrument-napi/scripts/patch-wasi-browser-shim.test.mjs
+++ b/crates/oxc-coverage-instrument-napi/scripts/patch-wasi-browser-shim.test.mjs
@@ -1,0 +1,150 @@
+// Unit tests for scripts/patch-wasi-browser-shim.mjs. Exercises the patch
+// against synthetic shim contents so the gate fires even on jobs that do
+// not build the wasm binding.
+
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(__dirname, 'patch-wasi-browser-shim.mjs');
+const REAL_SHIM = join(__dirname, '..', 'coverage-instrument.wasi-browser.js');
+const SENTINEL = '// oxc-coverage-instrument: SharedArrayBuffer guard (issue #89)';
+
+const SYNTHETIC_SHIM = `import {
+  createOnMessage as __wasmCreateOnMessageForFsProxy,
+  getDefaultContext as __emnapiGetDefaultContext,
+  instantiateNapiModuleSync as __emnapiInstantiateNapiModuleSync,
+  WASI as __WASI,
+} from '@napi-rs/wasm-runtime'
+
+
+
+const __wasi = new __WASI({ version: 'preview1' })
+const __wasmUrl = new URL('./coverage-instrument.wasm32-wasi.wasm', import.meta.url).href
+const __sharedMemory = new WebAssembly.Memory({ initial: 4000, maximum: 65536, shared: true })
+`;
+
+// Run the patch script with a stand-in shim at the expected location. We
+// can't override the script's resolved path, so swap the real shim aside
+// for the duration of the test if present.
+function runWith(syntheticContents) {
+  let backup = null;
+  if (existsSync(REAL_SHIM)) {
+    backup = `${REAL_SHIM}.test-backup`;
+    renameSync(REAL_SHIM, backup);
+  }
+  try {
+    writeFileSync(REAL_SHIM, syntheticContents);
+    const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+    const after = readFileSync(REAL_SHIM, 'utf8');
+    return { result, after };
+  } finally {
+    rmSync(REAL_SHIM, { force: true });
+    if (backup) {
+      renameSync(backup, REAL_SHIM);
+    }
+  }
+}
+
+console.log('Testing patch-wasi-browser-shim.mjs...\n');
+
+// Test 1: guard is injected on a fresh shim
+{
+  const { result, after } = runWith(SYNTHETIC_SHIM);
+  assert.equal(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
+  assert.ok(after.includes(SENTINEL), 'guard sentinel missing after patch');
+  assert.ok(
+    after.includes("typeof SharedArrayBuffer === 'undefined'"),
+    'SharedArrayBuffer check missing',
+  );
+  assert.ok(
+    after.includes('Cross-Origin-Opener-Policy'),
+    'COOP guidance missing from error message',
+  );
+  assert.ok(
+    after.includes('Cross-Origin-Embedder-Policy'),
+    'COEP guidance missing from error message',
+  );
+  // Guard must precede the shared-memory allocation.
+  assert.ok(
+    after.indexOf(SENTINEL) < after.indexOf('new WebAssembly.Memory'),
+    'guard injected after WebAssembly.Memory allocation',
+  );
+  console.log('  [PASS] Guard injected with diagnostic prose');
+}
+
+// Test 2: idempotent (second run is a no-op)
+{
+  const patchedOnce = runWith(SYNTHETIC_SHIM).after;
+  const { result, after } = runWith(patchedOnce);
+  assert.equal(result.status, 0, 'second run should succeed');
+  assert.equal(after, patchedOnce, 'second run mutated already-patched shim');
+  // Sentinel should appear exactly once.
+  const occurrences = after.split(SENTINEL).length - 1;
+  assert.equal(occurrences, 1, `expected exactly 1 sentinel, found ${occurrences}`);
+  console.log('  [PASS] Idempotent on re-run');
+}
+
+// Test 3: missing shim is a no-op (non-wasm builds)
+{
+  let backup = null;
+  if (existsSync(REAL_SHIM)) {
+    backup = `${REAL_SHIM}.test-backup`;
+    renameSync(REAL_SHIM, backup);
+  }
+  try {
+    const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+    assert.equal(result.status, 0, 'missing shim should exit 0');
+    assert.ok(
+      !existsSync(REAL_SHIM),
+      'patch script created a shim where none existed',
+    );
+    console.log('  [PASS] Missing shim is a no-op');
+  } finally {
+    if (backup) {
+      renameSync(backup, REAL_SHIM);
+    }
+  }
+}
+
+// Test 4: malformed shim (no import block) errors loudly
+{
+  const tmp = mkdtempSync(join(tmpdir(), 'patch-shim-test-'));
+  let backup = null;
+  if (existsSync(REAL_SHIM)) {
+    backup = `${REAL_SHIM}.test-backup`;
+    copyFileSync(REAL_SHIM, backup);
+    rmSync(REAL_SHIM);
+  }
+  try {
+    writeFileSync(REAL_SHIM, 'const x = 1;\n');
+    const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+    assert.notEqual(result.status, 0, 'malformed shim should exit non-zero');
+    assert.ok(
+      result.stderr.includes('could not locate'),
+      `expected diagnostic stderr, got: ${result.stderr}`,
+    );
+    console.log('  [PASS] Malformed shim errors loudly');
+  } finally {
+    rmSync(REAL_SHIM, { force: true });
+    if (backup) {
+      copyFileSync(backup, REAL_SHIM);
+      rmSync(backup);
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+console.log('\nAll patch-shim tests passed.');


### PR DESCRIPTION
## Summary

When the host page is missing the COOP / COEP headers required for cross-origin isolation, `SharedArrayBuffer` is undefined and the napi-generated `coverage-instrument.wasi-browser.js` shim throws an opaque `TypeError` from inside `new WebAssembly.Memory({ shared: true })`. Users have no signal that the fix lives on the host page, not in their bundler or this package.

This adds a postbuild patch that injects a `SharedArrayBuffer` guard at the top of the regenerated shim so the failure surfaces a precise diagnostic pointing at COOP/COEP and the README runtime matrix.

## Approach

- New script `crates/oxc-coverage-instrument-napi/scripts/patch-wasi-browser-shim.mjs` rewrites the shim after each `napi build`. Idempotent via a sentinel comment, no-op when the shim is absent (non-wasm builds), errors loudly when the import block can't be located.
- Wired into the napi crate's `build` and `build:debug` scripts.
- Added a workflow step after `Build native binding` in `release-npm.yml` (runs across the matrix; no-op on native targets) and after `Build wasm32-wasi binding` in `ci.yml`.
- New `scripts/patch-wasi-browser-shim.test.mjs` exercises guard injection, idempotency, missing-shim no-op, and malformed-shim error paths. Chained into `npm test` so accidentally removing the patch breaks the gate.

## Test plan

- [x] `npm test` in the napi crate (existing tests + 4 new patch-shim tests)
- [x] `cargo check --workspace`
- [x] `node --check` on the patched shim
- [x] VM-context smoke: extracted guard executed against `delete globalThis.SharedArrayBuffer` throws an Error mentioning `oxc-coverage-instrument`, `SharedArrayBuffer`, `Cross-Origin-Opener-Policy`, `Cross-Origin-Embedder-Policy`, and `#runtime-matrix`; with `SharedArrayBuffer` present the guard is a silent no-op
- [ ] CI green on the wasm32-wasi job

Closes #89