### PR TITLE
feat: add single-threaded WASI binding for Workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,24 +180,34 @@ jobs:
         run: node scripts/istanbul-upstream-specs.mjs
 
   napi-wasm:
-    # Build the napi binding for wasm32-wasip1-threads and run the full test
-    # suite under NAPI_RS_FORCE_WASI=error so the WASI binding is exercised
-    # end-to-end on every PR (the `error` value fails fast if the WASI binding
-    # cannot be loaded, instead of silently falling back to the native one).
+    # Build the napi binding for both WASI variants. The threaded variant runs
+    # the full test suite under NAPI_RS_FORCE_WASI=error; the single-threaded
+    # variant runs the issue #87 instrument() smoke while the broader JS
+    # package surface is wired in parallel.
     # Catches regressions that compile against native libc but not against the
     # wasm32 emulated environment.
-    name: Napi Test (wasm32-wasi)
+    name: Napi Test (${{ matrix.variant }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: wasm32-wasip1-threads
+            target: wasm32-wasip1-threads
+            wasi_link_dir: ''
+          - variant: wasm32-wasip1
+            target: wasm32-wasip1
+            wasi_link_dir: wasm32-wasip1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup-rust
         with:
-          cache-key: napi-wasm
-          targets: wasm32-wasip1-threads
+          cache-key: napi-wasm-${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -207,16 +217,38 @@ jobs:
         working-directory: crates/oxc-coverage-instrument-napi
         run: npm ci || npm install
 
+      - name: Patch napi-rs WASI link dir selector
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-napi-wasi-link-dir.mjs
+
       - name: Build wasm32-wasi binding
         working-directory: crates/oxc-coverage-instrument-napi
-        run: npx napi build --release --platform --target wasm32-wasip1-threads
+        env:
+          NAPI_RS_WASI_LINK_DIR: ${{ matrix.wasi_link_dir }}
+        run: |
+          rm -f coverage-instrument.wasm32-wasi*.wasm
+          npx napi build --release --platform --target ${{ matrix.target }}
+
+      - name: Patch single-threaded WASI artifacts
+        if: matrix.target == 'wasm32-wasip1'
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-wasi-singlethreaded-artifacts.mjs .
 
       # Inject the SharedArrayBuffer guard into the regenerated browser shim
       # (issue #89). The shim is rewritten by `napi build`, so the patch must
       # run after every wasm build that emits it.
       - name: Patch wasi-browser shim with SharedArrayBuffer guard
+        if: matrix.target == 'wasm32-wasip1-threads'
         working-directory: crates/oxc-coverage-instrument-napi
         run: node scripts/patch-wasi-browser-shim.mjs
+
+      - name: Patch root browser loader
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-browser-loader.mjs
+
+      - name: Test browser loader package selection
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: npm run test:browser-loader
 
       # The optionalDependency `@oxc-coverage-instrument/binding-wasm32-wasi`
       # is pinned at the previously published version; the loader in
@@ -227,37 +259,27 @@ jobs:
       # freshly-built local artifact; if napi build failed to produce it, the
       # loader fails loudly instead of pretending to test the new code.
       - name: Force loader to use freshly-built local wasm
-        working-directory: crates/oxc-coverage-instrument-napi
-        run: |
-          ls -la coverage-instrument.wasm32-wasi*.wasm || true
-          rm -f node_modules/@oxc-coverage-instrument/binding-wasm32-wasi/*.wasm
+        run: node scripts/force-local-wasm-artifacts.mjs
 
-      - name: Run napi tests against wasm binding
+      - name: Run threaded napi tests against wasm binding
+        if: matrix.target == 'wasm32-wasip1-threads'
         working-directory: crates/oxc-coverage-instrument-napi
         env:
           NAPI_RS_FORCE_WASI: error
-        run: node test.mjs
+        run: npm test
+
+      - name: Run single-threaded instrument smoke
+        if: matrix.target == 'wasm32-wasip1'
+        env:
+          NAPI_RS_FORCE_WASI: error
+        run: node scripts/wasm-instrument-smoke.mjs
 
       - name: Report wasm size and enforce ceiling
-        working-directory: crates/oxc-coverage-instrument-napi
-        # Issue #46 acceptance target: WASM artifact size <2 MB compressed.
+        # Issue #46 and #87 acceptance target: each WASM artifact size <2 MB compressed.
         # The ceiling is gated on brotli (the best compressor of the three);
         # baseline at branch-cut was 0.58 MB, leaving ~3.5x headroom for
         # dependency drift before the gate fires.
-        env:
-          MAX_BROTLI_BYTES: 2097152
-        run: |
-          ls -lh *.wasm
-          raw=$(wc -c < coverage-instrument.wasm32-wasi.wasm)
-          gz=$(gzip -9 -c coverage-instrument.wasm32-wasi.wasm | wc -c)
-          br=$(brotli -q 11 -c coverage-instrument.wasm32-wasi.wasm | wc -c)
-          printf '%-12s%10d  %.2f MB\n' 'raw'    "$raw" "$(echo "scale=2; $raw/1048576" | bc)"
-          printf '%-12s%10d  %.2f MB\n' 'gzip -9' "$gz"  "$(echo "scale=2; $gz/1048576"  | bc)"
-          printf '%-12s%10d  %.2f MB\n' 'brotli'  "$br"  "$(echo "scale=2; $br/1048576"  | bc)"
-          if [ "$br" -gt "$MAX_BROTLI_BYTES" ]; then
-            echo "::error::Brotli-compressed wasm size $br exceeds ceiling $MAX_BROTLI_BYTES (~2 MB). Issue #46 acceptance target violated."
-            exit 1
-          fi
+        run: node scripts/wasm-size-check.mjs crates/oxc-coverage-instrument-napi/coverage-instrument.wasm32-wasi.wasm
 
   istanbul-diff:
     # Byte-for-byte diff against istanbul-lib-instrument on the shared
@@ -341,23 +363,33 @@ jobs:
         run: npm run verify
 
   native-vs-wasm-parity:
-    # Byte-for-byte parity between the native and WASM (wasm32-wasip1-threads)
+    # Byte-for-byte parity between the native binding and each WASM variant
     # napi bindings on every conformance fixture. The existing `istanbul-diff`
     # job only runs the native binding; this job catches the case where a
     # future change subtly diverges WASM output from native (e.g. a
     # cfg(target_arch = "wasm32") branch that affects coverage shape).
-    name: Native vs WASM parity
+    name: Native vs WASM parity (${{ matrix.variant }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: wasm32-wasip1-threads
+            target: wasm32-wasip1-threads
+            wasi_link_dir: ''
+          - variant: wasm32-wasip1
+            target: wasm32-wasip1
+            wasi_link_dir: wasm32-wasip1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup-rust
         with:
-          cache-key: native-vs-wasm-parity
-          targets: wasm32-wasip1-threads
+          cache-key: native-vs-wasm-parity-${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -367,47 +399,75 @@ jobs:
         working-directory: crates/oxc-coverage-instrument-napi
         run: npm ci || npm install
 
+      - name: Patch napi-rs WASI link dir selector
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-napi-wasi-link-dir.mjs
+
       - name: Build native napi binding
         working-directory: crates/oxc-coverage-instrument-napi
         run: npx napi build --release --platform
 
       - name: Build wasm32-wasi napi binding
         working-directory: crates/oxc-coverage-instrument-napi
-        run: npx napi build --release --platform --target wasm32-wasip1-threads
+        env:
+          NAPI_RS_WASI_LINK_DIR: ${{ matrix.wasi_link_dir }}
+        run: |
+          rm -f coverage-instrument.wasm32-wasi*.wasm
+          npx napi build --release --platform --target ${{ matrix.target }}
+
+      - name: Patch single-threaded WASI artifacts
+        if: matrix.target == 'wasm32-wasip1'
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-wasi-singlethreaded-artifacts.mjs .
 
       - name: Patch wasi-browser shim with SharedArrayBuffer guard
+        if: matrix.target == 'wasm32-wasip1-threads'
         working-directory: crates/oxc-coverage-instrument-napi
         run: node scripts/patch-wasi-browser-shim.mjs
+
+      - name: Patch root browser loader
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-browser-loader.mjs
 
       # See napi-wasm job for rationale: prevent the wasi loader from falling
       # back to the previously published artifact if the local build is missing.
       - name: Force loader to use freshly-built local wasm
-        working-directory: crates/oxc-coverage-instrument-napi
-        run: |
-          ls -la coverage-instrument.wasm32-wasi*.wasm || true
-          rm -f node_modules/@oxc-coverage-instrument/binding-wasm32-wasi/*.wasm
+        run: node scripts/force-local-wasm-artifacts.mjs
 
       - name: Run native-vs-wasm parity
+        env:
+          OXC_COVERAGE_WASM_VARIANT: ${{ matrix.variant }}
         run: node scripts/native-vs-wasm-parity.mjs
 
   wasm-node-example:
-    # End-to-end smoke for the wasm-node example: builds both bindings, then
+    # End-to-end smoke for the wasm-node example: builds native plus each WASM
+    # variant, then
     # exercises both `npm run smoke` (native-preferred load) and
     # `npm run smoke:wasi` (NAPI_RS_FORCE_WASI=error) against the example's
     # `instrument()` call. Catches regressions where the published smoke
     # scripts drift away from the loader contract.
-    name: WASM node example
+    name: WASM node example (${{ matrix.variant }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: wasm32-wasip1-threads
+            target: wasm32-wasip1-threads
+            wasi_link_dir: ''
+          - variant: wasm32-wasip1
+            target: wasm32-wasip1
+            wasi_link_dir: wasm32-wasip1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup-rust
         with:
-          cache-key: wasm-node-example
-          targets: wasm32-wasip1-threads
+          cache-key: wasm-node-example-${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -417,17 +477,35 @@ jobs:
         working-directory: crates/oxc-coverage-instrument-napi
         run: npm ci || npm install
 
+      - name: Patch napi-rs WASI link dir selector
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-napi-wasi-link-dir.mjs
+
       - name: Build native napi binding
         working-directory: crates/oxc-coverage-instrument-napi
         run: npx napi build --release --platform
 
       - name: Build wasm32-wasi napi binding
         working-directory: crates/oxc-coverage-instrument-napi
-        run: npx napi build --release --platform --target wasm32-wasip1-threads
+        env:
+          NAPI_RS_WASI_LINK_DIR: ${{ matrix.wasi_link_dir }}
+        run: |
+          rm -f coverage-instrument.wasm32-wasi*.wasm
+          npx napi build --release --platform --target ${{ matrix.target }}
+
+      - name: Patch single-threaded WASI artifacts
+        if: matrix.target == 'wasm32-wasip1'
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-wasi-singlethreaded-artifacts.mjs .
 
       - name: Patch wasi-browser shim with SharedArrayBuffer guard
+        if: matrix.target == 'wasm32-wasip1-threads'
         working-directory: crates/oxc-coverage-instrument-napi
         run: node scripts/patch-wasi-browser-shim.mjs
+
+      - name: Patch root browser loader
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-browser-loader.mjs
 
       - name: Install example deps
         working-directory: examples/wasm-node
@@ -439,9 +517,7 @@ jobs:
       # shadow the freshly-built local wasm. Strip it so the loader has no
       # choice but to use the artifact under test.
       - name: Force loader to use freshly-built local wasm
-        run: |
-          rm -f crates/oxc-coverage-instrument-napi/node_modules/@oxc-coverage-instrument/binding-wasm32-wasi/*.wasm
-          rm -f examples/wasm-node/node_modules/@oxc-coverage-instrument/binding-wasm32-wasi/*.wasm
+        run: node scripts/force-local-wasm-artifacts.mjs
 
       - name: Run smoke (native binding)
         working-directory: examples/wasm-node
@@ -450,6 +526,93 @@ jobs:
       - name: Run smoke (WASI binding)
         working-directory: examples/wasm-node
         run: npm run smoke:wasi
+
+  cloudflare-workers-example:
+    # Secret-free Workers acceptance smoke for the single-threaded wasm target.
+    # The job builds the local wasm32-wasip1 artifact, creates a local optional
+    # package from that artifact, bundles with Wrangler, then runs the Worker in
+    # local workerd and compares its FileCoverage byte-for-byte with native.
+    name: Cloudflare Workers example
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache-key: cloudflare-workers-example
+          targets: wasm32-wasip1,wasm32-wasip1-threads
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Install napi deps
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: npm ci || npm install
+
+      - name: Patch napi-rs WASI link dir selector
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-napi-wasi-link-dir.mjs
+
+      - name: Build native napi binding
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: npx napi build --release --platform
+
+      - name: Build threaded wasm32-wasi napi binding
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: |
+          rm -f coverage-instrument.wasm32-wasi*.wasm
+          npx napi build --release --platform --target wasm32-wasip1-threads
+
+      - name: Patch threaded wasi-browser shim
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: |
+          node scripts/patch-wasi-browser-shim.mjs
+          node scripts/patch-browser-loader.mjs
+
+      - name: Install Workers example deps
+        working-directory: examples/cloudflare-workers
+        run: npm install
+
+      - name: Prepare local threaded optional package
+        run: |
+          node scripts/force-local-wasm-artifacts.mjs
+          node scripts/prepare-local-wasm-package.mjs \
+            --package-name @oxc-coverage-instrument/binding-wasm32-wasi \
+            --install-root crates/oxc-coverage-instrument-napi \
+            --install-root examples/cloudflare-workers
+
+      - name: Build single-threaded wasm32-wasi napi binding
+        working-directory: crates/oxc-coverage-instrument-napi
+        env:
+          NAPI_RS_WASI_LINK_DIR: wasm32-wasip1
+        run: |
+          rm -f coverage-instrument.wasm32-wasi*.wasm
+          npx napi build --release --platform --target wasm32-wasip1
+          node scripts/patch-wasi-singlethreaded-artifacts.mjs .
+          node scripts/patch-browser-loader.mjs
+
+      - name: Prepare local single-threaded optional package
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: |
+          node scripts/prepare-wasi-singlethreaded-package.mjs . \
+            --install-root . \
+            --install-root ../../examples/cloudflare-workers
+
+      - name: Validate local single-threaded optional package
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/validate-wasi-singlethreaded-package.mjs npm/wasm32-wasi-singlethreaded
+
+      - name: Bundle Worker
+        working-directory: examples/cloudflare-workers
+        run: npm run build
+
+      - name: Smoke Worker against native FileCoverage
+        working-directory: examples/cloudflare-workers
+        run: npm run smoke
 
   ci-ok:
     name: CI
@@ -469,6 +632,7 @@ jobs:
       - vitest-typescript-example
       - native-vs-wasm-parity
       - wasm-node-example
+      - cloudflare-workers-example
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -65,6 +65,10 @@ jobs:
           # be absent from the tarball, breaking the browser export only
           # for that one release. Track the wasm regression separately.
           - os: ubuntu-latest
+            target: wasm32-wasip1
+            build: NAPI_RS_WASI_LINK_DIR=wasm32-wasip1 npx napi build --release --platform --target wasm32-wasip1
+
+          - os: ubuntu-latest
             target: wasm32-wasip1-threads
             build: npx napi build --release --platform --target wasm32-wasip1-threads
 
@@ -107,17 +111,31 @@ jobs:
         working-directory: crates/oxc-coverage-instrument-napi
         run: npm ci || npm install
 
+      - name: Patch napi-rs WASI link dir selector
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-napi-wasi-link-dir.mjs
+
       - name: Build native binding
         working-directory: crates/oxc-coverage-instrument-napi
         run: ${{ matrix.build }}
+
+      - name: Patch single-threaded WASI artifacts
+        if: matrix.target == 'wasm32-wasip1'
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-wasi-singlethreaded-artifacts.mjs .
 
       # Inject the SharedArrayBuffer guard into the regenerated browser shim
       # (issue #89). The shim is only emitted by the wasm32-wasip1-threads
       # matrix entry; the patch script is a no-op when the shim is absent,
       # so it is safe to run unconditionally across the matrix.
       - name: Patch wasi-browser shim with SharedArrayBuffer guard
+        if: matrix.target == 'wasm32-wasip1-threads'
         working-directory: crates/oxc-coverage-instrument-napi
         run: node scripts/patch-wasi-browser-shim.mjs
+
+      - name: Patch root browser loader
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-browser-loader.mjs
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -228,6 +246,12 @@ jobs:
         with:
           path: crates/oxc-coverage-instrument-napi/artifacts
 
+      - name: Isolate single-threaded wasm artifact
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: |
+          mkdir -p artifacts-singlethreaded
+          mv artifacts/bindings-wasm32-wasip1 artifacts-singlethreaded/
+
       - name: Move artifacts into npm dirs
         # `--build-output-dir` tells `napi artifacts` where to find the wasi
         # shim files (coverage-instrument.wasi.cjs, *-browser.js, wasi-worker*.mjs)
@@ -236,6 +260,14 @@ jobs:
         # wasm32-wasi npm-dir population step.
         working-directory: crates/oxc-coverage-instrument-napi
         run: npx napi artifacts --output-dir artifacts --build-output-dir artifacts/bindings-wasm32-wasip1-threads
+
+      - name: Prepare single-threaded WASI npm package
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/prepare-wasi-singlethreaded-package.mjs artifacts-singlethreaded/bindings-wasm32-wasip1
+
+      - name: Validate single-threaded WASI npm package
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/validate-wasi-singlethreaded-package.mjs npm/wasm32-wasi-singlethreaded
 
       - name: Restore JS/TS wrapper from build artifacts
         # The JS/TS wrapper files (index.js, index.d.ts) are gitignored because
@@ -284,6 +316,10 @@ jobs:
           done
           echo "Restored wasm shims from $src"
 
+      - name: Patch root browser loader
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: node scripts/patch-browser-loader.mjs
+
       - name: Update versions from tag
         working-directory: crates/oxc-coverage-instrument-napi
         run: |
@@ -307,6 +343,21 @@ jobs:
       - name: Prepare root package
         working-directory: crates/oxc-coverage-instrument-napi
         run: npx napi pre-publish --no-gh-release -t npm --skip-optional-publish
+
+      - name: Restore single-threaded optional dependency
+        working-directory: crates/oxc-coverage-instrument-napi
+        run: |
+          VERSION="${TAG_REF#refs/tags/v}"
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.optionalDependencies ||= {};
+            pkg.optionalDependencies['@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded'] = '$VERSION';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Verify npm pack surfaces
+        run: node scripts/npm-pack-surface-check.mjs
 
       - name: Publish platform packages
         working-directory: crates/oxc-coverage-instrument-napi

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,11 @@ node_modules/
 /coverage/
 crates/*/coverage/
 examples/*/coverage/
+examples/*/.wrangler/
+examples/*/dist/
 examples/*/node_modules/
 examples/*/package-lock.json
+!examples/cloudflare-workers/package-lock.json
 
 # napi build artifacts
 *.node
@@ -32,6 +35,10 @@ crates/oxc-coverage-instrument-napi/coverage-instrument.wasi.cjs
 crates/oxc-coverage-instrument-napi/coverage-instrument.wasi-browser.js
 crates/oxc-coverage-instrument-napi/wasi-worker.mjs
 crates/oxc-coverage-instrument-napi/wasi-worker-browser.mjs
+crates/oxc-coverage-instrument-napi/npm/*/coverage-instrument.wasi.cjs
+crates/oxc-coverage-instrument-napi/npm/*/coverage-instrument.wasi-browser.js
+crates/oxc-coverage-instrument-napi/npm/*/wasi-worker.mjs
+crates/oxc-coverage-instrument-napi/npm/*/wasi-worker-browser.mjs
 crates/oxc-coverage-instrument-napi/node_modules/
 crates/oxc-coverage-instrument-napi/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -431,19 +431,20 @@ The `html` format writes a self-contained directory tree (`--output-dir`, defaul
 
 ### Runtime matrix
 
-`oxc-coverage-instrument` ships prebuilt native bindings for seven platforms plus a WebAssembly fallback (`@oxc-coverage-instrument/binding-wasm32-wasi`, ~2.8 MB raw / ~0.6 MB brotli). The wasm binding is selected automatically when no matching native binary is available, or explicitly via `NAPI_RS_FORCE_WASI` (see [Forcing the WASM binding](#forcing-the-wasm-binding) below).
+`oxc-coverage-instrument` ships prebuilt native bindings for seven platforms plus WebAssembly fallbacks (`@oxc-coverage-instrument/binding-wasm32-wasi` for runtimes with `SharedArrayBuffer`, and a single-threaded `wasm32-wasip1` variant for runtimes that disallow shared memory). The wasm binding is selected automatically when no matching native binary is available, or explicitly via `NAPI_RS_FORCE_WASI` (see [Forcing the WASM binding](#forcing-the-wasm-binding) below).
 
 | Runtime | Status | Notes |
 |:--------|:-------|:------|
 | Node 18+ (darwin/linux/win32, x64/arm64) | native | Preferred when a matching `.node` is installed. |
 | Node 22 LTS (any arch) | wasm fallback | Loads via `node:wasi`; emits an experimental-feature warning. |
 | Deno 2.x | wasm | Uses Deno's `node:wasi` polyfill. Live deploy smoke tracked in [#88](https://github.com/fallow-rs/oxc-coverage-instrument/issues/88). |
-| Browser (with COOP/COEP) | wasm | Imports the `browser` export. Requires `SharedArrayBuffer` (set `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` on the host page) AND an ESM bundler with top-level await support (Vite 2+, webpack 5 with `experiments.topLevelAwait: true`, esbuild, rollup with `output.format: 'esm'`). webpack 4 and Parcel 1 are not supported. |
+| Browser (with COOP/COEP) | threaded wasm | Imports the `browser` export. Uses the threaded `wasm32-wasip1-threads` binding when `SharedArrayBuffer` is available (set `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` on the host page) and an ESM bundler with top-level await support is present. webpack 4 and Parcel 1 are not supported. |
+| Browser (without COOP/COEP) | single-threaded wasm | Falls back to the `wasm32-wasip1` binding when `SharedArrayBuffer` is unavailable. |
 | Bun (supported targets) | native | Bun's `node:wasi` is incomplete ([oven-sh/bun#16156](https://github.com/oven-sh/bun/issues/16156)); falls back to the native binding. |
-| Cloudflare Workers | not yet | Workers lacks `SharedArrayBuffer`. Single-threaded `wasm32-wasip1` build tracked in [#87](https://github.com/fallow-rs/oxc-coverage-instrument/issues/87). |
+| Cloudflare Workers | single-threaded wasm | Workers lacks `SharedArrayBuffer`; the `browser` export selects the `wasm32-wasip1` binding. `examples/cloudflare-workers/` verifies Worker `FileCoverage` against native output byte-for-byte. |
 | StackBlitz / WebContainer | partial | Newer WebContainer images load the wasm binding; older ones may fall through. Live smoke tracked in [#88](https://github.com/fallow-rs/oxc-coverage-instrument/issues/88). |
 
-See `examples/wasm-node/` for a complete end-to-end smoke that exercises both bindings.
+See `examples/wasm-node/` for a complete end-to-end Node smoke that exercises native plus WASM. `examples/cloudflare-workers/` contains the secret-free Workers acceptance smoke that compares Worker `FileCoverage` with native output byte-for-byte.
 
 #### Forcing the WASM binding
 

--- a/crates/oxc-coverage-instrument-napi/npm/wasm32-wasi-singlethreaded/README.md
+++ b/crates/oxc-coverage-instrument-napi/npm/wasm32-wasi-singlethreaded/README.md
@@ -1,0 +1,9 @@
+# `@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded`
+
+This is the **wasm32-wasip1** single-threaded binding for `@oxc-coverage-instrument/binding`.
+
+It is selected automatically by the host package `oxc-coverage-instrument` from the `browser` export when `SharedArrayBuffer` is unavailable. That covers Cloudflare Workers, browsers without COOP/COEP isolation, and other runtimes that disallow shared WebAssembly memory.
+
+When `SharedArrayBuffer` is available, the host package prefers `@oxc-coverage-instrument/binding-wasm32-wasi`, the threaded **wasm32-wasip1-threads** binding.
+
+See the main package's README for the full runtime support matrix.

--- a/crates/oxc-coverage-instrument-napi/npm/wasm32-wasi-singlethreaded/package.json
+++ b/crates/oxc-coverage-instrument-napi/npm/wasm32-wasi-singlethreaded/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded",
+  "version": "0.7.2",
+  "main": "coverage-instrument.wasi.cjs",
+  "browser": "coverage-instrument.wasi-browser.js",
+  "files": [
+    "coverage-instrument.wasm32-wasi.wasm",
+    "coverage-instrument.wasi.cjs",
+    "coverage-instrument.wasi-browser.js",
+    "wasi-worker.mjs",
+    "wasi-worker-browser.mjs"
+  ],
+  "description": "Single-threaded WASI WebAssembly binding for oxc-coverage-instrument.",
+  "keywords": [
+    "oxc",
+    "istanbul",
+    "coverage",
+    "javascript",
+    "typescript",
+    "instrumentation",
+    "code-coverage",
+    "wasm",
+    "wasi"
+  ],
+  "homepage": "https://github.com/fallow-rs/oxc-coverage-instrument",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fallow-rs/oxc-coverage-instrument.git",
+    "directory": "napi"
+  },
+  "bugs": "https://github.com/fallow-rs/oxc-coverage-instrument/issues",
+  "dependencies": {
+    "@napi-rs/wasm-runtime": "^1.1.4"
+  }
+}

--- a/crates/oxc-coverage-instrument-napi/npm/wasm32-wasi/README.md
+++ b/crates/oxc-coverage-instrument-napi/npm/wasm32-wasi/README.md
@@ -2,9 +2,12 @@
 
 This is the **wasm32-wasip1-threads** binding for `@oxc-coverage-instrument/binding`. It is selected automatically by the host package `oxc-coverage-instrument` when:
 
-- the host runtime has no matching native binding (e.g., browsers with `SharedArrayBuffer` enabled, Deno using the `node:wasi` shim), OR
+- the browser runtime exposes `SharedArrayBuffer`, OR
+- the Node/Deno host runtime has no matching native binding and loads the WASI fallback, OR
 - the consumer sets `NAPI_RS_FORCE_WASI=1` explicitly to bypass the native binding.
 
-**Currently unsupported runtimes**: Cloudflare Workers lacks `SharedArrayBuffer`, which `wasm32-wasip1-threads` requires. Bun's `node:wasi` is incomplete (no `wasi.initialize()`), so the wasm binding does not load there; Bun on its officially-supported platforms uses the native binding instead.
+Browsers and edge runtimes without `SharedArrayBuffer` (including Cloudflare Workers and pages without COOP/COEP isolation) are served by `@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded` through the host package's `browser` export instead.
+
+**Currently unsupported runtimes**: Bun's `node:wasi` is incomplete (no `wasi.initialize()`), so the wasm binding does not load there; Bun on its officially-supported platforms uses the native binding instead.
 
 See the main package's README for the full runtime support matrix.

--- a/crates/oxc-coverage-instrument-napi/package.json
+++ b/crates/oxc-coverage-instrument-napi/package.json
@@ -55,6 +55,7 @@
       "x86_64-unknown-linux-musl",
       "x86_64-pc-windows-msvc",
       "aarch64-pc-windows-msvc",
+      "wasm32-wasip1",
       "wasm32-wasip1-threads"
     ]
   },
@@ -62,16 +63,17 @@
     "@napi-rs/wasm-runtime": "^1.1.4"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3.6.0",
+    "@napi-rs/cli": "3.6.2",
     "istanbul-lib-instrument": "^6.0.3"
   },
   "scripts": {
-    "build": "napi build --release --platform && node scripts/patch-wasi-browser-shim.mjs",
-    "build:debug": "napi build --platform && node scripts/patch-wasi-browser-shim.mjs",
-    "patch-shim": "node scripts/patch-wasi-browser-shim.mjs",
+    "build": "napi build --release --platform && npm run patch-shim",
+    "build:debug": "napi build --platform && npm run patch-shim",
+    "patch-shim": "node scripts/patch-wasi-browser-shim.mjs && node scripts/patch-browser-loader.mjs",
     "prepublishOnly": "napi prepublish -t npm",
     "artifacts": "napi artifacts",
-    "test": "node test.mjs && node scripts/patch-wasi-browser-shim.test.mjs"
+    "test": "node test.mjs && node scripts/patch-wasi-browser-shim.test.mjs",
+    "test:browser-loader": "node scripts/browser-loader.test.mjs"
   },
   "optionalDependencies": {
     "@oxc-coverage-instrument/binding-darwin-arm64": "0.7.2",
@@ -81,6 +83,7 @@
     "@oxc-coverage-instrument/binding-linux-x64-musl": "0.7.2",
     "@oxc-coverage-instrument/binding-win32-arm64-msvc": "0.7.2",
     "@oxc-coverage-instrument/binding-win32-x64-msvc": "0.7.2",
-    "@oxc-coverage-instrument/binding-wasm32-wasi": "0.7.2"
+    "@oxc-coverage-instrument/binding-wasm32-wasi": "0.7.2",
+    "@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded": "0.7.2"
   }
 }

--- a/crates/oxc-coverage-instrument-napi/scripts/browser-loader.test.mjs
+++ b/crates/oxc-coverage-instrument-napi/scripts/browser-loader.test.mjs
@@ -1,0 +1,111 @@
+// Unit tests for browser.js package selection. The test imports a temporary
+// copy of browser.js with stub optional dependencies so it does not need real
+// wasm artifacts or a Workers account.
+
+import { strict as assert } from 'node:assert';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BROWSER_JS = join(__dirname, '..', 'browser.js');
+const THREADED = '@oxc-coverage-instrument/binding-wasm32-wasi';
+const SINGLE_THREADED = '@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded';
+
+function writeStubPackage(root, name, selectedName, shouldThrow = false) {
+  const packageDir = join(root, 'node_modules', ...name.split('/'));
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, 'package.json'),
+    JSON.stringify({ name, version: '0.0.0-test', type: 'module', exports: './index.js' }),
+  );
+  const body = shouldThrow
+    ? `throw new Error(${JSON.stringify(`unexpected import: ${name}`)});\n`
+    : `export function instrument() { return ${JSON.stringify(selectedName)}; }
+export function remapCoverageMap() { return ${JSON.stringify(selectedName)}; }
+export function remapCoverageMapWithLoader() { return ${JSON.stringify(selectedName)}; }
+export function v8ToIstanbul() { return ${JSON.stringify(selectedName)}; }
+export function v8ToIstanbulWithLoader() { return ${JSON.stringify(selectedName)}; }
+export default { selected: ${JSON.stringify(selectedName)} };
+`;
+  writeFileSync(join(packageDir, 'index.js'), body);
+}
+
+async function importBrowserLoader({ hasSharedArrayBuffer, forceSingleThreaded = false }) {
+  const root = mkdtempSync(join(tmpdir(), 'oxc-browser-loader-'));
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'SharedArrayBuffer');
+  const forceDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'OXC_COVERAGE_FORCE_WASI_SINGLE_THREADED',
+  );
+  try {
+    writeFileSync(join(root, 'package.json'), '{"type":"module"}\n');
+    writeFileSync(join(root, 'browser.mjs'), readFileSync(BROWSER_JS, 'utf8'));
+
+    if (hasSharedArrayBuffer) {
+      writeStubPackage(root, THREADED, 'threaded', forceSingleThreaded);
+      writeStubPackage(root, SINGLE_THREADED, 'single-threaded', !forceSingleThreaded);
+      Object.defineProperty(globalThis, 'SharedArrayBuffer', {
+        configurable: true,
+        writable: true,
+        value: function SharedArrayBufferStub() {},
+      });
+    } else {
+      writeStubPackage(root, THREADED, 'threaded', true);
+      writeStubPackage(root, SINGLE_THREADED, 'single-threaded');
+      Object.defineProperty(globalThis, 'SharedArrayBuffer', {
+        configurable: true,
+        writable: true,
+        value: undefined,
+      });
+    }
+    Object.defineProperty(globalThis, 'OXC_COVERAGE_FORCE_WASI_SINGLE_THREADED', {
+      configurable: true,
+      writable: true,
+      value: forceSingleThreaded,
+    });
+
+    return await import(pathToFileURL(join(root, 'browser.mjs')).href);
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(globalThis, 'SharedArrayBuffer', descriptor);
+    } else {
+      delete globalThis.SharedArrayBuffer;
+    }
+    if (forceDescriptor) {
+      Object.defineProperty(globalThis, 'OXC_COVERAGE_FORCE_WASI_SINGLE_THREADED', forceDescriptor);
+    } else {
+      delete globalThis.OXC_COVERAGE_FORCE_WASI_SINGLE_THREADED;
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+console.log('Testing browser.js wasm package selection...\n');
+
+{
+  const binding = await importBrowserLoader({ hasSharedArrayBuffer: true });
+  assert.equal(binding.instrument(), 'threaded');
+  assert.equal(binding.default.selected, 'threaded');
+  console.log('  [PASS] SharedArrayBuffer selects threaded wasm binding');
+}
+
+{
+  const binding = await importBrowserLoader({ hasSharedArrayBuffer: false });
+  assert.equal(binding.instrument(), 'single-threaded');
+  assert.equal(binding.default.selected, 'single-threaded');
+  console.log('  [PASS] Missing SharedArrayBuffer selects single-threaded wasm binding');
+}
+
+{
+  const binding = await importBrowserLoader({
+    hasSharedArrayBuffer: true,
+    forceSingleThreaded: true,
+  });
+  assert.equal(binding.instrument(), 'single-threaded');
+  assert.equal(binding.default.selected, 'single-threaded');
+  console.log('  [PASS] Force flag selects single-threaded wasm binding');
+}
+
+console.log('\nAll browser-loader tests passed.');

--- a/crates/oxc-coverage-instrument-napi/scripts/patch-browser-loader.mjs
+++ b/crates/oxc-coverage-instrument-napi/scripts/patch-browser-loader.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Post-build patch for the generated root browser export.
+//
+// napi-rs regenerates `browser.js` as a static re-export of the wasm32-wasi
+// package. This package ships two WASI browser bindings: the threaded build for
+// cross-origin-isolated hosts with SharedArrayBuffer, and a single-threaded
+// build for Workers / non-isolated browsers. Rewrite the root browser export to
+// pick the right optional dependency at module initialization time.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SENTINEL = '// oxc-coverage-instrument: browser WASI selector (issue #87)';
+const BROWSER_LOADER = `${SENTINEL}
+const binding =
+  globalThis.OXC_COVERAGE_FORCE_WASI_SINGLE_THREADED === true ||
+  typeof SharedArrayBuffer === 'undefined'
+    ? await import('@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded')
+    : await import('@oxc-coverage-instrument/binding-wasm32-wasi');
+
+const api = binding.default ?? binding;
+
+export default api;
+export const instrument = binding.instrument ?? api.instrument;
+export const remapCoverageMap = binding.remapCoverageMap ?? api.remapCoverageMap;
+export const remapCoverageMapWithLoader =
+  binding.remapCoverageMapWithLoader ?? api.remapCoverageMapWithLoader;
+export const v8ToIstanbul = binding.v8ToIstanbul ?? api.v8ToIstanbul;
+export const v8ToIstanbulWithLoader =
+  binding.v8ToIstanbulWithLoader ?? api.v8ToIstanbulWithLoader;
+`;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const browserPath = join(__dirname, '..', 'browser.js');
+
+if (!existsSync(browserPath)) {
+  console.log(`[patch-browser-loader] ${browserPath} not present; skipping.`);
+  process.exit(0);
+}
+
+const original = readFileSync(browserPath, 'utf8');
+if (original === BROWSER_LOADER) {
+  console.log('[patch-browser-loader] browser loader already patched; nothing to do.');
+  process.exit(0);
+}
+
+if (!original.includes(SENTINEL) && !original.includes('@oxc-coverage-instrument/binding-wasm32-wasi')) {
+  console.error('[patch-browser-loader] generated browser.js shape is unexpected; aborting.');
+  process.exit(1);
+}
+
+writeFileSync(browserPath, BROWSER_LOADER);
+console.log(`[patch-browser-loader] rewrote ${browserPath} with SharedArrayBuffer selector.`);

--- a/crates/oxc-coverage-instrument-napi/scripts/patch-napi-wasi-link-dir.mjs
+++ b/crates/oxc-coverage-instrument-napi/scripts/patch-napi-wasi-link-dir.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// napi-rs 3.6.x accepts `--target wasm32-wasip1`, but its build helper still
+// hardcodes a threaded emnapi link directory for every WASI target. That makes
+// the supposedly single-threaded artifact import shared memory and fail in
+// Workers. Patch the installed CLI so CI can choose the emnapi link directory
+// with `NAPI_RS_WASI_LINK_DIR=wasm32-wasip1`.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, '..', 'node_modules', '@napi-rs', 'cli', 'dist');
+const files = ['cli.js', 'index.js', 'index.cjs'];
+const threadedLinkDirs = new Set(['wasm32-wasi-threads', 'wasm32-wasip1-threads']);
+
+function patchSource(source) {
+  let patched = false;
+  const lines = source.split('\n').map((line) => {
+    if (!line.includes('const emnapi =') || !line.includes('lib')) {
+      return line;
+    }
+    for (const linkDir of threadedLinkDirs) {
+      const replacement = `process.env.NAPI_RS_WASI_LINK_DIR || "${linkDir}"`;
+      const quoted = `"${linkDir}"`;
+      if (line.includes(quoted)) {
+        patched = true;
+        return line.replace(quoted, replacement);
+      }
+      const singleQuoted = `'${linkDir}'`;
+      if (line.includes(singleQuoted)) {
+        patched = true;
+        return line.replace(singleQuoted, replacement);
+      }
+    }
+    return line;
+  });
+  return { source: lines.join('\n'), patched };
+}
+
+for (const file of files) {
+  const path = join(cliRoot, file);
+  if (!existsSync(path)) {
+    console.error(`[patch-napi-wasi-link-dir] missing ${path}; run npm install first.`);
+    process.exit(1);
+  }
+  const original = readFileSync(path, 'utf8');
+  if (original.includes('process.env.NAPI_RS_WASI_LINK_DIR')) {
+    console.log(`[patch-napi-wasi-link-dir] ${file} already patched.`);
+    continue;
+  }
+  const { source, patched } = patchSource(original);
+  if (!patched) {
+    console.error(`[patch-napi-wasi-link-dir] ${file} has unexpected napi-rs shape.`);
+    process.exit(1);
+  }
+  writeFileSync(path, source);
+  console.log(`[patch-napi-wasi-link-dir] patched ${file}.`);
+}

--- a/crates/oxc-coverage-instrument-napi/scripts/patch-wasi-singlethreaded-artifacts.mjs
+++ b/crates/oxc-coverage-instrument-napi/scripts/patch-wasi-singlethreaded-artifacts.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+// Post-build patch for the generated single-threaded WASI artifacts.
+//
+// napi-rs 3.6 emits the same worker/shared-memory shims for wasm32-wasip1 and
+// wasm32-wasip1-threads. The single-threaded artifact also marks one runtime
+// global immutable even though the generated code writes to it. Patch both
+// issues after `napi build --target wasm32-wasip1` and validate the result.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, '..');
+const targetDir = process.argv[2] ? resolve(packageRoot, process.argv[2]) : packageRoot;
+
+const threadedPackage = '@oxc-coverage-instrument/binding-wasm32-wasi';
+const singlePackage = '@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded';
+
+export function patchSingleThreadedWasm(buffer) {
+  if (WebAssembly.validate(buffer)) {
+    return { buffer, patched: false };
+  }
+
+  const bytes = Buffer.from(buffer);
+  let offset = 8;
+  let importedGlobals = 0;
+  const candidates = [];
+
+  const readU32 = () => {
+    let result = 0;
+    let shift = 0;
+    while (true) {
+      const byte = bytes[offset++];
+      result |= (byte & 0x7f) << shift;
+      if ((byte & 0x80) === 0) {
+        return result >>> 0;
+      }
+      shift += 7;
+    }
+  };
+
+  const skipString = () => {
+    const length = readU32();
+    offset += length;
+  };
+
+  const skipLimits = () => {
+    const flags = readU32();
+    readU32();
+    if (flags & 1) readU32();
+    if (flags & 2) readU32();
+  };
+
+  const skipInitExpr = () => {
+    while (offset < bytes.length) {
+      const opcode = bytes[offset++];
+      if (opcode === 0x0b) return;
+      if (opcode === 0x23 || opcode === 0x41) {
+        readU32();
+      } else if (opcode === 0x42) {
+        readU32();
+      } else if (opcode === 0x43) {
+        offset += 4;
+      } else if (opcode === 0x44) {
+        offset += 8;
+      } else {
+        throw new Error(`unsupported wasm global init opcode 0x${opcode.toString(16)}`);
+      }
+    }
+  };
+
+  while (offset < bytes.length) {
+    const sectionId = bytes[offset++];
+    const sectionLength = readU32();
+    const sectionEnd = offset + sectionLength;
+
+    if (sectionId === 2) {
+      const count = readU32();
+      for (let index = 0; index < count; index += 1) {
+        skipString();
+        skipString();
+        const kind = bytes[offset++];
+        if (kind === 0) {
+          readU32();
+        } else if (kind === 1) {
+          offset += 1;
+          skipLimits();
+        } else if (kind === 2) {
+          skipLimits();
+        } else if (kind === 3) {
+          offset += 1;
+          offset += 1;
+          importedGlobals += 1;
+        } else {
+          throw new Error(`unsupported wasm import kind ${kind}`);
+        }
+      }
+    } else if (sectionId === 6) {
+      const count = readU32();
+      for (let localIndex = 0; localIndex < count; localIndex += 1) {
+        const valtype = bytes[offset++];
+        const mutOffset = offset;
+        const mutability = bytes[offset++];
+        const globalIndex = importedGlobals + localIndex;
+        if (valtype === 0x7f && mutability === 0) {
+          candidates.push({ globalIndex, mutOffset });
+        }
+        skipInitExpr();
+      }
+    }
+
+    offset = sectionEnd;
+  }
+
+  for (const candidate of candidates) {
+    const patched = Buffer.from(bytes);
+    patched[candidate.mutOffset] = 1;
+    if (WebAssembly.validate(patched)) {
+      return { buffer: patched, patched: true, globalIndex: candidate.globalIndex };
+    }
+  }
+
+  throw new Error('failed to patch single-threaded wasm: no immutable i32 global made it valid');
+}
+
+export function patchSingleThreadedShim(source) {
+  const out = source
+    .replaceAll(threadedPackage, singlePackage)
+    .replace(
+      /\n\n\/\/ oxc-coverage-instrument: SharedArrayBuffer guard \(issue #89\)\nif \(typeof SharedArrayBuffer === 'undefined'\) \{\n  throw new Error\(\n    'oxc-coverage-instrument: the browser WASM binding requires SharedArrayBuffer\. ' \+\n      'Enable Cross-Origin-Opener-Policy: same-origin and ' \+\n      'Cross-Origin-Embedder-Policy: require-corp on your host page so the ' \+\n      'browser is cross-origin isolated\. See ' \+\n      'https:\/\/github\.com\/fallow-rs\/oxc-coverage-instrument#runtime-matrix',\n  \);\n\}\n/,
+      '\n',
+    )
+    .replaceAll(
+      'Cannot find coverage-instrument.wasm32-wasi.wasm file, and @oxc-coverage-instrument/binding-wasm32-wasi package is not installed.',
+      `Cannot find coverage-instrument.wasm32-wasi.wasm file, and ${singlePackage} package is not installed.`,
+    )
+    .replace(
+      /const __sharedMemory = new WebAssembly\.Memory\(\{\s*initial: 4000,\s*maximum: 65536,\s*shared: true,\s*\}\)/,
+      'const __sharedMemory = new WebAssembly.Memory({\n  initial: 4000,\n  maximum: 65536,\n})',
+    )
+    .replace(
+      'memory: __sharedMemory,\n    }',
+      'memory: __sharedMemory,\n      __tls_align: 1,\n      __tls_size: 0,\n      __wasm_init_tls: () => {},\n    }',
+    )
+    .replace(/asyncWorkPoolSize: 4,\n\s*/g, 'asyncWorkPoolSize: 0,\n  ')
+    .replace(/asyncWorkPoolSize: \(function\(\) \{[\s\S]*?\n  \}\)\(\),\n\s*/g, 'asyncWorkPoolSize: 0,\n  ')
+    .replace(/reuseWorker: true,\n\s*/g, '')
+    .replace(/\n  onCreateWorker\(\) \{[\s\S]*?\n  \},\n  overwriteImports/, '\n  overwriteImports');
+
+  if (out.includes('shared: true')) {
+    throw new Error('failed to remove shared memory from single-threaded shim');
+  }
+  if (out.includes('reuseWorker: true') || out.includes('onCreateWorker()')) {
+    throw new Error('failed to remove worker-pool setup from single-threaded shim');
+  }
+  return out;
+}
+
+export function patchSingleThreadedBrowserShim(source) {
+  let out = patchSingleThreadedShim(source);
+
+  if (out.includes('from \'@napi-rs/wasm-runtime\'') && out.includes('await fetch(__wasmUrl)')) {
+    out = out
+      .replace(
+        /} from '@napi-rs\/wasm-runtime'\n/,
+        "} from '@napi-rs/wasm-runtime'\nimport __wasmModule from './coverage-instrument.wasm32-wasi.wasm'\n",
+      )
+      .replace(
+        /const __wasmUrl = new URL\('\.\/coverage-instrument\.wasm32-wasi\.wasm', import\.meta\.url\)\.href\n/,
+        '',
+      )
+      .replace(
+        /const __wasmFile = await fetch\(__wasmUrl\)\.then\(\(res\) => res\.arrayBuffer\(\)\)/,
+        `const __wasmFile =
+  __wasmModule instanceof WebAssembly.Module
+    ? __wasmModule
+    : typeof __wasmModule === 'string'
+      ? await fetch(__wasmModule).then((res) => res.arrayBuffer())
+      : __wasmModule`,
+      );
+  }
+
+  return out;
+}
+
+function patchFile(path, patcher) {
+  if (!existsSync(path)) {
+    throw new Error(`missing required file: ${path}`);
+  }
+  const original = readFileSync(path);
+  const next = patcher(original);
+  writeFileSync(path, next);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const wasmPath = join(targetDir, 'coverage-instrument.wasm32-wasi.wasm');
+  patchFile(wasmPath, (buffer) => {
+    const result = patchSingleThreadedWasm(buffer);
+    if (result.patched) {
+      console.log(`[patch-wasi-singlethreaded-artifacts] made wasm global #${result.globalIndex} mutable.`);
+    } else {
+      console.log('[patch-wasi-singlethreaded-artifacts] wasm already validates.');
+    }
+    return result.buffer;
+  });
+
+  patchFile(join(targetDir, 'coverage-instrument.wasi.cjs'), (buffer) =>
+    patchSingleThreadedShim(buffer.toString('utf8')),
+  );
+  patchFile(join(targetDir, 'coverage-instrument.wasi-browser.js'), (buffer) =>
+    patchSingleThreadedBrowserShim(buffer.toString('utf8')),
+  );
+
+  console.log(`[patch-wasi-singlethreaded-artifacts] patched ${targetDir}.`);
+}

