### PR TITLE
fix(ci): unbreak wasm builds (emnapi pin) and Actions Security (zizmor)

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -39,3 +39,10 @@ rules:
   template-injection:
     ignore:
       - ci.yml
+  # release-npm.yml bootstraps a recent npm (npm@latest) so OIDC trusted
+  # publishing / provenance works; the base runner's npm is too old. This is a
+  # CI toolchain bootstrap of a first-party tool, not an untrusted ad-hoc
+  # dependency install.
+  adhoc-packages:
+    ignore:
+      - release-npm.yml

--- a/crates/oxc-coverage-instrument-napi/package-lock.json
+++ b/crates/oxc-coverage-instrument-napi/package-lock.json
@@ -292,20 +292,20 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -313,9 +313,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1912,9 +1912,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1928,9 +1925,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1943,9 +1937,6 @@
       "integrity": "sha512-mC0NBb0Auyo2JPxQdLOCSO4pAYtF17jaft1g2P0RBPXgeGFQ8A7wjUiu4eNIFT8rM2IsuBIdsDZUDtilgQ2dtA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/crates/oxc-coverage-instrument-napi/package.json
+++ b/crates/oxc-coverage-instrument-napi/package.json
@@ -79,6 +79,11 @@
     "test": "node test.mjs && node scripts/patch-wasi-browser-shim.test.mjs",
     "test:browser-loader": "node scripts/browser-loader.test.mjs"
   },
+  "overrides": {
+    "emnapi": "1.11.1",
+    "@emnapi/core": "1.11.1",
+    "@emnapi/runtime": "1.11.1"
+  },
   "optionalDependencies": {
     "@oxc-coverage-instrument/binding-darwin-arm64": "0.9.1",
     "@oxc-coverage-instrument/binding-darwin-x64": "0.9.1",


### PR DESCRIPTION
Every open PR (including the Dependabot ones) was red on the same shared jobs even though main was green on its last run. Both failures are environment drift, not code: main would fail the same way on a fresh run.

## Fixes

**Napi wasm builds** (`Napi Test (wasm32-wasip1*)`, `Native vs WASM parity`, `WASM node example`, `Cloudflare Workers example`)
- The napi lockfile went out of sync once the `binding-*` optionalDependencies were bumped to 0.9.1 (the sibling binding packages publish after the release commit, so the release-time lockfile could not resolve them).
- CI installs with `npm ci || npm install`. The failed sync check fell back to `npm install`, which re-resolved floating `emnapi ^1.10.0` to 1.11.1 while `@emnapi/core`/`@emnapi/runtime` stayed at 1.10.0. napi-rs then aborted every wasm build with `emnapi version mismatch`.
- Pin `emnapi`, `@emnapi/core`, `@emnapi/runtime` to one lockstep version via `overrides` so the fallback can never split them again, and regenerate the lockfile so `npm ci` passes cleanly.

**Actions Security** (`zizmor`)
- zizmor 1.26.x added the `adhoc-packages` audit, which flags the `npm install -g npm@latest` bootstrap in `release-npm.yml`. The workflow runs zizmor via unpinned `uvx`, so the new audit started failing with no code change.
- That step bootstraps a recent npm for OIDC trusted publishing / provenance; it is a first-party toolchain bootstrap, not an untrusted install. Added a per-file ignore with rationale, matching the existing entries in `.github/zizmor.yml`.

Verified locally: `npm ci` in the napi crate now exits 0 and the lockfile carries a consistent emnapi 1.11.1 set. CI on this PR validates the wasm builds and the zizmor job end to end.

Closes: N/A (CI environment-drift fix, no tracking issue)