### PR TITLE
ci: pin taiki-e/install-action by version with explicit tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: taiki-e/install-action@9b29ffac42f36c4efe76140737435c61cfb92383 # cargo-audit
+      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        with:
+          tool: cargo-audit
       - run: cargo audit
 
   deny:
@@ -146,7 +148,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: taiki-e/install-action@b9da40722b5dc25d162879fdf6a098f2d71926cc # cargo-shear
+      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        with:
+          tool: cargo-shear
       - run: cargo shear
 
   zizmor:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           key: coverage
 
-      - uses: taiki-e/install-action@2d15d02e710b40b6332201aba6af30d595b5cd96 # cargo-llvm-cov
+      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        with:
+          tool: cargo-llvm-cov
 
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION
Follow-up to #145 (closed). The `cargo-audit` / `cargo-shear` / `cargo-llvm-cov` steps pinned `taiki-e/install-action` by its tool-name convenience tag (the SHA of the `cargo-audit` tag, commented `# cargo-audit`). Dependabot rewrites that tool-name-tag SHA to a plain version-tag SHA and keeps the stale comment, so `install-action` loses the tool selector and fails with `no tool specified`.

Pin all three to a version tag (v2.81.11, matching `bench.yml`) and select the tool via `with: tool:`, the same pattern `cargo-codspeed` and `cargo-zigbuild` already use. Dependabot can now bump `install-action` without dropping the tool.

Closes: N/A (CI hygiene follow-up to #145)