### PR TITLE
test(napi): add real @babel/core-emitted source map to the getMapping parity harness

### DIFF
--- a/crates/oxc-coverage-instrument-napi/package-lock.json
+++ b/crates/oxc-coverage-instrument-napi/package-lock.json
@@ -12,6 +12,7 @@
         "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "devDependencies": {
+        "@babel/core": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.13",
         "@napi-rs/cli": "3.6.2",
         "istanbul-lib-coverage": "^3.2.2",
@@ -1877,6 +1878,117 @@
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
       }
+    },
+    "node_modules/@oxc-coverage-instrument/binding-darwin-arm64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-darwin-arm64/-/binding-darwin-arm64-0.8.0.tgz",
+      "integrity": "sha512-olOspVcHY5xy3xXqCp/y5bhBOPtN1J0Ix+VF8h5HJSy6r/A2zPS9RIAgx15jygkr2JqEmf3SW8yJuM5qtSkglg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-coverage-instrument/binding-darwin-x64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-darwin-x64/-/binding-darwin-x64-0.8.0.tgz",
+      "integrity": "sha512-5CFhV/ohoPYboQlCk+vl7JmHsNeU/nFUumm/uk1HrwothCPnCJfaIKo+v4KWTe9g8+KDEyYdLOTW8LNSr3Ccog==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-coverage-instrument/binding-linux-arm64-gnu": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.8.0.tgz",
+      "integrity": "sha512-rxlpegOJdBU+3ouIzrFnwK1OtmKQ1XY38mgkU4YK44OAYXZLY+EBTmnYHvIS88ObXpAQfNHTA3N6wxXvNI2RNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-coverage-instrument/binding-linux-x64-gnu": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.8.0.tgz",
+      "integrity": "sha512-+UZ79wWC5gt0krOO1ga7gtRfAn3wYpbbMmzcTcRiUbNRP+W4wWnLVElw1CEuK/s/YL14P0p4fDu9CjHnm+oXiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-coverage-instrument/binding-linux-x64-musl": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-linux-x64-musl/-/binding-linux-x64-musl-0.8.0.tgz",
+      "integrity": "sha512-+bVFZ+ehWlz9dtY0Bh9op1/akqlOLzIkJIxWIhwyLSFP35d3YV35bsJi39Q54X7PQ9ezRy8wrHcRB56JHVolXg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-coverage-instrument/binding-wasm32-wasi": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-wasm32-wasi/-/binding-wasm32-wasi-0.8.0.tgz",
+      "integrity": "sha512-DcUQ0wdg2kMx/HleEmPsX3F7ElAcRW5DLAYRytfpdE48+1pe7qPpC/QEU7ApHz1Bsyk8u48774LFxQz4Wo5rlg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      }
+    },
+    "node_modules/@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded/-/binding-wasm32-wasi-singlethreaded-0.8.0.tgz",
+      "integrity": "sha512-ckFg+9VdVeFFahOp8/LkuXKKx75+znX5ri8CRn5burz3DUX+FwCrh4ZMd8rfcMjtPuc793LmqgfRGKEGdwwjKQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      }
+    },
+    "node_modules/@oxc-coverage-instrument/binding-win32-arm64-msvc": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.8.0.tgz",
+      "integrity": "sha512-WMhkvFB4bPX7gIEIOhLXwydnS9oNHfIDDyainq1XUoXYXDOQ/aGdQ4nQW8SIFb0+L4tg55Ieiqf8qJLi4DiKfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-coverage-instrument/binding-win32-x64-msvc": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.8.0.tgz",
+      "integrity": "sha512-9owNUS4NLV2JAt8rHuLYcHopuoyXxoIqnIrRHLvq8Dal0XUdCj+p01Xjl08+vu0iEvaVHPEiNfUqlPc6vnCvMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",

--- a/crates/oxc-coverage-instrument-napi/package.json
+++ b/crates/oxc-coverage-instrument-napi/package.json
@@ -63,6 +63,7 @@
     "@napi-rs/wasm-runtime": "^1.1.4"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.0",
     "@jridgewell/gen-mapping": "^0.3.13",
     "@napi-rs/cli": "3.6.2",
     "istanbul-lib-coverage": "^3.2.2",