--- a/crates/oxc-coverage-instrument-napi/scripts/prepare-wasi-singlethreaded-package.mjs
+++ b/crates/oxc-coverage-instrument-napi/scripts/prepare-wasi-singlethreaded-package.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Populate the manually named single-threaded WASI optional package.
+//
+// napi-rs currently maps both wasm32-wasip1 and wasm32-wasip1-threads to the
+// same generated package suffix (`wasm32-wasi`). Keep the generated threaded
+// package as-is, then copy the single-threaded build artifacts into this
+// repo-owned package name and patch the browser shim so it does not require
+// SharedArrayBuffer or worker-backed shared memory.
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  patchSingleThreadedBrowserShim,
+  patchSingleThreadedShim,
+  patchSingleThreadedWasm,
+} from './patch-wasi-singlethreaded-artifacts.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, '..');
+let sourceDir = packageRoot;
+const installRoots = [];
+for (let i = 2; i < process.argv.length; i += 1) {
+  const arg = process.argv[i];
+  if (arg === '--install-root') {
+    installRoots.push(resolve(packageRoot, process.argv[++i]));
+  } else if (arg === '--source-dir') {
+    sourceDir = resolve(packageRoot, process.argv[++i]);
+  } else if (!arg.startsWith('--')) {
+    sourceDir = resolve(packageRoot, arg);
+  } else {
+    console.error(`[prepare-wasi-singlethreaded-package] unknown argument: ${arg}`);
+    process.exit(1);
+  }
+}
+const targetDir = join(packageRoot, 'npm', 'wasm32-wasi-singlethreaded');
+const singlePackage = '@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded';
+
+const requiredFiles = [
+  'coverage-instrument.wasm32-wasi.wasm',
+  'coverage-instrument.wasi.cjs',
+  'coverage-instrument.wasi-browser.js',
+  'wasi-worker.mjs',
+  'wasi-worker-browser.mjs',
+];
+
+function readRequired(path) {
+  if (!existsSync(path)) {
+    console.error(`[prepare-wasi-singlethreaded-package] missing required file: ${path}`);
+    process.exit(1);
+  }
+  return readFileSync(path, 'utf8');
+}
+
+mkdirSync(targetDir, { recursive: true });
+for (const file of requiredFiles) {
+  const sourcePath = join(sourceDir, file);
+  const targetPath = join(targetDir, file);
+  if (file === 'coverage-instrument.wasi-browser.js') {
+    writeFileSync(targetPath, patchSingleThreadedBrowserShim(readRequired(sourcePath)));
+  } else if (file.endsWith('.js') || file.endsWith('.cjs')) {
+    writeFileSync(targetPath, patchSingleThreadedShim(readRequired(sourcePath)));
+  } else if (file.endsWith('.wasm')) {
+    if (!existsSync(sourcePath)) {
+      console.error(`[prepare-wasi-singlethreaded-package] missing required file: ${sourcePath}`);
+      process.exit(1);
+    }
+    const result = patchSingleThreadedWasm(readFileSync(sourcePath));
+    writeFileSync(targetPath, result.buffer);
+    if (result.patched) {
+      console.log(`[prepare-wasi-singlethreaded-package] made wasm global #${result.globalIndex} mutable.`);
+    }
+  } else {
+    if (!existsSync(sourcePath)) {
+      console.error(`[prepare-wasi-singlethreaded-package] missing required file: ${sourcePath}`);
+      process.exit(1);
+    }
+    copyFileSync(sourcePath, targetPath);
+  }
+}
+
+console.log(
+  `[prepare-wasi-singlethreaded-package] populated ${targetDir} from ${sourceDir}.`,
+);
+
+for (const installRoot of installRoots) {
+  const packageDir = join(installRoot, 'node_modules', ...singlePackage.split('/'));
+  rmSync(packageDir, { recursive: true, force: true });
+  mkdirSync(packageDir, { recursive: true });
+  for (const file of [...requiredFiles, 'package.json']) {
+    copyFileSync(join(targetDir, file), join(packageDir, file));
+  }
+  console.log(`[prepare-wasi-singlethreaded-package] installed ${singlePackage} at ${packageDir}.`);
+}

