### PR TITLE
feat: add trackOptionalChainBranches option to disable ?. branch tracking (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ The same applies to the surviving arm when `/* istanbul ignore if */` drops the 
 
 Each `?.` link surfaces in `branchMap` as an `optional-chain` entry with two arms: arm 0 when the observed value is `null`/`undefined` (the link short-circuits), arm 1 when the link continues. `istanbul-lib-instrument` does not track these. Reporters that walk `branchMap` by type-agnostic shape pick up the new entries automatically; reporters that hard-code the istanbul type names need to learn the new label.
 
+Set `trackOptionalChainBranches: false` (Rust: `track_optional_chain: false`; vitest adapter: `createOxcInstrumenter({ trackOptionalChainBranches: false })`) to opt out: optional chains are left native, with no `_oc` helper and no `optional-chain` branches. This matches `istanbul-lib-instrument` byte-for-byte on `?.` and removes the per-operand helper-call overhead in optional-chain-dense hot paths. Statement, function, and other branch coverage are unaffected. Defaults to `true`.
+
 **Migration from `@vitest/coverage-istanbul`:** a codebase that uses `??=`/`||=`/`&&=` heavily will see a higher branch-coverage denominator (and so a slightly lower branch %) after switching providers. To rebaseline CI thresholds after the swap:
 
 ```bash

--- a/crates/oxc-coverage-instrument-napi/src/lib.rs
+++ b/crates/oxc-coverage-instrument-napi/src/lib.rs
@@ -166,6 +166,13 @@ pub struct InstrumentOptions {
     pub compose_input_source_map: Option<bool>,
     /// When true, adds truthy-value tracking (bT) for logical expression operands.
     pub report_logic: Option<bool>,
+    /// Track each optional-chaining (`?.`) link as a branch (default: true).
+    /// When false, optional chains are left native: no `_oc` helper is emitted
+    /// and no `optional-chain` branches are registered. Matches
+    /// `istanbul-lib-instrument` (which does not track `?.` as a branch) and
+    /// avoids the per-operand helper-call overhead in optional-chain-dense hot
+    /// paths. Statement and other branch coverage are unaffected.
+    pub track_optional_chain_branches: Option<bool>,
     /// Class method names to exclude from coverage instrumentation.
     pub ignore_class_methods: Option<Vec<String>>,
     /// When true, run the TypeScript-strip pass before instrumentation.
@@ -288,6 +295,7 @@ pub fn instrument(
                 input_source_map: o.input_source_map,
                 compose_input_source_map: o.compose_input_source_map.unwrap_or(false),
                 report_logic: o.report_logic.unwrap_or(false),
+                track_optional_chain: o.track_optional_chain_branches.unwrap_or(true),
                 ignore_class_methods: o.ignore_class_methods.unwrap_or_default(),
                 strip_typescript: o.strip_typescript.unwrap_or(false),
                 decorator_mode,

--- a/crates/oxc-coverage-instrument-napi/test.mjs
+++ b/crates/oxc-coverage-instrument-napi/test.mjs
@@ -1501,4 +1501,75 @@ function runInstrumented(result, filename, callExpression) {
   console.log('  [PASS] verbatim issue #107 FileCoverage is reconciled and merges (regression fixture)');
 }
 
+// Test: trackOptionalChainBranches gates optional-chain (?.) instrumentation (issue #108)
+{
+  const source = 'function f(e, cb) { return e?.stderr?.replace(/x/, "y") ?? cb?.(1); }';
+
+  // Default (flag omitted): each ?. link is a branch and the _oc helper is emitted.
+  const tracked = instrument(source, 'oc.js', { coverageVariable: '__ocOn' });
+  const trackedMap = JSON.parse(tracked.coverageMap);
+  const trackedOc = Object.values(trackedMap.branchMap).filter((e) => e.type === 'optional-chain');
+  assert.equal(trackedOc.length, 3, 'default tracks all three ?. links (two member, one call)');
+  assert.ok(tracked.code.includes('_oc('), 'default emits the _oc helper');
+
+  // trackOptionalChainBranches: false leaves the chain native.
+  const native = instrument(source, 'oc.js', {
+    coverageVariable: '__ocOff',
+    trackOptionalChainBranches: false,
+  });
+  const nativeMap = JSON.parse(native.coverageMap);
+  const nativeOc = Object.values(nativeMap.branchMap).filter((e) => e.type === 'optional-chain');
+  assert.equal(nativeOc.length, 0, 'no optional-chain branches when tracking is off');
+  assert.ok(!native.code.includes('_oc('), 'the _oc helper must not be emitted when off');
+  // The ?? is still a logical branch; only ?. tracking is suppressed.
+  assert.ok(
+    Object.values(nativeMap.branchMap).some((e) => e.type === 'binary-expr'),
+    'non-optional-chain branches are still tracked',
+  );
+  // Statement coverage is unaffected by the toggle.
+  assert.equal(
+    Object.keys(nativeMap.statementMap).length,
+    Object.keys(trackedMap.statementMap).length,
+    'statement coverage is identical with and without optional-chain tracking',
+  );
+
+  // The native-mode code still runs and preserves ?. semantics.
+  const g = {};
+  assert.doesNotThrow(() => {
+    new Function('globalThis', `${native.code}\nglobalThis.__r = eval('f')(null, null);`)(g);
+  }, 'native optional-chain code runs without throwing');
+  assert.equal(g.__r, undefined, 'e?.stderr on null short-circuits to undefined, ?? cb?.(1) on null cb stays undefined');
+
+  console.log('  [PASS] trackOptionalChainBranches gates optional-chain instrumentation (issue #108)');
+}
+
+// Test: createOxcInstrumenter forwards trackOptionalChainBranches and validates it
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  const source = 'export function f(e) { return e?.a?.b; }';
+
+  const on = createOxcInstrumenter();
+  on.instrumentSync(source, 'oc.ts');
+  const onOc = Object.values(on.lastFileCoverage().branchMap).filter(
+    (e) => e.type === 'optional-chain',
+  );
+  assert.equal(onOc.length, 2, 'adapter defaults to tracking ?. links');
+
+  const off = createOxcInstrumenter({ trackOptionalChainBranches: false });
+  const offCode = off.instrumentSync(source, 'oc.ts');
+  const offOc = Object.values(off.lastFileCoverage().branchMap).filter(
+    (e) => e.type === 'optional-chain',
+  );
+  assert.equal(offOc.length, 0, 'adapter honors trackOptionalChainBranches: false');
+  assert.ok(!offCode.includes('_oc('), 'adapter emits no _oc helper when off');
+
+  assert.throws(
+    () => createOxcInstrumenter({ trackOptionalChainBranches: 'no' }),
+    /trackOptionalChainBranches.*must be a boolean/,
+    'non-boolean trackOptionalChainBranches throws TypeError',
+  );
+
+  console.log('  [PASS] createOxcInstrumenter forwards/validates trackOptionalChainBranches');
+}
+
 console.log('\nAll tests passed!');

--- a/crates/oxc-coverage-instrument-napi/vitest.js
+++ b/crates/oxc-coverage-instrument-napi/vitest.js
@@ -39,6 +39,11 @@ const TS_EXTENSION_REGEX = /\.([mc]ts|tsx?)$/i;
  *   Vitest passes its internal `__VITEST_COVERAGE__`; defaults to `__coverage__`.
  * @param {string[]} [options.ignoreClassMethods] Class method names to skip.
  * @param {boolean} [options.reportLogic] Enable truthy-value tracking (bT).
+ * @param {boolean} [options.trackOptionalChainBranches] Track each optional
+ *   chaining (`?.`) link as a branch (default: true). Set to false to leave
+ *   optional chains native (no `_oc` helper, no `optional-chain` branch),
+ *   matching `istanbul-lib-instrument` and avoiding the per-operand helper-call
+ *   overhead in `?.`-dense hot paths.
  * @param {boolean} [options.stripTypescript] Run the TypeScript-strip pass
  *   before instrumentation. When omitted (default), the adapter auto-detects:
  *   it strips when the filename matches `/\.([mc]ts|tsx?)$/i` AND no
@@ -76,6 +81,19 @@ function createOxcInstrumenter(options) {
   const coverageVariable = options.coverageVariable || '__coverage__';
   const ignoreClassMethods = options.ignoreClassMethods || [];
   const reportLogic = options.reportLogic || false;
+  // Defaults to true (track), so a bare `|| true` would wrongly coerce an
+  // explicit `false` back to `true`. Treat only `undefined` as "use the
+  // default" and validate everything else as a strict boolean.
+  const trackOptionalChainBranchesRaw = options.trackOptionalChainBranches;
+  if (
+    trackOptionalChainBranchesRaw !== undefined &&
+    typeof trackOptionalChainBranchesRaw !== 'boolean'
+  ) {
+    throw new TypeError(
+      `oxc-coverage-instrument: createOxcInstrumenter({ trackOptionalChainBranches }) must be a boolean or undefined, got ${typeof options.trackOptionalChainBranches}`,
+    );
+  }
+  const trackOptionalChainBranches = trackOptionalChainBranchesRaw ?? true;
   const functionIdentityOverlay = options.functionIdentityOverlay || false;
   if (typeof functionIdentityOverlay !== 'boolean') {
     throw new TypeError(
@@ -142,6 +160,7 @@ function createOxcInstrumenter(options) {
         sourceMap: true,
         inputSourceMap: inputSourceMap ? JSON.stringify(inputSourceMap) : undefined,
         reportLogic,
+        trackOptionalChainBranches,
         ignoreClassMethods,
         stripTypescript,
         experimentalDecorators,

--- a/crates/oxc-coverage-instrument/src/instrument.rs
+++ b/crates/oxc-coverage-instrument/src/instrument.rs
@@ -69,6 +69,21 @@ pub struct InstrumentOptions {
     /// This enables nyc-style logic coverage that tracks not just which branch was
     /// taken, but whether each operand evaluated to a truthy value.
     pub report_logic: bool,
+    /// When true (the default), each optional-chaining (`?.`) link is tracked as
+    /// an `optional-chain` branch: its operand is wrapped in a `cov_fn_oc`
+    /// helper call that records whether the value was nullish. This is more
+    /// complete than `istanbul-lib-instrument`, which does not track `?.` as a
+    /// branch.
+    ///
+    /// Set to false to leave optional chains native: no `cov_fn_oc` helper is
+    /// emitted and no `optional-chain` branch is registered. This matches
+    /// `istanbul-lib-instrument` byte-for-byte on `?.` and avoids the
+    /// per-operand helper-call overhead in optional-chain-dense hot paths
+    /// (issue #108). Statement, function, and other branch coverage are
+    /// unaffected.
+    ///
+    /// Defaults to true so existing behavior is unchanged.
+    pub track_optional_chain: bool,
     /// Class method names to exclude from coverage instrumentation.
     /// Matches Istanbul's `ignoreClassMethods` behavior for class methods and
     /// named function expressions with a matching id.
@@ -187,6 +202,7 @@ impl Default for InstrumentOptions {
             input_source_map: None,
             compose_input_source_map: false,
             report_logic: false,
+            track_optional_chain: true,
             ignore_class_methods: Vec::new(),
             strip_typescript: false,
             decorator_mode: DecoratorMode::PassThrough,
@@ -309,6 +325,7 @@ pub fn instrument(
         source,
         cov_fn_name: &cov_fn_name,
         report_logic: options.report_logic,
+        track_optional_chain: options.track_optional_chain,
         ignore_class_methods: options.ignore_class_methods.clone(),
         eager_remapper,
     });
@@ -540,6 +557,10 @@ pub(crate) fn collect_for_v8_to_istanbul(
         source,
         cov_fn_name: &cov_fn_name,
         report_logic: false,
+        // V8-collect builds the location maps that V8 byte ranges intersect
+        // against, so optional-chain branches stay tracked (the default); this
+        // path emits no runtime helper, only the maps.
+        track_optional_chain: true,
         ignore_class_methods: Vec::new(),
         // V8-collect never composes an input source map; gate is a no-op.
         eager_remapper: None,

--- a/crates/oxc-coverage-instrument/src/transform.rs
+++ b/crates/oxc-coverage-instrument/src/transform.rs
@@ -107,8 +107,10 @@ pub struct CoverageTransform<'src, 'arena> {
     cov_fn_bt_name: Option<&'arena str>,
     /// `${cov_fn_name}_oc` optional-chain link observer, pre-interned. Used
     /// every time we wrap a `?.` link; one allocation per file rather than
-    /// one per link.
-    cov_fn_oc_name: &'arena str,
+    /// one per link. `None` when `track_optional_chain` is off (mirrors
+    /// `cov_fn_bt_name`'s allocate-only-when-needed shape), since no link is
+    /// ever wrapped in that mode.
+    cov_fn_oc_name: Option<&'arena str>,
     /// When true, adds truthy-value tracking (`bT`) for logical expression operands.
     report_logic: bool,
     /// When true (the default), each optional-chaining (`?.`) link is wrapped in
@@ -217,7 +219,8 @@ impl<'src, 'arena> CoverageTransform<'src, 'arena> {
             skip_current_var_decl: false,
             cov_fn_name,
             cov_fn_bt_name: report_logic.then(|| allocator.alloc_str(&format!("{cov_fn_name}_bt"))),
-            cov_fn_oc_name: allocator.alloc_str(&format!("{cov_fn_name}_oc")),
+            cov_fn_oc_name: track_optional_chain
+                .then(|| allocator.alloc_str(&format!("{cov_fn_name}_oc")) as &str),
             report_logic,
             track_optional_chain,
             ignore_class_methods,
@@ -518,7 +521,12 @@ impl<'src, 'arena> CoverageTransform<'src, 'arena> {
         // Build `cov_fn_oc(<original>, <branch_id>)`. The helper observes
         // the value, increments b[id][0] or b[id][1] based on nullishness,
         // and returns the value unchanged so native `?.` semantics fire.
-        let callee = ctx.ast.expression_identifier(SPAN, self.cov_fn_oc_name);
+        // Reaching here means an optional link was wrapped, which the three
+        // dispatch points gate behind `track_optional_chain`, so the name is set.
+        let oc_name = self
+            .cov_fn_oc_name
+            .expect("wrap_optional_chain_link runs only when track_optional_chain is on");
+        let callee = ctx.ast.expression_identifier(SPAN, oc_name);
         let original = mem::replace(object, dummy_expr(ctx));
         let mut args = ctx.ast.vec();
         args.push(Argument::from(original));

--- a/crates/oxc-coverage-instrument/src/transform.rs
+++ b/crates/oxc-coverage-instrument/src/transform.rs
@@ -111,6 +111,11 @@ pub struct CoverageTransform<'src, 'arena> {
     cov_fn_oc_name: &'arena str,
     /// When true, adds truthy-value tracking (`bT`) for logical expression operands.
     report_logic: bool,
+    /// When true (the default), each optional-chaining (`?.`) link is wrapped in
+    /// the `cov_fn_oc` helper and registered as an `optional-chain` branch. When
+    /// false the chain is left native (no helper, no branch), matching
+    /// `istanbul-lib-instrument` and avoiding the per-operand call overhead.
+    track_optional_chain: bool,
     /// Class method names to exclude from coverage instrumentation.
     ignore_class_methods: Vec<String>,
     /// Branch IDs of logical expression branches (for building the `bT` map).
@@ -164,6 +169,10 @@ pub struct TransformInit<'src, 'arena> {
     /// When true, emits the truthy-value tracker (`bT` counters) for logical
     /// expression operands.
     pub report_logic: bool,
+    /// When true (the default), optional-chain (`?.`) links are tracked as
+    /// `optional-chain` branches via the `cov_fn_oc` helper. When false they are
+    /// left native (issue #108).
+    pub track_optional_chain: bool,
     /// Class method and named-function-expression identifiers to skip,
     /// matching Istanbul's `ignoreClassMethods` semantics.
     pub ignore_class_methods: Vec<String>,
@@ -180,6 +189,7 @@ impl<'src, 'arena> CoverageTransform<'src, 'arena> {
             source,
             cov_fn_name,
             report_logic,
+            track_optional_chain,
             ignore_class_methods,
             eager_remapper,
         } = init;
@@ -209,6 +219,7 @@ impl<'src, 'arena> CoverageTransform<'src, 'arena> {
             cov_fn_bt_name: report_logic.then(|| allocator.alloc_str(&format!("{cov_fn_name}_bt"))),
             cov_fn_oc_name: allocator.alloc_str(&format!("{cov_fn_name}_oc")),
             report_logic,
+            track_optional_chain,
             ignore_class_methods,
             logical_branch_ids: Vec::new(),
             pending_class_field_hoists: Vec::new(),
@@ -2037,7 +2048,7 @@ impl<'a> Traverse<'a, CoverageState> for CoverageTransform<'_, 'a> {
         member: &mut StaticMemberExpression<'a>,
         ctx: &mut TraverseCtx<'a, CoverageState>,
     ) {
-        if member.optional && !self.in_ignored_subtree() {
+        if self.track_optional_chain && member.optional && !self.in_ignored_subtree() {
             self.wrap_optional_chain_link(&mut member.object, member.span, ctx);
         }
     }
@@ -2047,7 +2058,7 @@ impl<'a> Traverse<'a, CoverageState> for CoverageTransform<'_, 'a> {
         member: &mut ComputedMemberExpression<'a>,
         ctx: &mut TraverseCtx<'a, CoverageState>,
     ) {
-        if member.optional && !self.in_ignored_subtree() {
+        if self.track_optional_chain && member.optional && !self.in_ignored_subtree() {
             self.wrap_optional_chain_link(&mut member.object, member.span, ctx);
         }
     }
@@ -2057,7 +2068,7 @@ impl<'a> Traverse<'a, CoverageState> for CoverageTransform<'_, 'a> {
         call: &mut CallExpression<'a>,
         ctx: &mut TraverseCtx<'a, CoverageState>,
     ) {
-        if call.optional && !self.in_ignored_subtree() {
+        if self.track_optional_chain && call.optional && !self.in_ignored_subtree() {
             self.wrap_optional_chain_link(&mut call.callee, call.span, ctx);
         }
     }

--- a/crates/oxc-coverage-instrument/tests/integration_test.rs
+++ b/crates/oxc-coverage-instrument/tests/integration_test.rs
@@ -176,6 +176,53 @@ fn optional_call_tracked_as_branch() {
 }
 
 #[test]
+fn track_optional_chain_false_leaves_chain_native() {
+    // issue #108: with tracking off, member/computed/call optional links emit
+    // no `optional-chain` branch and no `_oc` helper, matching
+    // istanbul-lib-instrument.
+    let source = "function f(e, cb) { return e?.stderr?.['k']?.replace(/x/, 'y') ?? cb?.(1); }";
+    let opts = InstrumentOptions { track_optional_chain: false, ..InstrumentOptions::default() };
+    let r = instrument(source, "test.js", &opts).unwrap();
+
+    let oc_count =
+        r.coverage_map.branch_map.values().filter(|e| e.branch_type == "optional-chain").count();
+    assert_eq!(oc_count, 0, "no optional-chain branches when tracking is disabled");
+    assert!(!r.code.contains("_oc("), "the `_oc` helper must not be emitted:\n{}", r.code);
+    // The `??` is still a logical branch: only `?.` tracking is suppressed.
+    assert!(
+        r.coverage_map.branch_map.values().any(|e| e.branch_type == "binary-expr"),
+        "non-optional-chain branches (the `??`) are still tracked",
+    );
+}
+
+#[test]
+fn track_optional_chain_default_on_matches_existing_behavior() {
+    // The default (true) is unchanged: the same source tracked produces
+    // optional-chain branches and the helper.
+    let source = "function f(e) { return e?.stderr?.replace(/x/, 'y'); }";
+    let tracked = instrument_js(source);
+    let oc_count = tracked
+        .coverage_map
+        .branch_map
+        .values()
+        .filter(|e| e.branch_type == "optional-chain")
+        .count();
+    assert_eq!(oc_count, 2, "default still tracks each `?.` link");
+    assert!(tracked.code.contains("_oc(val, id)"), "default still emits the helper");
+
+    // Statement/function counts are identical with and without tracking; only
+    // the optional-chain branches differ.
+    let opts = InstrumentOptions { track_optional_chain: false, ..InstrumentOptions::default() };
+    let untracked = instrument(source, "test.js", &opts).unwrap();
+    assert_eq!(
+        tracked.coverage_map.statement_map.len(),
+        untracked.coverage_map.statement_map.len(),
+        "statement coverage is unaffected by the optional-chain toggle",
+    );
+    assert_eq!(tracked.coverage_map.fn_map.len(), untracked.coverage_map.fn_map.len());
+}
+
+#[test]
 fn class_field_initializer_keeps_function_name() {
     // `field = function () {}` previously wrapped the value as
     // `(++cov.s[N], function () {})`, which broke NamedEvaluation and


### PR DESCRIPTION
## Summary

Adds an opt-out for optional-chain (`?.`) branch tracking, as requested in #108.

#69 tracks each `?.` link as an `optional-chain` branch by wrapping every operand in a runtime `_oc` helper call. That is more complete than `istanbul-lib-instrument` (which leaves `?.` native), but it is unconditional: it adds per-operand call overhead in optional-chain-dense hot paths, and it diverges from istanbul for projects that want byte-comparable HTML reports or gate only on line coverage.

## What changed

A boolean, defaulting to `true` so existing behavior is unchanged:

- **Rust**: `InstrumentOptions::track_optional_chain` (default `true`).
- **napi**: `InstrumentOptions.trackOptionalChainBranches` (default `true`).
- **vitest adapter**: `createOxcInstrumenter({ trackOptionalChainBranches })`, validated as a strict boolean so an explicit `false` is honored rather than coerced.

When `false`, the three optional-link dispatch points (static member, computed member, call) skip `wrap_optional_chain_link`, so no `optional-chain` branch is registered and the `_oc` helper append self-disables. The chain is left native, matching istanbul. Statement, function, and other branch coverage are unaffected. The flag mirrors the existing `report_logic` plumbing through `TransformInit` / `CoverageTransform`; the v8-collect path keeps tracking on since it only builds the location maps that V8 byte ranges intersect against.

## Output parity

For `function f(item) { return item?.a?.b?.c ?? 0; }`:

```js
// trackOptionalChainBranches: true (default), branchMap: 4
function cov_oc(val, id) { ++cov.b[id][val == null ? 0 : 1]; return val; }
// ... _oc(_oc(_oc(item, 3)?.a, 2)?.b, 1)?.c ...

// trackOptionalChainBranches: false, branchMap: 1
return (++cov.b[0][0], item?.a?.b?.c) ?? (++cov.b[0][1], 0);
```

The `false` output instruments only the surrounding `??`, byte-for-byte the istanbul shape.

## Tests

- Rust `integration_test.rs`: `track_optional_chain_false_leaves_chain_native` (no `optional-chain` branches, no `_oc` helper, `??` still tracked) and `track_optional_chain_default_on_matches_existing_behavior` (default unchanged; statement/function counts identical across the toggle).
- napi `test.mjs`: gating through `instrument()` (default vs `false`, including a runtime execution of the native output) and through the vitest adapter (forwarding plus strict-boolean `TypeError` validation).

Full workspace `cargo test --all-targets`, `clippy -D warnings`, `cargo fmt`, rustdoc `-D warnings`, and the napi suite pass.

Closes #108
