### PR TITLE
refactor: split oversized parser/builder units and cover CLI error paths

### DIFF
--- a/crates/oxc-coverage-instrument-cli/src/main.rs
+++ b/crates/oxc-coverage-instrument-cli/src/main.rs
@@ -220,29 +220,40 @@ fn dispatch(args: &[String]) -> Result<ExitCode, ExitCode> {
     }
 }
 
-fn parse_instrument_args(args: &[String]) -> Result<InstrumentArgs, ExitCode> {
-    if args.is_empty() {
+/// Resolve the leading positional filename for the instrument path, handling
+/// the empty-args, `--help`/`-h`, `--version`/`-V`, and unknown-leading-flag
+/// short-circuits before any option scanning begins. `Err` carries the exit
+/// code for those early-return cases (success for help/version, failure
+/// otherwise); `Ok` is the filename to instrument.
+fn instrument_filename(args: &[String]) -> Result<String, ExitCode> {
+    let Some(first) = args.first() else {
         eprintln!("error: instrument requires a file argument");
         print_instrument_usage();
         return Err(ExitCode::FAILURE);
-    }
+    };
 
-    if args[0] == "--help" || args[0] == "-h" {
+    if first == "--help" || first == "-h" {
         print_instrument_usage();
         return Err(ExitCode::SUCCESS);
     }
-    if args[0] == "--version" || args[0] == "-V" {
+    if first == "--version" || first == "-V" {
         print_version();
         return Err(ExitCode::SUCCESS);
     }
-    if args[0].starts_with('-') {
-        eprintln!("error: unknown option: {}", args[0]);
+    if first.starts_with('-') {
+        eprintln!("error: unknown option: {first}");
         print_instrument_usage();
         return Err(ExitCode::FAILURE);
     }
 
+    Ok(first.clone())
+}
+
+fn parse_instrument_args(args: &[String]) -> Result<InstrumentArgs, ExitCode> {
+    let filename = instrument_filename(args)?;
+
     let mut cli = InstrumentArgs {
-        filename: args[0].clone(),
+        filename,
         output_file: None,
         coverage_map_only: false,
         source_map: false,

--- a/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
+++ b/crates/oxc-coverage-instrument-cli/tests/cli_test.rs
@@ -772,3 +772,144 @@ fn report_flag_without_value_exits_failure() {
         "trailing --format must surface a missing-value error, got: {stderr}",
     );
 }
+
+#[test]
+fn report_threshold_rejects_non_numeric_value() {
+    // Distinct from the out-of-range and non-finite tests: a token that does
+    // not parse as f64 at all must hit the parse-error arm, not the range arm.
+    let cov = write_temp("report_threshold_nonnumeric.json", SAMPLE_COVERAGE);
+    let out = cli()
+        .arg("report")
+        .arg("--format")
+        .arg("html")
+        .arg("--output-dir")
+        .arg(std::env::temp_dir().join("oxc_cov_cli_threshold_nonnumeric_out"))
+        .arg("--threshold")
+        .arg("not-a-number")
+        .arg(&cov)
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "non-numeric --threshold must be rejected");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--threshold must be a number"),
+        "non-numeric --threshold should surface the parse error, got: {stderr}"
+    );
+}
+
+#[test]
+fn report_fail_under_rejects_non_numeric_value() {
+    let cov = write_temp("report_fail_under_nonnumeric.json", SAMPLE_COVERAGE);
+    let out = cli()
+        .arg("report")
+        .arg("--format")
+        .arg("text-summary")
+        .arg("--fail-under")
+        .arg("ninety")
+        .arg(&cov)
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "non-numeric --fail-under must be rejected");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--fail-under must be a number"), "got: {stderr}");
+}
+
+#[test]
+fn report_fail_under_rejects_out_of_range_value() {
+    let cov = write_temp("report_fail_under_oob.json", SAMPLE_COVERAGE);
+    let out = cli()
+        .arg("report")
+        .arg("--format")
+        .arg("text-summary")
+        .arg("--fail-under")
+        .arg("250")
+        .arg(&cov)
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "out-of-range --fail-under must be rejected");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("outside [0, 100]"), "got: {stderr}");
+}
+
+#[test]
+fn report_fail_under_rejects_non_finite_value() {
+    // `parse_percentage` shares the finite-number guard with `--threshold`;
+    // NaN / inf parse as f64 but must be rejected before the range check.
+    let cov = write_temp("report_fail_under_nan.json", SAMPLE_COVERAGE);
+    for bad in ["nan", "inf", "-inf"] {
+        let out = cli()
+            .arg("report")
+            .arg("--format")
+            .arg("text-summary")
+            .arg("--fail-under")
+            .arg(bad)
+            .arg(&cov)
+            .output()
+            .unwrap();
+        assert!(!out.status.success(), "should reject --fail-under {bad}");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("finite number") || stderr.contains("outside [0, 100]"),
+            "rejection for {bad:?} should mention finite-number or range; got: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn report_nonexistent_coverage_file_reports_read_error() {
+    // Distinct from the missing-positional case: a path IS supplied but the
+    // file is absent, so the read in read_coverage_map fails.
+    let missing = std::env::temp_dir().join("oxc_cov_cli_report_absent_file.json");
+    let _ = std::fs::remove_file(&missing);
+    let out = cli().arg("report").arg("--format").arg("text").arg(&missing).output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("cannot read"), "should report read failure, got: {stderr}");
+}
+
+#[test]
+fn explicit_instrument_subcommand_without_file_reports_error() {
+    // `instrument` with no following filename feeds an empty slice to
+    // parse_instrument_args, which must ask for a file rather than panic.
+    let out = cli().arg("instrument").output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("instrument requires a file argument"), "got: {stderr}");
+}
+
+#[test]
+fn output_to_unwritable_path_reports_write_error() {
+    // `-o` pointing into a directory that does not exist makes the code-file
+    // write in write_code_and_map fail; the CLI must surface a clear error.
+    let src = write_temp("output_unwritable.js", "const x = 1;");
+    let bad_dir = std::env::temp_dir().join("oxc_cov_cli_nonexistent_dir_xyz");
+    let _ = std::fs::remove_dir_all(&bad_dir);
+    let bad_out = bad_dir.join("nested").join("out.js");
+    let out = cli().arg(&src).arg("-o").arg(&bad_out).output().unwrap();
+    assert!(!out.status.success(), "writing under a missing dir should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("cannot write"), "got: {stderr}");
+}
+
+#[test]
+fn source_map_with_output_file_writes_sidecar_map() {
+    // With `-o`, the source map goes to `<out>.map` (the file branch of
+    // write_or_print_source_map) rather than to stderr.
+    let src = write_temp("source_map_sidecar.js", "const x = 1;");
+    let out_path = std::env::temp_dir().join("oxc_cov_cli_source_map_sidecar.instrumented.js");
+    let sm_path = std::path::PathBuf::from(format!("{}.map", out_path.display()));
+    let map_path = std::path::PathBuf::from(format!("{}.map.json", out_path.display()));
+    let _ = std::fs::remove_file(&out_path);
+    let _ = std::fs::remove_file(&sm_path);
+    let _ = std::fs::remove_file(&map_path);
+
+    let out = cli().arg(&src).arg("--source-map").arg("-o").arg(&out_path).output().unwrap();
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+
+    let sm = std::fs::read_to_string(&sm_path).expect("source map sidecar should be written");
+    let value: serde_json::Value =
+        serde_json::from_str(&sm).expect("sidecar .map should be valid JSON");
+    assert_eq!(value["version"], 3, "expected a v3 source map in the sidecar");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("Source map:"), "should report the sidecar path, got: {stderr}");
+}