--- a/crates/oxc-coverage-instrument-napi/scripts/validate-wasi-singlethreaded-package.mjs
+++ b/crates/oxc-coverage-instrument-napi/scripts/validate-wasi-singlethreaded-package.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultPackageDir = resolve(__dirname, '..', 'npm', 'wasm32-wasi-singlethreaded');
+const packageDir = process.argv[2] ? resolve(process.cwd(), process.argv[2]) : defaultPackageDir;
+const packageName = '@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded';
+
+const requiredFiles = [
+  'coverage-instrument.wasm32-wasi.wasm',
+  'coverage-instrument.wasi.cjs',
+  'coverage-instrument.wasi-browser.js',
+  'wasi-worker.mjs',
+  'wasi-worker-browser.mjs',
+  'package.json',
+];
+
+function readRequired(file, encoding) {
+  const path = join(packageDir, file);
+  if (!existsSync(path)) {
+    throw new Error(`missing required single-threaded package file: ${path}`);
+  }
+  return readFileSync(path, encoding);
+}
+
+for (const file of requiredFiles) {
+  readRequired(file);
+}
+
+const packageJson = JSON.parse(readRequired('package.json', 'utf8'));
+if (packageJson.name !== packageName) {
+  throw new Error(`expected package name ${packageName}, received ${packageJson.name}`);
+}
+
+const wasm = readRequired('coverage-instrument.wasm32-wasi.wasm');
+if (!WebAssembly.validate(wasm)) {
+  throw new Error('single-threaded WASI wasm does not pass WebAssembly.validate');
+}
+
+for (const file of ['coverage-instrument.wasi.cjs', 'coverage-instrument.wasi-browser.js']) {
+  const source = readRequired(file, 'utf8');
+  for (const forbidden of ['shared: true', 'reuseWorker: true', 'onCreateWorker()']) {
+    if (source.includes(forbidden)) {
+      throw new Error(`${file} still contains threaded shim marker: ${forbidden}`);
+    }
+  }
+  if (!source.includes('asyncWorkPoolSize: 0')) {
+    throw new Error(`${file} does not disable the async worker pool`);
+  }
+}
+
+console.log(`[validate-wasi-singlethreaded-package] validated ${packageDir}.`);

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -1,0 +1,16 @@
+# Cloudflare Workers example
+
+Secret-free smoke scaffold for the single-threaded `wasm32-wasip1` binding in Cloudflare Workers. The Worker imports `oxc-coverage-instrument`, instruments a deterministic 100-line fixture, and returns the produced Istanbul `FileCoverage`.
+
+CI builds the native binding and the local single-threaded WASM artifact first, prepares a local `@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded` package from that artifact, bundles the Worker with Wrangler, then compares the Worker `FileCoverage` byte-for-byte with the native Node binding.
+
+## Run
+
+```bash
+cd examples/cloudflare-workers
+npm install
+npm run build
+npm run smoke
+```
+
+`npm run smoke` starts `wrangler dev --local` on `127.0.0.1:8787`, calls the Worker, compares the returned `FileCoverage` with the native binding, and then shuts Wrangler down. It does not deploy and does not need Cloudflare credentials.

