### PR TITLE
feat: compose inputSourceMap eagerly during instrument()

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,25 @@ const remapped = JSON.parse(
 );
 ```
 
+#### Composing eagerly during `instrument()`
+
+The flow above is lazy: `instrument()` embeds the `inputSourceMap` and a downstream `remapCoverageMap` walks every entry back to the original source at report time. For collectors that dump `window.__coverage__` directly (Playwright E2E, per-test snapshots), that round-trip happens once per collected file. Set `composeInputSourceMap: true` (Rust: `compose_input_source_map: true`) alongside `inputSourceMap` to fold the map in once, during instrumentation:
+
+```js
+const { code, coverageMap } = instrument(intermediateJs, 'intermediate.js', {
+    inputSourceMap: JSON.stringify(inputSourceMap),
+    composeInputSourceMap: true,
+});
+// coverageMap is keyed by the original source path with original-source
+// positions and carries no inputSourceMap. The runtime __coverage__ baked into
+// `code` is keyed the same way, so collection is just:
+//   const raw = await page.evaluate(() => window.__coverage__);
+//   writeFileSync(out, JSON.stringify(raw));
+// remapCoverageMap(raw) is then a no-op.
+```
+
+The composed result is bit-for-bit equal to instrument-without-compose followed by `remap_coverage`, using the same default keep-generated-position semantics for positions whose source-map lookup fails (no `dropUnmapped` knob is exposed at instrument time; use the lazy `remapCoverageMap` path if you need pruning). When the input map is unusable (declares no source, fails to parse), composition backs off and the `inputSourceMap` is left embedded so the lazy path still works. The flag has no effect when `inputSourceMap` is unset. The `x_fallow_functionMap` overlay, if requested, keeps its pre-remap-derived ids in both the eager and lazy paths (the remap pipeline does not rewrite it).
+
 ### Converting V8 byte-range coverage to Istanbul
 
 `v8_to_istanbul` accepts the same shape Node's inspector and `@vitest/coverage-v8` emit. With block coverage enabled, statement/function/branch counts are populated by intersecting V8 ranges with locations recovered from a visit-only AST pass. Inline `//# sourceMappingURL=data:...` trailers are decoded automatically; external map references resolve through the optional loader on `v8_to_istanbul_with_loader`.

