### PR TITLE
feat(instrument): name callback arguments from the callee (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,21 @@ Each `?.` link surfaces in `branchMap` as an `optional-chain` entry with two arm
 
 Set `trackOptionalChainBranches: false` (Rust: `track_optional_chain: false`; vitest adapter: `createOxcInstrumenter({ trackOptionalChainBranches: false })`) to opt out: optional chains are left native, with no `_oc` helper and no `optional-chain` branches. This matches `istanbul-lib-instrument` byte-for-byte on `?.` and removes the per-operand helper-call overhead in optional-chain-dense hot paths. Statement, function, and other branch coverage are unaffected. Defaults to `true`.
 
+### 6. Callback-argument names from the callee (opt-in, off by default)
+
+Section 2 recovers names from a binding (variable declarator, property key, class method, assignment target). A function that is passed *directly as a call or `new` argument* has no such binding, so both `istanbul-lib-instrument` and this instrumenter fall back to `(anonymous_N)`. In callback-heavy code (route handlers, `.map`/`.filter`, promise `.then`, `describe`/`it`, `new Promise`) that fallback dominates the `fnMap`.
+
+Set `nameCallbackArguments: true` (Rust: `name_callback_arguments: true`; vitest adapter: `createOxcInstrumenter({ nameCallbackArguments: true })`) to name these from the callee:
+
+| Source | `fnMap[].name` with the option | default |
+|---|---|---|
+| `arr.map((x) => x)` | `map` | `(anonymous_0)` |
+| `el.addEventListener("click", () => {})` | `addEventListener` | `(anonymous_0)` |
+| `new Promise((resolve) => {})` | `Promise` | `(anonymous_0)` |
+| `(function () {})()` (IIFE, callee not argument) | `(anonymous_0)` | `(anonymous_0)` |
+
+Only the callee is used, never a sibling string argument (a route path or a test description): the traversal ancestor for an argument position exposes the callee but not the other arguments. A binding name (section 2) and an explicit named function expression both still take precedence; this only replaces the `(anonymous_N)` fallback. Because the name comes from the callee rather than a running counter, it is also **stable across rebuilds** (the `(anonymous_N)` index renumbers whenever an unrelated function is added), which matters for tools that key function identity on the name. Defaults to `false`, so the default output stays byte-identical to what Istanbul consumers expect.
+
 **Migration from `@vitest/coverage-istanbul`:** a codebase that uses `??=`/`||=`/`&&=` heavily will see a higher branch-coverage denominator (and so a slightly lower branch %) after switching providers. To rebaseline CI thresholds after the swap:
 
 ```bash

--- a/crates/oxc-coverage-instrument-napi/src/lib.rs
+++ b/crates/oxc-coverage-instrument-napi/src/lib.rs
@@ -94,6 +94,7 @@ mod tests {
             experimental_decorators: None,
             emit_decorator_metadata: None,
             function_identity_overlay: None,
+            name_callback_arguments: None,
         }
     }
 
@@ -260,6 +261,7 @@ mod tests {
         assert!(!opts.strip_typescript);
         assert_eq!(opts.decorator_mode, DecoratorMode::PassThrough);
         assert!(!opts.function_identity_overlay);
+        assert!(!opts.name_callback_arguments);
     }
 
     #[test]
@@ -276,6 +278,7 @@ mod tests {
         input.experimental_decorators = Some(true);
         input.emit_decorator_metadata = Some(true);
         input.function_identity_overlay = Some(true);
+        input.name_callback_arguments = Some(true);
 
         let opts = native_instrument_options(Some(input)).expect("mapped options");
         assert_eq!(opts.coverage_variable, "__cov");
@@ -288,6 +291,7 @@ mod tests {
         assert!(opts.strip_typescript);
         assert_eq!(opts.decorator_mode, DecoratorMode::ExperimentalWithMetadata);
         assert!(opts.function_identity_overlay);
+        assert!(opts.name_callback_arguments);
     }
 
     #[test]
@@ -406,6 +410,20 @@ pub struct InstrumentOptions {
     /// Defaults to false. The default JSON output stays byte-identical to
     /// what Istanbul consumers expect.
     pub function_identity_overlay: Option<bool>,
+    /// When true, name an otherwise-anonymous function/arrow that is a direct
+    /// argument of a call or `new` expression from its callee: `arr.map(cb)`
+    /// -> `"map"`, `el.addEventListener("click", () => {})` ->
+    /// `"addEventListener"`, `new Promise((res) => {})` -> `"Promise"`.
+    /// `istanbul-lib-instrument` leaves these `(anonymous_N)`, so this is an
+    /// opt-in enhancement. Names inferred from a binding (variable declarator,
+    /// property key, assignment target, default value) still win; this only
+    /// replaces the `(anonymous_N)` fallback with a callee-derived name that is
+    /// also stable across rebuilds (the `(anonymous_N)` counter renumbers).
+    /// Only the callee is used, never a sibling string argument.
+    ///
+    /// Defaults to false. The default JSON output stays byte-identical to what
+    /// Istanbul consumers expect.
+    pub name_callback_arguments: Option<bool>,
 }
 
 /// Options for `remapCoverageMap` and `remapCoverageMapWithLoader`.
@@ -507,6 +525,7 @@ fn native_instrument_options(
         strip_typescript: o.strip_typescript.unwrap_or(false),
         decorator_mode,
         function_identity_overlay: o.function_identity_overlay.unwrap_or(false),
+        name_callback_arguments: o.name_callback_arguments.unwrap_or(false),
     })
 }
 

--- a/crates/oxc-coverage-instrument-napi/test.mjs
+++ b/crates/oxc-coverage-instrument-napi/test.mjs
@@ -1625,6 +1625,54 @@ function runInstrumented(result, filename, callExpression) {
   console.log('  [PASS] createOxcInstrumenter forwards/validates trackOptionalChainBranches');
 }
 
+// Test: nameCallbackArguments names callback arguments from the callee
+{
+  const source = 'arr.map((x) => x + 1);\nnew Promise((resolve) => resolve(1));';
+
+  const off = instrument(source, 'cb.js');
+  const offNames = Object.values(JSON.parse(off.coverageMap).fnMap).map((f) => f.name);
+  assert.ok(
+    offNames.every((n) => n.startsWith('(anonymous_')),
+    `default leaves callback args anonymous, got ${JSON.stringify(offNames)}`,
+  );
+
+  const on = instrument(source, 'cb.js', { nameCallbackArguments: true });
+  const onNames = Object.values(JSON.parse(on.coverageMap).fnMap).map((f) => f.name);
+  assert.deepEqual(onNames, ['map', 'Promise'], 'callee names surface with the option on');
+
+  console.log('  [PASS] nameCallbackArguments names callback arguments from the callee');
+}
+
+// Test: createOxcInstrumenter forwards nameCallbackArguments and validates it
+{
+  const { createOxcInstrumenter } = await import('./vitest.js');
+  const source = 'export const f = (arr) => arr.filter((x) => x > 0);';
+
+  const off = createOxcInstrumenter();
+  off.instrumentSync(source, 'cb.ts');
+  const offNames = Object.values(off.lastFileCoverage().fnMap).map((f) => f.name);
+  assert.ok(
+    offNames.includes('f') && offNames.some((n) => n.startsWith('(anonymous_')),
+    `adapter defaults to leaving callback args anonymous, got ${JSON.stringify(offNames)}`,
+  );
+
+  const on = createOxcInstrumenter({ nameCallbackArguments: true });
+  on.instrumentSync(source, 'cb.ts');
+  const onNames = Object.values(on.lastFileCoverage().fnMap).map((f) => f.name);
+  assert.ok(
+    onNames.includes('f') && onNames.includes('filter'),
+    `adapter honors nameCallbackArguments: true, got ${JSON.stringify(onNames)}`,
+  );
+
+  assert.throws(
+    () => createOxcInstrumenter({ nameCallbackArguments: 'yes' }),
+    /nameCallbackArguments.*must be a boolean/,
+    'non-boolean nameCallbackArguments throws TypeError',
+  );
+
+  console.log('  [PASS] createOxcInstrumenter forwards/validates nameCallbackArguments');
+}
+
 // Test: istanbul-lib-source-maps getMapping byte-parity (issue #111)
 //
 // The remap path now resolves surviving positions through an istanbul

--- a/crates/oxc-coverage-instrument-napi/vitest.d.ts
+++ b/crates/oxc-coverage-instrument-napi/vitest.d.ts
@@ -6,16 +6,23 @@
  */
 export interface OxcInstrumenterOptions {
   /** Global variable name for coverage data (Vitest passes `__VITEST_COVERAGE__`). */
-  coverageVariable?: string
+  coverageVariable?: string;
   /** Class method names to exclude from coverage instrumentation. */
-  ignoreClassMethods?: string[]
+  ignoreClassMethods?: string[];
   /** When true, adds truthy-value tracking (bT) for logical expressions. */
-  reportLogic?: boolean
+  reportLogic?: boolean;
   /**
    * Attach the optional `x_fallow_functionMap` extension to the last file
    * coverage object. Defaults to false.
    */
-  functionIdentityOverlay?: boolean
+  functionIdentityOverlay?: boolean;
+  /**
+   * Name an otherwise-anonymous function/arrow that is a direct call/`new`
+   * argument from the callee (`arr.map(cb)` -> `"map"`), instead of the
+   * `(anonymous_N)` fallback. Binding names still take precedence. Defaults to
+   * false (byte-identical to Istanbul).
+   */
+  nameCallbackArguments?: boolean;
   /**
    * Run the TypeScript-strip pass before instrumentation. When omitted
    * (default), the adapter auto-detects: it strips when the filename matches
@@ -25,7 +32,7 @@ export interface OxcInstrumenterOptions {
    * TypeScript but do not produce an `inputSourceMap`. Set to `true` to force
    * strip. Non-boolean values throw `TypeError`.
    */
-  stripTypescript?: boolean
+  stripTypescript?: boolean;
 }
 
 /**
@@ -48,9 +55,9 @@ export interface OxcInstrumenterOptions {
  * ```
  */
 export declare function createOxcInstrumenter(options?: OxcInstrumenterOptions): {
-  instrumentSync(code: string, filename: string, inputSourceMap?: any): string
-  lastSourceMap(): any
-  lastFileCoverage(): any
+  instrumentSync(code: string, filename: string, inputSourceMap?: any): string;
+  lastSourceMap(): any;
+  lastFileCoverage(): any;
   /** Property alias for compatibility with vite-plugin-istanbul. */
-  readonly fileCoverage: any
-}
+  readonly fileCoverage: any;
+};