--- a/examples/cloudflare-workers/package-lock.json
+++ b/examples/cloudflare-workers/package-lock.json
@@ -1,0 +1,1642 @@
+{
+  "name": "oxc-coverage-instrument-cloudflare-workers-smoke",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "oxc-coverage-instrument-cloudflare-workers-smoke",
+      "dependencies": {
+        "oxc-coverage-instrument": "file:../../crates/oxc-coverage-instrument-napi"
+      },
+      "devDependencies": {
+        "wrangler": "^4.94.0"
+      }
+    },
+    "../../crates/oxc-coverage-instrument-napi": {
+      "name": "oxc-coverage-instrument",
+      "version": "0.7.2",
+      "license": "MIT",
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "devDependencies": {
+        "@napi-rs/cli": "^3.6.0",
+        "istanbul-lib-instrument": "^6.0.3"
+      },
+      "optionalDependencies": {
+        "@oxc-coverage-instrument/binding-darwin-arm64": "0.7.2",
+        "@oxc-coverage-instrument/binding-darwin-x64": "0.7.2",
+        "@oxc-coverage-instrument/binding-linux-arm64-gnu": "0.7.2",
+        "@oxc-coverage-instrument/binding-linux-x64-gnu": "0.7.2",
+        "@oxc-coverage-instrument/binding-linux-x64-musl": "0.7.2",
+        "@oxc-coverage-instrument/binding-wasm32-wasi": "0.7.2",
+        "@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded": "0.7.2",
+        "@oxc-coverage-instrument/binding-win32-arm64-msvc": "0.7.2",
+        "@oxc-coverage-instrument/binding-win32-x64-msvc": "0.7.2"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260521.1.tgz",
+      "integrity": "sha512-aiNdXmxlhwGjTSajL3I7uQPpN4lAOcXjvg5ZOlJKIywnevr798n9XCS6lvuqgniM3KjurBNWRRypMJntg/eSLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260521.1.tgz",
+      "integrity": "sha512-ikN8aKSi4Ak28ndOkuSO5rq6lmV6wwDQu9F9Vu6J7EkwAOth74J/Hjn4j4EuFceW/npw2Ws0Y/muzA6WKHl4TA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260521.1.tgz",
+      "integrity": "sha512-D/gUhvQcG0pJr5aJl6yUoi2JxbFpjVtDq9xUJHPjfkAjL28TUVgCR/e5r8YGirepv4I1DK7ihuii9LZ2GGMJbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260521.1.tgz",
+      "integrity": "sha512-vhjWPIHenczegTakhRPwEmTeaavCpNqsuo3RlLCkUdU47HrwLvy/4QersGggs4+kF4Do+IE/EznCGyT40xYcLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260521.1.tgz",
+      "integrity": "sha512-wBolYC/+lnGIEbkkPdzFtjTOWip2uQH6maeAP1ZV0kyxi5SGpsa83+wD5rH5OOle+sHE5qJMdwCKjwRwj+FKJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260521.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260521.0.tgz",
+      "integrity": "sha512-roRfxPq49OkuSeQsc43hRjSB1+HdHtDNKRwDEVk2hCjCBuBWxb5Wvwq88b0ULj6QVEJLN/+ZqF19M+h4VYJ/zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260521.1",
+        "ws": "8.20.1",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/oxc-coverage-instrument": {
+      "resolved": "../../crates/oxc-coverage-instrument-napi",
+      "link": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rosie-skills": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills/-/rosie-skills-0.6.4.tgz",
+      "integrity": "sha512-ojfhSiQRdZ2QyWbmKAHOSAUbaLYrTc5zIH7mS1jKoP8KCFSQddwVhMyFqldckTeybTfW3zNcsZzyOTzGTN1SBA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "rosie-skills": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "rosie-skills-darwin-arm64": "0.6.4",
+        "rosie-skills-freebsd-x64": "0.6.4",
+        "rosie-skills-linux-x64": "0.6.4"
+      }
+    },
+    "node_modules/rosie-skills-darwin-arm64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-darwin-arm64/-/rosie-skills-darwin-arm64-0.6.4.tgz",
+      "integrity": "sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rosie-skills-freebsd-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-freebsd-x64/-/rosie-skills-freebsd-x64-0.6.4.tgz",
+      "integrity": "sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rosie-skills-linux-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-linux-x64/-/rosie-skills-linux-x64-0.6.4.tgz",
+      "integrity": "sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260521.1.tgz",
+      "integrity": "sha512-HzIThcZ0ZVEuzVxpY2IYZ3yssSrTjtrWXAVfmOl5rVwyqcu7aeZXGMiwrEmi9MOcC3wjy+BNv+hFrMMY5OrjQQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260521.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260521.1",
+        "@cloudflare/workerd-linux-64": "1.20260521.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260521.1",
+        "@cloudflare/workerd-windows-64": "1.20260521.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.94.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.94.0.tgz",
+      "integrity": "sha512-GsNw0DomGFfeXFtKVTwn2X69UKcCxcTB0CXykjsMineJIxOeyrw7LovlHQ/3JU8KJHH7repLB+kOHvfTBA/Eew==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260521.0",
+        "path-to-regexp": "6.3.0",
+        "rosie-skills": "^0.6.3",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260521.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260521.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "oxc-coverage-instrument-cloudflare-workers-smoke",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "wrangler deploy --dry-run --outdir dist",
+    "dev": "wrangler dev --local --ip 127.0.0.1 --port 8787",
+    "smoke": "node scripts/smoke.mjs"
+  },
+  "dependencies": {
+    "oxc-coverage-instrument": "file:../../crates/oxc-coverage-instrument-napi"
+  },
+  "devDependencies": {
+    "wrangler": "^4.94.0"
+  }
+}