--- a/crates/oxc-coverage-instrument-napi/test.mjs
+++ b/crates/oxc-coverage-instrument-napi/test.mjs
@@ -1590,6 +1590,7 @@ function runInstrumented(result, filename, callExpression) {
   const { GenMapping, addMapping, setSourceContent, toEncodedMap } = await import(
     '@jridgewell/gen-mapping'
   );
+  const babel = (await import('@babel/core')).default;
 
   const utf16LineLength = (content, line1) => {
     const raw = content.split('\n')[line1 - 1] ?? '';
@@ -1631,19 +1632,11 @@ function runInstrumented(result, filename, callExpression) {
 
   const sortedArray = (set) => [...set].sort();
 
-  // Build an input source map from explicit token mappings, instrument the
-  // intermediate JS with it embedded, then remap through istanbul and through us
-  // and assert the surviving spans match. Single-source maps only (cross-source
-  // arm/decl source-equality is istanbul drop-semantics territory, out of #111
-  // scope).
-  const parityCheck = async (label, sourcePath, sourceContent, intermediateJs, mappings) => {
-    const gm = new GenMapping({ file: 'intermediate.js' });
-    setSourceContent(gm, sourcePath, sourceContent);
-    for (const m of mappings) {
-      addMapping(gm, { generated: m.gen, source: sourcePath, original: m.orig });
-    }
-    const inputMap = toEncodedMap(gm);
-
+  // Core: instrument the intermediate JS with `inputMap` embedded, remap through
+  // istanbul and through us, and assert the surviving spans match column-by-column.
+  // Single-source maps only (cross-source arm/decl source-equality is istanbul
+  // drop-semantics territory, out of #111 scope).
+  const compareRemap = async (label, intermediateJs, inputMap, sourceContent) => {
     const result = instrument(intermediateJs, 'intermediate.js', {
       inputSourceMap: JSON.stringify(inputMap),
     });
@@ -1696,6 +1689,17 @@ function runInstrumented(result, filename, callExpression) {
       );
     }
     return ours;
+  };
+
+  // Build an input source map from explicit token mappings (via gen-mapping),
+  // then run it through the shared remap+compare core.
+  const parityCheck = async (label, sourcePath, sourceContent, intermediateJs, mappings) => {
+    const gm = new GenMapping({ file: 'intermediate.js' });
+    setSourceContent(gm, sourcePath, sourceContent);
+    for (const m of mappings) {
+      addMapping(gm, { generated: m.gen, source: sourcePath, original: m.orig });
+    }
+    return compareRemap(label, intermediateJs, toEncodedMap(gm), sourceContent);
   };
 
   // Reporter case 1: an exclusive end that falls past the last segment. Direct
@@ -1787,6 +1791,84 @@ function runInstrumented(result, filename, callExpression) {
       { gen: { line: 3, column: 9 }, orig: { line: 3, column: 9 } },
       { gen: { line: 4, column: 0 }, orig: { line: 4, column: 0 } },
     ]);
+  }
+
+  // Real-transpiler case: a REAL @babel/core transform emits the input source
+  // map (real VLQ, segments at token starts, sourcesContent), exercising the
+  // sparse-segment scenario that hand-built maps don't. An inline rename plugin
+  // shortens long identifiers, which collapses member chains and shifts columns
+  // hard, so exclusive ends land between segments (the exact #111 case).
+  {
+    const realSrc = [
+      "import { defineAsyncComponent } from 'vue';",
+      'const state = { someVeryLongPropertyName1: 0, anotherQuiteLongFieldName: 1 };',
+      'function classify(inputValue) {',
+      "  const label = inputValue > 0 ? 'positive' : 'negative';",
+      '  return state.someVeryLongPropertyName1 + label.length;',
+      '}',
+      "const lazyComponentFactory = defineAsyncComponent(() => importHelper('./Widget.vue'));",
+      'const mapped = [1, 2, 3].map((eachNumber) => eachNumber * state.anotherQuiteLongFieldName);',
+      'export { classify, lazyComponentFactory, mapped };',
+      '',
+    ].join('\n');
+
+    // Pass 1: collect a rename table for identifiers longer than 4 chars (skip
+    // import/export specifiers so the module bindings stay resolvable).
+    const renames = new Map();
+    let renameCounter = 0;
+    const collectRenames = () => ({
+      visitor: {
+        Identifier(path) {
+          const name = path.node.name;
+          if (name.length <= 4) return;
+          if (path.parentPath.isImportSpecifier() || path.parentPath.isExportSpecifier()) return;
+          if (!renames.has(name)) renames.set(name, `v${renameCounter++}`);
+        },
+      },
+    });
+    babel.transformSync(realSrc, {
+      filename: 'src/app.js',
+      plugins: [collectRenames],
+      sourceType: 'module',
+    });
+    const applyRenames = () => ({
+      visitor: {
+        Identifier(path) {
+          const renamed = renames.get(path.node.name);
+          if (!renamed) return;
+          if (path.parentPath.isImportSpecifier() || path.parentPath.isExportSpecifier()) return;
+          path.node.name = renamed;
+        },
+      },
+    });
+    const out = babel.transformSync(realSrc, {
+      filename: 'src/app.js',
+      plugins: [applyRenames],
+      sourceType: 'module',
+      sourceMaps: true,
+      compact: false,
+    });
+    const inputMap = out.map;
+    if (!inputMap.sourcesContent) inputMap.sourcesContent = [realSrc];
+
+    const ours = await compareRemap(
+      'real @babel/core-emitted map',
+      out.code,
+      inputMap,
+      realSrc,
+    );
+
+    // Prove the fix is load-bearing on a real map: at least one surviving
+    // single-line statement must span more than one column (ends are widened to
+    // the full token, not truncated back to a previous segment).
+    const file = Object.keys(ours)[0];
+    const widened = Object.values(ours[file].statementMap).filter(
+      (l) => l.start.line === l.end.line && l.end.column - l.start.column > 1,
+    );
+    assert.ok(
+      widened.length > 0,
+      'real-map remap produces widened multi-column statement spans (ends not truncated)',
+    );
   }
 
   console.log('  [PASS] istanbul-lib-source-maps getMapping byte-parity (issue #111)');


### PR DESCRIPTION
## Summary

Follow-up test hardening for the #111 getMapping remap (already merged + released in v0.8.0). The byte-parity test previously remapped only hand-built `@jridgewell/gen-mapping` maps through both `istanbul-lib-source-maps@5` and us. Hand-built maps don't reproduce the segment density, column shifts, and `sourcesContent` shape a real transpiler emits, which is exactly where the truncation #111 fixed bites.

Adds a parity case driven by a **real `@babel/core` transform**: an inline rename plugin shortens long identifiers (collapsing member chains, shifting columns so exclusive ends land between segments), babel emits a real source map with `sourcesContent`, we instrument the output and remap through both istanbul `transformCoverage` and `remapCoverageMap(dropUnmapped:true)`, asserting the surviving spans match column-by-column plus at least one widened multi-column statement span (proving the fix is load-bearing on a real map).

- `parityCheck` refactored to share a `compareRemap` core with the new case.
- `@babel/core` promoted from a transitive to a declared devDependency.

Test-only + devDep change; no Rust source or published-surface change, so no release.

Issue: N/A (test hardening for already-closed #111)