--- a/crates/oxc-coverage-instrument-napi/vitest.js
+++ b/crates/oxc-coverage-instrument-napi/vitest.js
@@ -74,6 +74,10 @@ const TS_EXTENSION_REGEX = /\.([mc]ts|tsx?)$/i;
  *   adapter preserves the tsconfig-style ergonomics for the vitest UX.
  * @param {boolean} [options.functionIdentityOverlay] Attach the optional
  *   `x_fallow_functionMap` extension to the last file coverage object.
+ * @param {boolean} [options.nameCallbackArguments] Name an otherwise-anonymous
+ *   function/arrow that is a direct call/`new` argument from the callee
+ *   (`arr.map(cb)` -> `"map"`). Binding names still take precedence. Defaults
+ *   to false.
  * @returns {{ instrumentSync, lastSourceMap, lastFileCoverage }}
  */
 function createOxcInstrumenter(options) {
@@ -98,6 +102,12 @@ function createOxcInstrumenter(options) {
   if (typeof functionIdentityOverlay !== 'boolean') {
     throw new TypeError(
       `oxc-coverage-instrument: createOxcInstrumenter({ functionIdentityOverlay }) must be a boolean or undefined, got ${typeof options.functionIdentityOverlay}`,
+    );
+  }
+  const nameCallbackArguments = options.nameCallbackArguments || false;
+  if (typeof nameCallbackArguments !== 'boolean') {
+    throw new TypeError(
+      `oxc-coverage-instrument: createOxcInstrumenter({ nameCallbackArguments }) must be a boolean or undefined, got ${typeof options.nameCallbackArguments}`,
     );
   }
   const stripTypescriptOverride = options.stripTypescript;
@@ -166,6 +176,7 @@ function createOxcInstrumenter(options) {
         experimentalDecorators,
         emitDecoratorMetadata,
         functionIdentityOverlay,
+        nameCallbackArguments,
       });
 
       // Store raw JSON — defer parsing until actually needed.

--- a/crates/oxc-coverage-instrument/src/instrument.rs
+++ b/crates/oxc-coverage-instrument/src/instrument.rs
@@ -134,6 +134,27 @@ pub struct InstrumentOptions {
     /// Defaults to false. The default JSON output stays byte-identical to
     /// what Istanbul consumers expect.
     pub function_identity_overlay: bool,
+    /// When true, give a name to a function/arrow expression that is a direct
+    /// argument of a call or `new` expression and has no other inferable name,
+    /// derived from the callee: `arr.map(x => x)` -> `"map"`,
+    /// `el.addEventListener("click", () => {})` -> `"addEventListener"`,
+    /// `new Promise((res) => {})` -> `"Promise"`. `istanbul-lib-instrument`
+    /// leaves these `(anonymous_N)`, so this is an opt-in enhancement (like
+    /// `track_optional_chain` being more complete than Istanbul) rather than
+    /// the default. Names inferred from a binding (variable declarator,
+    /// property key, assignment target, default value) still take precedence;
+    /// this only replaces the `(anonymous_N)` fallback. Because the name comes
+    /// from the callee, it is stable across rebuilds (the `(anonymous_N)`
+    /// counter renumbers when unrelated functions are added), which matters for
+    /// downstream tools that key function identity on the name.
+    ///
+    /// Only the callee is used, never a sibling string argument (e.g. a route
+    /// path or a test description): the traversal ancestor for an argument
+    /// position exposes the callee but not the other arguments.
+    ///
+    /// Defaults to false. The default JSON output stays byte-identical to what
+    /// Istanbul consumers expect.
+    pub name_callback_arguments: bool,
 }
 
 /// How `strip_typescript` handles decorator syntax.
@@ -207,6 +228,7 @@ impl Default for InstrumentOptions {
             strip_typescript: false,
             decorator_mode: DecoratorMode::PassThrough,
             function_identity_overlay: false,
+            name_callback_arguments: false,
         }
     }
 }