--- a/crates/oxc-coverage-instrument/src/coverage_builder.rs
+++ b/crates/oxc-coverage-instrument/src/coverage_builder.rs
@@ -62,20 +62,7 @@ pub(crate) fn build_file_coverage(maps: CoverageMaps) -> FileCoverage {
     let f = fn_map.keys().map(|k| (k.clone(), 0)).collect();
     let b =
         branch_map.iter().map(|(k, entry)| (k.clone(), vec![0; entry.locations.len()])).collect();
-    let b_t = if logical_branch_ids.is_empty() {
-        None
-    } else {
-        Some(
-            logical_branch_ids
-                .iter()
-                .filter_map(|&id| {
-                    let key = id.to_string();
-                    let len = branch_map.get(&key)?.locations.len();
-                    Some((key, vec![0; len]))
-                })
-                .collect(),
-        )
-    };
+    let b_t = build_truthy_hit_map(&branch_map, &logical_branch_ids);
 
     FileCoverage {
         path,
@@ -89,6 +76,29 @@ pub(crate) fn build_file_coverage(maps: CoverageMaps) -> FileCoverage {
         input_source_map: None,
         x_fallow_function_map: None,
     }
+}
+
+/// Build the optional truthy (`bT`) hit map: one zeroed hit Vec per logical
+/// branch id, sized to that branch's surviving arm count. Returns `None` when
+/// no logical branches were tracked (the common case, `report_logic` off) so
+/// the field is omitted from the serialized map.
+fn build_truthy_hit_map(
+    branch_map: &BTreeMap<String, BranchEntry>,
+    logical_branch_ids: &[usize],
+) -> Option<BTreeMap<String, Vec<u32>>> {
+    if logical_branch_ids.is_empty() {
+        return None;
+    }
+    Some(
+        logical_branch_ids
+            .iter()
+            .filter_map(|&id| {
+                let key = id.to_string();
+                let len = branch_map.get(&key)?.locations.len();
+                Some((key, vec![0; len]))
+            })
+            .collect(),
+    )
 }
 
 /// Compute the optional `x_fallow_functionMap` overlay from a populated

--- a/crates/oxc-coverage-source-maps/src/lib.rs
+++ b/crates/oxc-coverage-source-maps/src/lib.rs
@@ -206,7 +206,14 @@ fn apply_source_map(
 /// them. Mirrors `istanbul-lib-source-maps`'s `transformer.js`. See
 /// [`RemapOptions::drop_unmapped`] for the exact per-kind rules.
 fn prune_unmapped(coverage: &mut FileCoverage, sm: &srcmap_sourcemap::SourceMap) {
-    // Statements: drop when either start or end fails to remap.
+    prune_statements(coverage, sm);
+    prune_functions(coverage, sm);
+    prune_branches(coverage, sm);
+}
+
+/// Statements: drop when either start or end fails to remap, taking the
+/// matching `s` hit slot with the dropped entry.
+fn prune_statements(coverage: &mut FileCoverage, sm: &srcmap_sourcemap::SourceMap) {
     let mut dropped_statements: Vec<String> = Vec::new();
     coverage.statement_map.retain(|key, loc| {
         if try_remap_location(loc, sm) {
@@ -219,10 +226,12 @@ fn prune_unmapped(coverage: &mut FileCoverage, sm: &srcmap_sourcemap::SourceMap)
     for key in &dropped_statements {
         coverage.s.remove(key);
     }
+}
 
-    // Functions: drop when any of decl.start, decl.end, loc.start, loc.end
-    // fails to remap. `FnEntry::line` is refreshed from the remapped
-    // `loc.start.line` on the surviving entries.
+/// Functions: drop when any of decl.start, decl.end, loc.start, loc.end fails
+/// to remap. `FnEntry::line` is refreshed from the remapped `loc.start.line`
+/// on the surviving entries; the matching `f` hit slot follows the drop.
+fn prune_functions(coverage: &mut FileCoverage, sm: &srcmap_sourcemap::SourceMap) {
     let mut dropped_fns: Vec<String> = Vec::new();
     coverage.fn_map.retain(|key, fn_entry| {
         let decl_ok = try_remap_location(&mut fn_entry.decl, sm);
@@ -238,11 +247,13 @@ fn prune_unmapped(coverage: &mut FileCoverage, sm: &srcmap_sourcemap::SourceMap)
     for key in &dropped_fns {
         coverage.f.remove(key);
     }
+}
 
-    // Branches: per-arm prune when either arm endpoint fails to remap; drop
-    // the whole branch when no arms survive OR when the umbrella `loc`
-    // start/end fails to remap. The `b` / `bT` arm vectors track surviving
-    // arms by position so their hit counts stay aligned.
+/// Branches: per-arm prune when either arm endpoint fails to remap; drop the
+/// whole branch when no arms survive OR when the umbrella `loc` start/end fails
+/// to remap. The `b` / `bT` arm vectors track surviving arms by position so
+/// their hit counts stay aligned.
+fn prune_branches(coverage: &mut FileCoverage, sm: &srcmap_sourcemap::SourceMap) {
     let mut dropped_branches: Vec<String> = Vec::new();
     let mut surviving_arms: BTreeMap<String, Vec<usize>> = BTreeMap::new();
     coverage.branch_map.retain(|key, branch_entry| {


### PR DESCRIPTION
Acts on two findings from the latest SIG audit: unit size (the one production property over the 4-star thresholds) and the CLI being the lowest-covered crate.

Closes #103

## Unit size
- `parse_instrument_args`: extract `instrument_filename()` for the empty-args / help / version / unknown-leading-flag short-circuits, leaving the option loop as the function body.
- `prune_unmapped`: split into `prune_statements` / `prune_functions` / `prune_branches`; the umbrella function is now a three-line orchestrator.
- `build_file_coverage`: extract `build_truthy_hit_map()` for the `bT` map.

## CLI coverage
Add integration tests for the previously uncovered error branches: `--fail-under` validation (non-numeric, out-of-range, non-finite), `--threshold` non-numeric, report on a nonexistent file, explicit `instrument` with no file, `-o` write failure under a missing directory, and the source-map sidecar write.

## Results
- CLI `main.rs`: 85.1% -> 92.0% line, 89.5% -> 94.9% function
- Workspace total: 95.7% -> 96.3% line
- Behavior unchanged; no public API changes. Full suite green, clippy clean, fmt clean.