--- a/crates/oxc-coverage-instrument-napi/src/lib.rs
+++ b/crates/oxc-coverage-instrument-napi/src/lib.rs
@@ -144,6 +144,16 @@ pub struct InstrumentOptions {
     pub source_map: Option<bool>,
     /// Input source map JSON string from a prior transformation.
     pub input_source_map: Option<String>,
+    /// When true AND `inputSourceMap` is set, compose the input source map into
+    /// the coverage map during instrumentation. The returned `coverageMap` (and
+    /// the runtime `__coverage__` baked into the instrumented `code`) carries
+    /// original-source positions, is keyed by the original source path, and has
+    /// no `inputSourceMap` embedded; `remapCoverageMap` on the result is a
+    /// no-op. Useful for E2E collectors (Playwright et al.) that dump
+    /// `window.__coverage__` directly and want original-source positions without
+    /// a downstream remap round-trip. Has no effect when `inputSourceMap` is
+    /// unset. Default false.
+    pub compose_input_source_map: Option<bool>,
     /// When true, adds truthy-value tracking (bT) for logical expression operands.
     pub report_logic: Option<bool>,
     /// Class method names to exclude from coverage instrumentation.
@@ -265,6 +275,7 @@ pub fn instrument(
                     .unwrap_or_else(|| "__coverage__".to_string()),
                 source_map: o.source_map.unwrap_or(false),
                 input_source_map: o.input_source_map,
+                compose_input_source_map: o.compose_input_source_map.unwrap_or(false),
                 report_logic: o.report_logic.unwrap_or(false),
                 ignore_class_methods: o.ignore_class_methods.unwrap_or_default(),
                 strip_typescript: o.strip_typescript.unwrap_or(false),

--- a/crates/oxc-coverage-instrument-napi/test.mjs
+++ b/crates/oxc-coverage-instrument-napi/test.mjs
@@ -529,6 +529,53 @@ function runInstrumented(result, filename, callExpression) {
   console.log('  [PASS] inputSourceMap composed into coverage map');
 }
 
+// Test 14b: composeInputSourceMap folds the input map in eagerly (issue #100)
+{
+  const originalTs = 'const x: number = 1;\nconst y: number = 2;\nconst z: number = 3;\n';
+  const intermediateJs = 'const x = 1;\nconst y = 2;\nconst z = 3;\n';
+  const inputSourceMap = {
+    version: 3,
+    sources: ['src/app.ts'],
+    sourcesContent: [originalTs],
+    mappings: 'AAAA;AACA;AACA',
+    names: [],
+  };
+
+  const result = instrument(intermediateJs, 'intermediate.js', {
+    inputSourceMap: JSON.stringify(inputSourceMap),
+    composeInputSourceMap: true,
+  });
+  const cm = JSON.parse(result.coverageMap);
+
+  // The returned coverage map is already in original-source space.
+  assert.equal(cm.path, 'src/app.ts', 'composed coverage map is keyed by the original source path');
+  assert(!cm.inputSourceMap, 'composed coverage map carries no embedded inputSourceMap');
+  const lines = Object.values(cm.statementMap)
+    .map((loc) => loc.start.line)
+    .sort();
+  assert.deepEqual(lines, [1, 2, 3], 'composed statement lines point at original.ts lines');
+
+  // The runtime coverage baked into `code` is keyed by the original path too,
+  // so an E2E collector can dump window.__coverage__ verbatim.
+  assert(
+    result.code.includes('var path = "src/app.ts"'),
+    'composed preamble keys the runtime coverage by the original source path',
+  );
+
+  // remapCoverageMap on the composed result is a no-op: the entry has no
+  // inputSourceMap, so it passes through unchanged under its original key.
+  const passthrough = JSON.parse(remapCoverageMap(JSON.stringify({ [cm.path]: cm })));
+  assert(passthrough['src/app.ts'], 'remapCoverageMap leaves the already-composed entry in place');
+  assert.deepEqual(
+    Object.values(passthrough['src/app.ts'].statementMap)
+      .map((loc) => loc.start.line)
+      .sort(),
+    [1, 2, 3],
+    'remapCoverageMap is a no-op on the composed result',
+  );
+  console.log('  [PASS] composeInputSourceMap folds the input map in eagerly');
+}
+
 // Test 15: ignoreClassMethods drops fnMap entries for matching methods
 {
   const source = `

--- a/crates/oxc-coverage-instrument/src/instrument.rs
+++ b/crates/oxc-coverage-instrument/src/instrument.rs
@@ -34,6 +34,31 @@ pub struct InstrumentOptions {
     /// When provided, this is stored on the `FileCoverage` as `inputSourceMap` so
     /// downstream tools (nyc, istanbul-reports) can chain back to the original source.
     pub input_source_map: Option<String>,
+    /// When true AND [`InstrumentOptions::input_source_map`] is set, compose the
+    /// input source map into the coverage map during instrumentation instead of
+    /// embedding it for downstream composition.
+    ///
+    /// The resulting `FileCoverage` (and the `coverageData` literal baked into
+    /// the instrumented code's preamble, hence the runtime coverage variable)
+    /// carries original-source positions, is re-keyed by the original source
+    /// `path`, and has no `inputSourceMap` field. A subsequent
+    /// [`crate::remap_coverage`] / `remapCoverageMap` on the result is a no-op.
+    ///
+    /// This trades the per-collection remap round-trip (instrument, then walk
+    /// every entry through its embedded map at report time) for a one-time
+    /// composition at instrument time. Useful for E2E collectors (Playwright et
+    /// al.) that dump `window.__coverage__` directly and want original-source
+    /// positions without a normalization pass.
+    ///
+    /// Composition uses the default keep-generated-position semantics for
+    /// positions whose source-map lookup fails (matching `remap_coverage` /
+    /// `remapCoverageMap` called without options). If the input map is unusable
+    /// (declares no source, fails to parse), composition backs off and the
+    /// embedded `inputSourceMap` is left in place so the lazy remap path still
+    /// works. Has no effect when `input_source_map` is `None`.
+    ///
+    /// Defaults to false.
+    pub compose_input_source_map: bool,
     /// When true, adds truthy-value tracking (`bT`) for logical expression operands.
     /// This enables nyc-style logic coverage that tracks not just which branch was
     /// taken, but whether each operand evaluated to a truthy value.
@@ -154,6 +179,7 @@ impl Default for InstrumentOptions {
             coverage_variable: "__coverage__".to_string(),
             source_map: false,
             input_source_map: None,
+            compose_input_source_map: false,
             report_logic: false,
             ignore_class_methods: Vec::new(),
             strip_typescript: false,
@@ -271,6 +297,23 @@ pub fn instrument(
     if options.function_identity_overlay {
         coverage_map.x_fallow_function_map =
             Some(build_function_identity_map(&coverage_map.path, &coverage_map.fn_map));
+    }
+
+    // Eager composition (issue #100): when requested, fold the embedded
+    // `inputSourceMap` into the coverage map now, before the map is serialized
+    // into the preamble's `coverageData` literal. The runtime `__coverage__`
+    // then ships original-source positions/path and `remap_coverage` on the
+    // result is a no-op. Run AFTER the function-identity overlay attaches so
+    // the overlay's ids stay derived from the pre-remap positions, keeping the
+    // eager path bit-for-bit equal to instrument-then-`remap_coverage` (the
+    // remap pipeline intentionally does not rewrite the overlay). When the
+    // input map is unusable, `remap_coverage` returns `None` and we leave the
+    // embedded map in place so the lazy remap path remains available.
+    if options.compose_input_source_map
+        && options.input_source_map.is_some()
+        && let Some(composed) = oxc_coverage_source_maps::remap_coverage(&coverage_map)
+    {
+        coverage_map = composed;
     }
 
     // Serialize the coverage map once and reuse it for both the hash guard and

--- a/crates/oxc-coverage-instrument/tests/source_maps_test.rs
+++ b/crates/oxc-coverage-instrument/tests/source_maps_test.rs
@@ -337,3 +337,240 @@ fn source_map_store_passes_through_when_no_map_available() {
     let remapped = store.transform_coverage_map(&coverage);
     assert!(remapped.contains_key("plain.js"), "passthrough preserves key");
 }
+
+// ---------------------------------------------------------------------------
+// Eager composition (issue #100): `InstrumentOptions::compose_input_source_map`
+// folds the embedded `inputSourceMap` into the coverage map at instrument time
+// instead of leaving it for a downstream `remap_coverage` / `remapCoverageMap`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compose_input_source_map_rewrites_path_and_positions() {
+    let (_, intermediate, input_sm) = three_line_inputs();
+    let opts = InstrumentOptions {
+        input_source_map: Some(input_sm),
+        compose_input_source_map: true,
+        ..InstrumentOptions::default()
+    };
+    let result = instrument(&intermediate, "intermediate.js", &opts).unwrap();
+
+    // Path and positions are already in the original source, and no input map
+    // is left embedded (the composition consumed it).
+    assert_eq!(result.coverage_map.path, "src/app.ts");
+    assert!(
+        result.coverage_map.input_source_map.is_none(),
+        "eager compose clears the consumed inputSourceMap"
+    );
+    let mut lines: Vec<u32> =
+        result.coverage_map.statement_map.values().map(|loc| loc.start.line).collect();
+    lines.sort_unstable();
+    assert_eq!(lines, vec![1, 2, 3], "statementMap lines after eager compose");
+}
+
+#[test]
+fn compose_input_source_map_equals_instrument_then_remap() {
+    // The whole contract: eager compose must be bit-for-bit equal to
+    // instrument-without-compose followed by `remap_coverage`. If this holds,
+    // `remapCoverageMap` on the eager result is provably a no-op.
+    let (_, intermediate, input_sm) = three_line_inputs();
+
+    let eager = instrument(
+        &intermediate,
+        "intermediate.js",
+        &InstrumentOptions {
+            input_source_map: Some(input_sm.clone()),
+            compose_input_source_map: true,
+            ..InstrumentOptions::default()
+        },
+    )
+    .unwrap();
+
+    let lazy_instrumented = instrument(
+        &intermediate,
+        "intermediate.js",
+        &InstrumentOptions { input_source_map: Some(input_sm), ..InstrumentOptions::default() },
+    )
+    .unwrap();
+    let lazy = remap_coverage(&lazy_instrumented.coverage_map).expect("lazy remap succeeds");
+
+    assert_eq!(
+        serde_json::to_value(&eager.coverage_map).unwrap(),
+        serde_json::to_value(&lazy).unwrap(),
+        "eager compose must equal instrument-then-remap_coverage"
+    );
+}
+
+#[test]
+fn compose_input_source_map_bakes_original_positions_into_preamble() {
+    // The point of composing eagerly is that the runtime `__coverage__` (the
+    // `coverageData` literal in the preamble injected into `code`) already
+    // carries the original-source path, so an E2E collector can dump it
+    // verbatim. The preamble keys the coverage object by `coverage.path`.
+    let (_, intermediate, input_sm) = three_line_inputs();
+
+    let composed = instrument(
+        &intermediate,
+        "intermediate.js",
+        &InstrumentOptions {
+            input_source_map: Some(input_sm.clone()),
+            compose_input_source_map: true,
+            ..InstrumentOptions::default()
+        },
+    )
+    .unwrap();
+    assert!(
+        composed.code.contains("var path = \"src/app.ts\""),
+        "composed preamble keys runtime coverage by the original source path"
+    );
+
+    let lazy = instrument(
+        &intermediate,
+        "intermediate.js",
+        &InstrumentOptions { input_source_map: Some(input_sm), ..InstrumentOptions::default() },
+    )
+    .unwrap();
+    assert!(
+        lazy.code.contains("var path = \"intermediate.js\""),
+        "without compose, the preamble keeps the generated path"
+    );
+}
+
+#[test]
+fn compose_input_source_map_no_op_without_input_map() {
+    // compose_input_source_map is gated on input_source_map being set; with no
+    // map there is nothing to compose, so the result is the plain generated map.
+    let opts = InstrumentOptions { compose_input_source_map: true, ..InstrumentOptions::default() };
+    let result = instrument("const x = 1;", "intermediate.js", &opts).unwrap();
+    assert_eq!(result.coverage_map.path, "intermediate.js", "no map -> path unchanged");
+    assert!(result.coverage_map.input_source_map.is_none());
+}
+
+#[test]
+fn compose_input_source_map_off_keeps_embedded_map() {
+    // Default (flag off) preserves the legacy behavior: the input map stays
+    // embedded for downstream remap and positions remain generated.
+    let (_, intermediate, input_sm) = three_line_inputs();
+    let opts =
+        InstrumentOptions { input_source_map: Some(input_sm), ..InstrumentOptions::default() };
+    let result = instrument(&intermediate, "intermediate.js", &opts).unwrap();
+    assert_eq!(result.coverage_map.path, "intermediate.js");
+    assert!(
+        result.coverage_map.input_source_map.is_some(),
+        "with compose off, the inputSourceMap stays embedded"
+    );
+}
+
+#[test]
+fn compose_input_source_map_unusable_map_backs_off() {
+    // A source map that declares no usable source makes `remap_coverage` return
+    // None; eager compose must back off and leave the embedded map in place so
+    // the lazy remap path is still available.
+    let input_sm = r#"{"version":3,"sources":[],"mappings":"","names":[]}"#;
+    let opts = InstrumentOptions {
+        input_source_map: Some(input_sm.to_string()),
+        compose_input_source_map: true,
+        ..InstrumentOptions::default()
+    };
+    let result = instrument("const x = 1;", "intermediate.js", &opts).unwrap();
+    assert_eq!(result.coverage_map.path, "intermediate.js", "unusable map -> path unchanged");
+    assert!(
+        result.coverage_map.input_source_map.is_some(),
+        "unusable map -> embedded map retained for the lazy fallback"
+    );
+}
+
+#[test]
+fn compose_input_source_map_preserves_function_identity_overlay() {
+    // The function-identity overlay is built before composition and the remap
+    // pipeline does not rewrite it, so the eager overlay must equal the overlay
+    // produced by instrument-then-remap. This keeps the `fallow:fn:<hex>` join
+    // keys stable across the eager and lazy paths.
+    let intermediate = "function add(a, b) {\n  return a + b;\n}\n";
+    let original_ts = "function add(a: number, b: number): number {\n  return a + b;\n}\n";
+    let input_sm = format!(
+        r#"{{"version":3,"sources":["src/app.ts"],"sourcesContent":[{original_ts:?}],"mappings":"AAAA;AACA;AACA","names":[]}}"#,
+    );
+
+    let eager = instrument(
+        intermediate,
+        "intermediate.js",
+        &InstrumentOptions {
+            input_source_map: Some(input_sm.clone()),
+            compose_input_source_map: true,
+            function_identity_overlay: true,
+            ..InstrumentOptions::default()
+        },
+    )
+    .unwrap();
+
+    let lazy_instrumented = instrument(
+        intermediate,
+        "intermediate.js",
+        &InstrumentOptions {
+            input_source_map: Some(input_sm),
+            function_identity_overlay: true,
+            ..InstrumentOptions::default()
+        },
+    )
+    .unwrap();
+    let lazy = remap_coverage(&lazy_instrumented.coverage_map).expect("lazy remap succeeds");
+
+    assert!(eager.coverage_map.x_fallow_function_map.is_some(), "overlay survives eager compose");
+    assert_eq!(
+        serde_json::to_value(&eager.coverage_map.x_fallow_function_map).unwrap(),
+        serde_json::to_value(&lazy.x_fallow_function_map).unwrap(),
+        "overlay must be identical across eager and lazy paths"
+    );
+}
+
+#[test]
+fn compose_input_source_map_does_not_double_compose_output_source_map() {
+    // The coverage map and the output `source_map` are independent artifacts.
+    // `compose_input_source_map` rewrites the COVERAGE map; the output source
+    // map (instrumented JS -> original source) is composed once by
+    // `finalize_source_map` regardless of the flag. So with `source_map: true`,
+    // the emitted `source_map` must be byte-identical whether or not
+    // `compose_input_source_map` is set: the flag must NOT feed the input map
+    // into the source-map chain a second time.
+    let (_, intermediate, input_sm) = three_line_inputs();
+
+    let without_compose = instrument(
+        &intermediate,
+        "intermediate.js",
+        &InstrumentOptions {
+            source_map: true,
+            input_source_map: Some(input_sm.clone()),
+            ..InstrumentOptions::default()
+        },
+    )
+    .unwrap();
+
+    let with_compose = instrument(
+        &intermediate,
+        "intermediate.js",
+        &InstrumentOptions {
+            source_map: true,
+            input_source_map: Some(input_sm),
+            compose_input_source_map: true,
+            ..InstrumentOptions::default()
+        },
+    )
+    .unwrap();
+
+    let sm_without = without_compose.source_map.expect("source_map emitted");
+    let sm_with = with_compose.source_map.expect("source_map emitted");
+    assert_eq!(
+        sm_with, sm_without,
+        "output source_map must not change when the coverage map is composed eagerly"
+    );
+
+    // And the output source map chains all the way back to the original source
+    // (instrumented JS -> src/app.ts), not just to the intermediate JS.
+    let parsed: serde_json::Value = serde_json::from_str(&sm_with).unwrap();
+    let sources: Vec<&str> =
+        parsed["sources"].as_array().unwrap().iter().map(|s| s.as_str().unwrap()).collect();
+    assert!(
+        sources.contains(&"src/app.ts"),
+        "output source map must point back at the original source, got: {sources:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `composeInputSourceMap` flag to `InstrumentOptions` (napi: `composeInputSourceMap`). When true and `inputSourceMap` is set, `instrument()` folds the input source map into the coverage map during instrumentation, so the returned `coverageMap` (and the runtime `__coverage__` baked into the instrumented `code`) ships original-source positions, is keyed by the original source path, and embeds no `inputSourceMap`. A downstream `remapCoverageMap` on the result is a no-op.

This removes the per-collection remap round-trip for E2E collectors (Playwright et al.) that dump `window.__coverage__` directly:

```ts
const raw = await page.evaluate(() => window.__coverage__);
writeFileSync(out, JSON.stringify(raw)); // already original-source
```

## Design

- Composition runs after the function-identity overlay attaches and before the coverage map is serialized into the preamble's `coverageData` literal, so the runtime `__coverage__` carries composed positions and the overlay keeps its pre-remap-derived ids. This makes the eager path bit-for-bit equal to instrument-then-`remap_coverage`.
- Graceful back-off: when the input map is unusable (no source / unparseable), the embedded map is retained so the lazy `remapCoverageMap` path still works.
- The output `source_map` is unaffected (still composed once by `finalize_source_map`); verified byte-identical with and without the flag.
- Scope: core + napi only. CLI never passes `inputSourceMap` (inert there); the Vitest adapter is intentionally untouched (the istanbul provider already remaps at report time).

## Tests

- Rust (`source_maps_test.rs`): eager==lazy bit-for-bit equality, preamble keying, off-by-default, no-op-without-map, unusable-map back-off, overlay preservation, and no-double-compose of the output source map.
- napi (`test.mjs`): full round-trip through the binding.
- End-to-end smoke: executed the instrumented code in a VM, confirmed `window.__coverage__` ships original-source positions with correct runtime hit counts and that `remap(lazy dump)` equals the eager dump.

Closes #100