@@ -386,6 +408,7 @@ fn run_coverage_transform<'src, 'arena>(
         report_logic: options.report_logic,
         track_optional_chain: options.track_optional_chain,
         ignore_class_methods: options.ignore_class_methods.clone(),
+        name_callback_arguments: options.name_callback_arguments,
         eager_remapper: eager_remapper(options),
     });
     let state = CoverageState { pragmas };
@@ -628,6 +651,10 @@ pub(crate) fn collect_for_v8_to_istanbul(
         // path emits no runtime helper, only the maps.
         track_optional_chain: true,
         ignore_class_methods: Vec::new(),
+        // V8-collect builds only the position maps that V8 byte ranges
+        // intersect against; the fnMap names never reach a consumer here, so
+        // it stays Istanbul-exact (no callback naming) with no options to wire.
+        name_callback_arguments: false,
         // V8-collect never composes an input source map; gate is a no-op.
         eager_remapper: None,
     });

--- a/crates/oxc-coverage-instrument/src/transform.rs
+++ b/crates/oxc-coverage-instrument/src/transform.rs
@@ -120,6 +120,9 @@ pub struct CoverageTransform<'src, 'arena> {
     track_optional_chain: bool,
     /// Class method names to exclude from coverage instrumentation.
     ignore_class_methods: Vec<String>,
+    /// When true, an anonymous function/arrow that is a direct call/`new`
+    /// argument is named from the callee instead of `(anonymous_N)`.
+    name_callback_arguments: bool,
     /// Branch IDs of logical expression branches (for building the `bT` map).
     pub logical_branch_ids: Vec<usize>,
     /// Per-class stack of class-field counters to hoist as synthetic
@@ -195,6 +198,10 @@ pub struct TransformInit<'src, 'arena> {
     /// Class method and named-function-expression identifiers to skip,
     /// matching Istanbul's `ignoreClassMethods` semantics.
     pub ignore_class_methods: Vec<String>,
+    /// When true, name an otherwise-anonymous function/arrow that is a direct
+    /// call/`new` argument from the callee (`arr.map(cb)` -> `"map"`). Opt-in;
+    /// Istanbul leaves these `(anonymous_N)`.
+    pub name_callback_arguments: bool,
     /// Eager-compose position-remap gate (issue #106). `Some` only in eager
     /// mode (`compose_input_source_map == true` with an input map present);
     /// `None` for every other caller, where gating is a strict no-op.
@@ -210,6 +217,7 @@ impl<'src, 'arena> CoverageTransform<'src, 'arena> {
             report_logic,
             track_optional_chain,
             ignore_class_methods,
+            name_callback_arguments,
             eager_remapper,
         } = init;
         let cov_fn_name = allocator.alloc_str(cov_fn_name);
@@ -241,6 +249,7 @@ impl<'src, 'arena> CoverageTransform<'src, 'arena> {
             report_logic,
             track_optional_chain,
             ignore_class_methods,
+            name_callback_arguments,
             logical_branch_ids: Vec::new(),
             pending_class_field_hoists: Vec::new(),
             eager_remapper,
@@ -635,14 +644,61 @@ impl<'src, 'arena> CoverageTransform<'src, 'arena> {
         );
     }
 
-    fn resolve_function_name(&mut self, func: &Function) -> String {
+    fn resolve_function_name(
+        &mut self,
+        func: &Function,
+        ctx: &TraverseCtx<'arena, CoverageState>,
+    ) -> String {
         if let Some(name) = self.pending_name.take() {
             return name;
         }
         if let Some(id) = &func.id {
             return id.name.to_string();
         }
+        if self.name_callback_arguments
+            && let Some(name) = callback_argument_name(ctx)
+        {
+            return name;
+        }
         format!("(anonymous_{})", self.fn_map.len())
+    }
+}
+
+/// When `name_callback_arguments` is enabled, derive a name for an
+/// otherwise-anonymous function/arrow that is a direct argument of a call or
+/// `new` expression, taken from the callee: `arr.map(cb)` -> `"map"`,
+/// `foo(cb)` -> `"foo"`, `new Promise(cb)` -> `"Promise"`. Istanbul leaves
+/// these `(anonymous_N)`.
+///
+/// The immediate ancestor must be the call/`new` *arguments* position, so an
+/// IIFE callee (`(() => {})()`) or a function returned from another function
+/// is not treated as a callback and stays anonymous. Only the callee is read;
+/// the argument-position ancestor deliberately excludes the sibling arguments,
+/// so a leading string literal (route path, test name) is not accessible here.
+fn callback_argument_name(ctx: &TraverseCtx<'_, CoverageState>) -> Option<String> {
+    use oxc_traverse::Ancestor;
+    let callee = match ctx.ancestors().next()? {
+        Ancestor::CallExpressionArguments(call) => call.callee(),
+        Ancestor::NewExpressionArguments(new_expr) => new_expr.callee(),
+        _ => return None,
+    };
+    callee_name(callee)
+}
+
+/// Extract a display name from a call/`new` callee expression. Mirrors the
+/// binding-name rules used elsewhere: a bare identifier keeps its name, a
+/// member access uses the (last) property name, and a computed access uses the
+/// string-literal key. Anything else (a computed non-string index, a call
+/// result, a parenthesized expression) yields no name.
+fn callee_name(callee: &Expression<'_>) -> Option<String> {
+    match callee {
+        Expression::Identifier(ident) => Some(ident.name.to_string()),
+        Expression::StaticMemberExpression(member) => Some(member.property.name.to_string()),
+        Expression::ComputedMemberExpression(member) => match &member.expression {
+            Expression::StringLiteral(lit) => Some(lit.value.to_string()),
+            _ => None,
+        },
+        _ => None,
     }
 }
 
@@ -1210,7 +1266,7 @@ impl<'a> Traverse<'a, CoverageState> for CoverageTransform<'_, 'a> {
             return;
         }
 
-        let name = self.resolve_function_name(func);
+        let name = self.resolve_function_name(func, ctx);
         // `decl` should point at the identifier itself, matching istanbul-lib-instrument:
         //   `function foo(…)`               → decl is the `foo` identifier span
         //   class methods `bar(…) {…}`      → decl is the method key span (set by
@@ -1280,6 +1336,7 @@ impl<'a> Traverse<'a, CoverageState> for CoverageTransform<'_, 'a> {
         let name = self
             .pending_name
             .take()
+            .or_else(|| self.name_callback_arguments.then(|| callback_argument_name(ctx)).flatten())
             .unwrap_or_else(|| format!("(anonymous_{})", self.fn_map.len()));
         let fn_id = self.add_function(
             name,

--- a/crates/oxc-coverage-instrument/tests/callback_argument_names_test.rs
+++ b/crates/oxc-coverage-instrument/tests/callback_argument_names_test.rs
@@ -1,0 +1,120 @@
+//! Tests for the opt-in `name_callback_arguments` option, which names an
+//! otherwise-anonymous function/arrow that is a direct call/`new` argument
+//! from its callee (`arr.map(cb)` -> `"map"`). `istanbul-lib-instrument`
+//! leaves these `(anonymous_N)`, so the default output is unchanged; only the
+//! flag surfaces the callee-derived names.
+
+use oxc_coverage_instrument::{InstrumentOptions, instrument};
+
+fn names(source: &str, name_callbacks: bool) -> Vec<String> {
+    let options =
+        InstrumentOptions { name_callback_arguments: name_callbacks, ..Default::default() };
+    let result = instrument(source, "t.js", &options).unwrap();
+    // fn_map is a BTreeMap keyed by the sequential id string ("0", "1", ...);
+    // BTreeMap orders lexicographically, which is good enough for these small
+    // single- or double-function fixtures.
+    result.coverage_map.fn_map.values().map(|entry| entry.name.clone()).collect()
+}
+
+#[test]
+fn default_leaves_callback_arguments_anonymous() {
+    // Off by default: byte-identical to istanbul for a plain callback.
+    let got = names("arr.map((x) => x + 1);", false);
+    assert_eq!(got.len(), 1);
+    assert!(
+        got[0].starts_with("(anonymous_"),
+        "default output must stay anonymous, got {}",
+        got[0]
+    );
+}
+
+#[test]
+fn member_callee_names_the_callback() {
+    assert_eq!(names("arr.map((x) => x + 1);", true), vec!["map"]);
+}
+
+#[test]
+fn plain_identifier_callee_names_the_callback() {
+    assert_eq!(names("useMemo(() => compute());", true), vec!["useMemo"]);
+}
+
+#[test]
+fn function_expression_argument_is_named_too() {
+    // Not just arrows: an anonymous `function` expression as an argument.
+    assert_eq!(names("run(function () { return 1; });", true), vec!["run"]);
+}
+
+#[test]
+fn new_expression_callee_names_the_callback() {
+    assert_eq!(names("new Promise((resolve) => resolve(1));", true), vec!["Promise"]);
+}
+
+#[test]
+fn later_argument_after_a_string_literal_is_named_from_callee() {
+    // The classic event-handler / route-handler shape: the function is the
+    // second argument, after a string. It is named from the callee, not the
+    // string (the argument-position ancestor cannot see sibling arguments).
+    assert_eq!(
+        names("el.addEventListener(\"click\", () => handle());", true),
+        vec!["addEventListener"]
+    );
+}
+
+#[test]
+fn computed_string_key_callee_is_named() {
+    assert_eq!(names("obj[\"handler\"](() => run());", true), vec!["handler"]);
+}
+
+#[test]
+fn binding_name_is_unaffected_by_the_flag() {
+    // The callee fallback runs only after the binding name (checked first), so
+    // a bound arrow keeps its declarator name with the flag on. Its body being
+    // a call (`run()`) does not pull "run": the arrow is not `run`'s argument.
+    assert_eq!(names("const handler = () => run();", true), vec!["handler"]);
+}
+
+#[test]
+fn named_function_expression_keeps_its_own_id() {
+    // `func.id` beats the callee: an explicitly named function expression
+    // reports its declared name, not the callee.
+    assert_eq!(names("run(function inner() { return 1; });", true), vec!["inner"]);
+}
+
+#[test]
+fn iife_callee_stays_anonymous() {
+    // The function is the *callee*, not an argument, so it is not a callback.
+    let got = names("(function () { return 1; })();", true);
+    assert_eq!(got.len(), 1);
+    assert!(got[0].starts_with("(anonymous_"), "IIFE must stay anonymous, got {}", got[0]);
+}
+
+#[test]
+fn computed_non_string_callee_stays_anonymous() {
+    // `arr[i](cb)` has no static callee name to borrow.
+    let got = names("handlers[index](() => run());", true);
+    assert_eq!(got.len(), 1);
+    assert!(
+        got[0].starts_with("(anonymous_"),
+        "computed non-string callee must stay anonymous, got {}",
+        got[0]
+    );
+}
+
+#[test]
+fn nested_callbacks_each_take_their_own_callee() {
+    // `outer(() => inner(() => {}))`: the inner arrow pulls "inner", the outer
+    // arrow pulls "outer". Each function reads its own immediate call ancestor,
+    // so nesting resolves correctly.
+    let mut got = names("outer(() => inner(() => 1));", true);
+    got.sort();
+    assert_eq!(got, vec!["inner", "outer"]);
+}
+
+#[test]
+fn repeated_callee_names_are_stable_and_repeat() {
+    // Two `.map` callbacks both surface as "map"; they are kept distinct by
+    // their line/column in the fnMap, and the name never renumbers (unlike
+    // `(anonymous_N)`), which matters for downstream identity.
+    let got = names("a.map((x) => x);\nb.map((y) => y);", true);
+    assert_eq!(got, vec!["map", "map"]);
+}


### PR DESCRIPTION
## Problem

A function/arrow passed **directly as a call or `new` argument** has no binding to inherit a name from, so both `istanbul-lib-instrument` and this instrumenter fall back to `(anonymous_N)`. In callback-heavy code (route handlers, `.map`/`.filter`, promise `.then`, `describe`/`it`, `new Promise`) that fallback dominates the `fnMap` and makes function-level coverage hard to read and hard to join to source.

## Change

New opt-in option `name_callback_arguments` (napi: `nameCallbackArguments`; vitest adapter: same) names these from the callee:

| Source | `fnMap[].name` with the option | default |
|---|---|---|
| `arr.map((x) => x)` | `map` | `(anonymous_0)` |
| `el.addEventListener("click", () => {})` | `addEventListener` | `(anonymous_0)` |
| `new Promise((resolve) => {})` | `Promise` | `(anonymous_0)` |
| `(function () {})()` (IIFE) | `(anonymous_0)` | `(anonymous_0)` |

- A binding name (variable declarator, property key, assignment target, default value) and an explicit named function expression **still take precedence**; this only replaces the `(anonymous_N)` fallback.
- Only the callee is used, never a sibling string argument (a route path / test description): the traversal ancestor for an argument position exposes the callee but not the other arguments.
- The callee-derived name is **stable across rebuilds** (the `(anonymous_N)` counter renumbers whenever an unrelated function is added), which matters for downstream tools that key function identity on the name.

## Safety

- **Defaults to `false`** — default JSON output stays byte-identical to what Istanbul consumers expect. Follows the same opt-in shape as `functionIdentityOverlay`.
- Threaded through core `InstrumentOptions`, the napi binding, and the vitest adapter (with boolean validation).
- New Rust integration tests (`callback_argument_names_test.rs`) and napi JS tests cover member/identifier/`new`/computed-key callees, binding precedence, named-fn-expression precedence, IIFE exclusion, nesting, and stability.
- Full workspace `cargo test`, `clippy`, `rustfmt`, and the napi JS suite pass. Conformance / snapshot / TS-equivalence suites unchanged.
- Documented under README "Differences from istanbul-lib-instrument" (§6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes: N/A (proactive enhancement, no tracking issue).

Note: the `Commit messages` (commitlint) check is red due to pre-existing `package-lock.json` drift (`npm ci` reports `conventional-commits-parser@6.4.0` missing from the lock after a recent @commitlint bump); unrelated to this change and affects all PRs. Not fixed here to keep the feature PR scoped.