--- a/examples/cloudflare-workers/scripts/smoke.mjs
+++ b/examples/cloudflare-workers/scripts/smoke.mjs
@@ -1,0 +1,110 @@
+import { strict as assert } from 'node:assert';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import { setTimeout as delay } from 'node:timers/promises';
+import { instrument } from 'oxc-coverage-instrument';
+import { fixtureFilename, fixtureSource } from '../src/fixture.js';
+
+const port = await new Promise((resolve, reject) => {
+  const server = createServer();
+  server.on('error', reject);
+  server.listen(0, '127.0.0.1', () => {
+    const address = server.address();
+    server.close(() => resolve(address.port));
+  });
+});
+const url = `http://127.0.0.1:${port}/`;
+const reference = JSON.parse(
+  instrument(fixtureSource, fixtureFilename, { sourceMap: true }).coverageMap,
+);
+
+const child = spawn(
+  process.platform === 'win32' ? 'npx.cmd' : 'npx',
+  ['wrangler', 'dev', '--local', '--ip', '127.0.0.1', '--port', String(port)],
+  {
+    cwd: new URL('..', import.meta.url),
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+      WRANGLER_LOG: 'error',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: process.platform !== 'win32',
+  },
+);
+
+let logs = '';
+child.stdout.on('data', (chunk) => {
+  logs += chunk.toString();
+});
+child.stderr.on('data', (chunk) => {
+  logs += chunk.toString();
+});
+
+let childExited = false;
+const childExit = new Promise((resolve) => {
+  child.once('exit', (code, signal) => {
+    childExited = true;
+    resolve({ code, signal });
+  });
+});
+
+function signalChild(signal) {
+  if (childExited) return;
+  try {
+    if (process.platform === 'win32') {
+      child.kill(signal);
+    } else {
+      process.kill(-child.pid, signal);
+    }
+  } catch (error) {
+    if (error.code !== 'ESRCH') {
+      throw error;
+    }
+  }
+}
+
+async function stopChild() {
+  signalChild('SIGTERM');
+  await Promise.race([childExit, delay(2000)]);
+  if (!childExited) {
+    signalChild('SIGKILL');
+    await childExit;
+  }
+}
+
+async function fetchWithRetry() {
+  let lastError;
+  for (let attempt = 0; attempt < 90; attempt += 1) {
+    if (childExited) {
+      throw lastError ?? new Error('wrangler dev exited before the Worker became reachable');
+    }
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(1000) });
+      const text = await response.text();
+      if (response.ok) return JSON.parse(text);
+      lastError = new Error(`HTTP ${response.status}: ${text}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(500);
+  }
+  throw lastError ?? new Error('Worker did not become reachable');
+}
+
+try {
+  const body = await fetchWithRetry();
+  assert.equal(body.ok, true, body.error ?? 'Worker response was not ok');
+  assert.equal(
+    body.hasSharedArrayBuffer,
+    false,
+    'Cloudflare Workers smoke must exercise the single-threaded browser binding',
+  );
+  assert.deepEqual(body.fileCoverage, reference);
+  console.log('Cloudflare Workers smoke OK: single-threaded WASI matches native coverage');
+} catch (error) {
+  console.error(logs);
+  throw error;
+} finally {
+  await stopChild();
+}

--- a/examples/cloudflare-workers/src/fixture.js
+++ b/examples/cloudflare-workers/src/fixture.js
@@ -1,0 +1,7 @@
+export const fixtureFilename = 'worker-fixture.js';
+
+export const fixtureSource = Array.from({ length: 100 }, (_, index) => {
+  const n = index + 1;
+  const op = n % 2 === 0 ? '>=' : '<';
+  return `export function branch${n}(value) { return value ${op} ${n} ? ${n} : -${n}; }`;
+}).join('\n');

--- a/examples/cloudflare-workers/src/index.js
+++ b/examples/cloudflare-workers/src/index.js
@@ -1,0 +1,34 @@
+import { fixtureFilename, fixtureSource } from './fixture.js';
+
+globalThis.OXC_COVERAGE_FORCE_WASI_SINGLE_THREADED = true;
+
+export default {
+  async fetch() {
+    try {
+      if (typeof SharedArrayBuffer !== 'undefined') {
+        Object.defineProperty(globalThis, 'SharedArrayBuffer', {
+          configurable: true,
+          value: undefined,
+        });
+      }
+
+      const { instrument } = await import('oxc-coverage-instrument');
+      const result = instrument(fixtureSource, fixtureFilename, { sourceMap: true });
+      const fileCoverage = JSON.parse(result.coverageMap);
+
+      return Response.json({
+        ok: true,
+        hasSharedArrayBuffer: typeof SharedArrayBuffer !== 'undefined',
+        fileCoverage,
+      });
+    } catch (error) {
+      return Response.json(
+        {
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        { status: 500 },
+      );
+    }
+  },
+};

--- a/examples/cloudflare-workers/wrangler.jsonc
+++ b/examples/cloudflare-workers/wrangler.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "oxc-coverage-instrument-workers-smoke",
+  "main": "src/index.js",
+  "compatibility_date": "2026-05-26",
+  "workers_dev": false,
+  "rules": [
+    {
+      "type": "CompiledWasm",
+      "globs": ["**/*.wasm"],
+      "fallthrough": true
+    }
+  ]
+}

--- a/examples/wasm-node/README.md
+++ b/examples/wasm-node/README.md
@@ -1,11 +1,11 @@
 # WASM (Node) example
 
-End-to-end smoke for the `wasm32-wasip1-threads` binding under Node. The same `instrument()` API call works with either the native `.node` binding (preferred when available) or the WASI binding (automatic fallback on platforms without a prebuilt native binary, or forced via `NAPI_RS_FORCE_WASI=1`).
+End-to-end smoke for the WASI bindings under Node. CI runs this example against both `wasm32-wasip1-threads` and `wasm32-wasip1`; the same `instrument()` API call works with either the native `.node` binding (preferred when available) or the currently-built WASI binding (automatic fallback on platforms without a prebuilt native binary, or forced via `NAPI_RS_FORCE_WASI=1`).
 
 ## What this demonstrates
 
-- `oxc-coverage-instrument` works identically against both the native and WASM bindings. No code change is required to opt into WASM; the loader picks the right binary at runtime.
-- The WASM build is a single ~2.8 MB artifact (~0.6 MB compressed) that covers every environment with a working `node:wasi` runtime.
+- `oxc-coverage-instrument` works identically against the native binding and each WASM variant. No code change is required to opt into WASM; the loader picks the right binary at runtime.
+- Each WASM build stays under the 2 MB brotli CI ceiling.
 
 ## Run
 
@@ -13,7 +13,7 @@ End-to-end smoke for the `wasm32-wasip1-threads` binding under Node. The same `i
 cd examples/wasm-node
 npm install
 npm run smoke       # uses the native binding (or wasm if no native is available)
-npm run smoke:wasi  # forces the wasm32-wasi binding via NAPI_RS_FORCE_WASI=error
+npm run smoke:wasi  # forces the currently-built wasm32-wasi binding via NAPI_RS_FORCE_WASI=error
 ```
 
 `smoke:wasi` will fail with a clear error if the WASI binding cannot be loaded, so it doubles as a regression gate that the WASM path stays healthy.
@@ -25,6 +25,7 @@ npm run smoke:wasi  # forces the wasm32-wasi binding via NAPI_RS_FORCE_WASI=erro
 | Node 22 LTS on darwin/linux/win32 | yes | yes (via `node:wasi`) | Native preferred automatically. |
 | Deno 2.x | no | yes (Deno's `node:wasi` shim) | Untested in CI; community feedback welcome. |
 | Bun (any version) | yes | no | Bun's `node:wasi` lacks `wasi.initialize()` ([bun#16156](https://github.com/oven-sh/bun/issues/16156)). Native binding works on all supported Bun platforms. |
-| Browser (with COOP/COEP) | no | yes (via `browser` export + `fetch`) | Requires `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` for `SharedArrayBuffer`. |
-| Cloudflare Workers | no | no | Workers lacks `SharedArrayBuffer`, which `wasm32-wasip1-threads` requires. Single-threaded WASI build is tracked as a follow-up. |
+| Browser (with COOP/COEP) | no | yes (via `browser` export + `fetch`) | Uses the threaded binding when `SharedArrayBuffer` is available. |
+| Browser (without COOP/COEP) | no | yes (via `browser` export + `fetch`) | Uses the single-threaded binding when `SharedArrayBuffer` is unavailable. |
+| Cloudflare Workers | no | yes (via `browser` export) | Uses the single-threaded binding; see `examples/cloudflare-workers/` for the local acceptance smoke. |
 | StackBlitz / WebContainer | no | partial | Falls under the browser case above; WebContainer's `node:wasi` polyfill is incomplete in older releases. |

--- a/scripts/force-local-wasm-artifacts.mjs
+++ b/scripts/force-local-wasm-artifacts.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, rmSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const napiDir = join(repoRoot, 'crates', 'oxc-coverage-instrument-napi');
+
+const packageNames = [
+  '@oxc-coverage-instrument/binding-wasm32-wasi',
+  '@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded',
+];
+
+const installRoots = [
+  join(repoRoot, 'crates', 'oxc-coverage-instrument-napi'),
+  join(repoRoot, 'examples', 'wasm-node'),
+  join(repoRoot, 'examples', 'cloudflare-workers'),
+];
+
+const localWasm = existsSync(napiDir)
+  ? readdirSync(napiDir).filter((name) => name.startsWith('coverage-instrument.wasm32-wasi') && name.endsWith('.wasm'))
+  : [];
+
+if (localWasm.length === 0) {
+  throw new Error(`no local coverage-instrument.wasm32-wasi*.wasm artifact found in ${napiDir}`);
+}
+
+let removed = 0;
+
+for (const installRoot of installRoots) {
+  for (const packageName of packageNames) {
+    const packageDir = join(installRoot, 'node_modules', ...packageName.split('/'));
+    if (!existsSync(packageDir)) {
+      continue;
+    }
+    for (const entry of readdirSync(packageDir)) {
+      if (entry.startsWith('coverage-instrument.wasm32-wasi') && entry.endsWith('.wasm')) {
+        rmSync(join(packageDir, entry), { force: true });
+        removed += 1;
+      }
+    }
+  }
+}
+
+console.log(
+  `local wasm artifacts available: ${localWasm.join(', ')}; removed ${removed} published optional-package wasm file(s)`,
+);

--- a/scripts/native-vs-wasm-parity.mjs
+++ b/scripts/native-vs-wasm-parity.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Byte-for-byte parity check between the native and WASM (wasm32-wasip1-threads)
-// napi bindings.
+// Byte-for-byte parity check between the native and currently-built WASM napi
+// binding.
 //
 // v0.7.1 shipped a one-off local check that the two bindings produce identical
 // coverage maps. This script reproduces that check on every PR so any future
@@ -30,6 +30,7 @@ const repoRoot = join(__dirname, '..');
 const fixturesDir = join(repoRoot, 'crates', 'oxc-coverage-instrument', 'tests', 'conformance', 'fixtures');
 
 const isDumpMode = process.argv.includes('--dump');
+const wasmVariant = process.env.OXC_COVERAGE_WASM_VARIANT || 'wasm';
 
 const listFixtures = () =>
   readdirSync(fixturesDir)
@@ -99,7 +100,7 @@ const diff = () => {
     process.exit(1);
   }
 
-  console.log(`native vs wasm parity OK: ${fixtures.size} fixtures byte-identical across both bindings`);
+  console.log(`native vs ${wasmVariant} parity OK: ${fixtures.size} fixtures byte-identical across both bindings`);
 };
 
 if (isDumpMode) {

--- a/scripts/npm-pack-surface-check.mjs
+++ b/scripts/npm-pack-surface-check.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const specs = [
+  {
+    dir: 'crates/oxc-coverage-instrument-napi',
+    files: [
+      'package/browser.js',
+      'package/index.js',
+      'package/index.d.ts',
+      'package/coverage-instrument.wasi.cjs',
+      'package/coverage-instrument.wasi-browser.js',
+      'package/wasi-worker.mjs',
+      'package/wasi-worker-browser.mjs',
+      'package/vitest.js',
+      'package/vitest.d.ts',
+    ],
+  },
+  {
+    dir: 'crates/oxc-coverage-instrument-napi/npm/wasm32-wasi',
+    files: [
+      'package/coverage-instrument.wasm32-wasi.wasm',
+      'package/coverage-instrument.wasi.cjs',
+      'package/coverage-instrument.wasi-browser.js',
+      'package/wasi-worker.mjs',
+      'package/wasi-worker-browser.mjs',
+    ],
+  },
+  {
+    dir: 'crates/oxc-coverage-instrument-napi/npm/wasm32-wasi-singlethreaded',
+    files: [
+      'package/coverage-instrument.wasm32-wasi.wasm',
+      'package/coverage-instrument.wasi.cjs',
+      'package/coverage-instrument.wasi-browser.js',
+      'package/wasi-worker.mjs',
+      'package/wasi-worker-browser.mjs',
+    ],
+  },
+];
+
+for (const spec of specs) {
+  const result = spawnSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: resolve(spec.dir),
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr);
+    throw new Error(`npm pack failed in ${spec.dir}`);
+  }
+
+  const pack = JSON.parse(result.stdout)[0];
+  const actual = new Set(pack.files.map((file) => file.path.replace(/^package\//, '')));
+  const missing = spec.files.filter((file) => !actual.has(file.replace(/^package\//, '')));
+  if (missing.length > 0) {
+    throw new Error(`${spec.dir} package is missing files: ${missing.join(', ')}`);
+  }
+  console.log(`npm pack surface OK: ${spec.dir}`);
+}

--- a/scripts/prepare-local-wasm-package.mjs
+++ b/scripts/prepare-local-wasm-package.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const napiDir = join(repoRoot, 'crates', 'oxc-coverage-instrument-napi');
+
+let packageName = '@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded';
+const installRoots = [];
+
+for (let i = 2; i < process.argv.length; i += 1) {
+  const arg = process.argv[i];
+  if (arg === '--package-name') {
+    packageName = process.argv[++i];
+  } else if (arg === '--install-root') {
+    installRoots.push(resolve(repoRoot, process.argv[++i]));
+  } else {
+    throw new Error(`unknown argument: ${arg}`);
+  }
+}
+
+if (!packageName || !packageName.startsWith('@oxc-coverage-instrument/')) {
+  throw new Error(`invalid package name: ${packageName}`);
+}
+
+if (installRoots.length === 0) {
+  throw new Error('usage: node scripts/prepare-local-wasm-package.mjs --install-root <dir> [--install-root <dir> ...]');
+}
+
+const rootPackage = JSON.parse(readFileSync(join(napiDir, 'package.json'), 'utf8'));
+const files = [
+  'coverage-instrument.wasm32-wasi.wasm',
+  'coverage-instrument.wasi.cjs',
+  'coverage-instrument.wasi-browser.js',
+  'wasi-worker.mjs',
+  'wasi-worker-browser.mjs',
+];
+
+for (const file of files) {
+  const path = join(napiDir, file);
+  if (!existsSync(path)) {
+    throw new Error(`expected local wasm package file is missing: ${path}`);
+  }
+}
+
+for (const installRoot of installRoots) {
+  const packageDir = join(installRoot, 'node_modules', ...packageName.split('/'));
+  rmSync(packageDir, { recursive: true, force: true });
+  mkdirSync(packageDir, { recursive: true });
+
+  for (const file of files) {
+    copyFileSync(join(napiDir, file), join(packageDir, file));
+  }
+
+  writeFileSync(
+    join(packageDir, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: packageName,
+        version: rootPackage.version,
+        main: 'coverage-instrument.wasi.cjs',
+        browser: 'coverage-instrument.wasi-browser.js',
+        files,
+        dependencies: {
+          '@napi-rs/wasm-runtime': rootPackage.dependencies['@napi-rs/wasm-runtime'],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  console.log(`prepared ${packageName} from local wasm artifacts at ${packageDir}`);
+}

--- a/scripts/wasm-instrument-smoke.mjs
+++ b/scripts/wasm-instrument-smoke.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import { strict as assert } from 'node:assert';
+import { instrument } from '../crates/oxc-coverage-instrument-napi/index.js';
+
+const filename = 'wasm-smoke-fixture.js';
+const source = Array.from({ length: 100 }, (_, index) => {
+  const n = index + 1;
+  return `export function f${n}(value) { return value === ${n} ? ${n} : ${n + 1}; }`;
+}).join('\n');
+
+const result = instrument(source, filename, { sourceMap: true });
+const fileCoverage = JSON.parse(result.coverageMap);
+
+assert.ok(result.code.includes('__coverage__'), 'expected instrumented coverage preamble');
+assert.ok(typeof result.sourceMap === 'string', 'expected source map output');
+assert.equal(fileCoverage.path, filename, `expected FileCoverage path ${filename}`);
+assert.ok(Object.keys(fileCoverage.statementMap).length >= 100, 'expected statement coverage for the 100-line fixture');
+assert.ok(Object.keys(fileCoverage.fnMap).length >= 100, 'expected function coverage for the 100-line fixture');
+
+console.log(
+  `wasm instrument smoke OK: ${Object.keys(fileCoverage.statementMap).length} statements, ${Object.keys(fileCoverage.fnMap).length} functions`,
+);

--- a/scripts/wasm-size-check.mjs
+++ b/scripts/wasm-size-check.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import { brotliCompressSync, constants, gzipSync } from 'node:zlib';
+
+const DEFAULT_MAX_BROTLI_BYTES = 2 * 1024 * 1024;
+
+let maxBrotliBytes = DEFAULT_MAX_BROTLI_BYTES;
+const files = [];
+
+for (const arg of process.argv.slice(2)) {
+  if (arg.startsWith('--max-brotli-bytes=')) {
+    maxBrotliBytes = Number.parseInt(arg.slice('--max-brotli-bytes='.length), 10);
+  } else {
+    files.push(arg);
+  }
+}
+
+if (!Number.isSafeInteger(maxBrotliBytes) || maxBrotliBytes <= 0) {
+  throw new Error(`invalid --max-brotli-bytes value: ${maxBrotliBytes}`);
+}
+
+if (files.length === 0) {
+  throw new Error('usage: node scripts/wasm-size-check.mjs [--max-brotli-bytes=N] <file.wasm> [...]');
+}
+
+const mb = (bytes) => `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+let failed = false;
+
+for (const file of files) {
+  const bytes = readFileSync(file);
+  const gzip = gzipSync(bytes, { level: 9 });
+  const brotli = brotliCompressSync(bytes, {
+    params: {
+      [constants.BROTLI_PARAM_QUALITY]: 11,
+    },
+  });
+
+  console.log(`${basename(file)}`);
+  console.log(`  raw      ${bytes.byteLength.toString().padStart(10)}  ${mb(bytes.byteLength)}`);
+  console.log(`  gzip -9  ${gzip.byteLength.toString().padStart(10)}  ${mb(gzip.byteLength)}`);
+  console.log(`  brotli   ${brotli.byteLength.toString().padStart(10)}  ${mb(brotli.byteLength)}`);
+
+  if (brotli.byteLength > maxBrotliBytes) {
+    console.error(
+      `::error file=${file}::Brotli-compressed wasm size ${brotli.byteLength} exceeds ceiling ${maxBrotliBytes} (${mb(maxBrotliBytes)}).`,
+    );
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- add the `wasm32-wasip1` napi target and `@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded` optional package
- rewrite the browser export to prefer threaded WASI when `SharedArrayBuffer` is available and fall back to single-threaded WASI otherwise
- add post-build patches for napi-rs 3.6 single-threaded WASI artifacts, including non-shared memory shims and WASM validation
- add required CI coverage for single-threaded WASI smoke/parity, npm pack surfaces, and a secret-free Cloudflare Workers smoke

## Reviewer focus

The fragile part is the napi-rs/emnapi workaround: `patch-napi-wasi-link-dir.mjs` and `patch-wasi-singlethreaded-artifacts.mjs` patch generated build outputs because napi-rs currently maps WASI package names together and emits thread-oriented WASI shims for `wasm32-wasip1`. The CI/runtime gates are meant to fail loudly if that generated shape changes.

## Verification

- `npm test`
- `node scripts/browser-loader.test.mjs`
- `NAPI_RS_FORCE_WASI=error node scripts/wasm-instrument-smoke.mjs`
- `OXC_COVERAGE_WASM_VARIANT=wasm32-wasip1 NAPI_RS_FORCE_WASI=error node scripts/native-vs-wasm-parity.mjs`
- `npm run smoke` in `examples/cloudflare-workers`
- `node scripts/npm-pack-surface-check.mjs`
- `git diff --check`
- workflow YAML parse
- `typos .`

Fixes #87