### PR TITLE
perf(source-maps): reuse getMapping caches across eager-gate calls

### DIFF
--- a/crates/oxc-coverage-reports/src/html/mod.rs
+++ b/crates/oxc-coverage-reports/src/html/mod.rs
@@ -127,6 +127,14 @@ pub fn write(
     output_dir: &Path,
     options: &HtmlOptions,
 ) -> io::Result<()> {
+    // Only pay for the remap (and its clone + orphan-counter prune) when at
+    // least one entry carries an `inputSourceMap`; a map with none renders
+    // identically from the borrowed original. The skipped branch therefore does
+    // NOT run `FileCoverage::prune_orphan_counters`, which is safe here because
+    // every counter consumer below (`compute_line_hits`, the `*_metric`
+    // helpers, ...) iterates `statementMap`/`fnMap`/`branchMap` and reads the
+    // `s`/`f`/`b` slot via `.get(id).unwrap_or(0)`, so an orphan slot is never
+    // observed. Revisit if `write` ever re-serializes a raw `FileCoverage`.
     let remapped;
     let report_map = if coverage_map.values().any(|coverage| coverage.input_source_map.is_some()) {
         remapped = remap_coverage_map(coverage_map);

--- a/crates/oxc-coverage-source-maps/src/lib.rs
+++ b/crates/oxc-coverage-source-maps/src/lib.rs
@@ -32,6 +32,7 @@
 //! end of line), matching `istanbul-lib-source-maps`'s
 //! `createSourceMapStore().transformCoverage` byte-for-byte.
 
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 
 use oxc_coverage_types::{BranchEntry, FileCoverage, FnEntry, Location, Position};
@@ -73,6 +74,12 @@ pub struct RemapOptions {
 /// later compose agree by construction.
 pub struct PositionRemapper {
     sm: srcmap_sourcemap::SourceMap,
+    /// Lookup caches shared across every `location_maps` call for this map. The
+    /// eager gate queries one node at a time on a hot traversal path; without a
+    /// persistent context the per-`(source, line)` column index (issue #122
+    /// getMapping) would be rebuilt and discarded on every node. `RefCell`
+    /// because `location_maps` takes `&self` (the transform visits with `&self`).
+    caches: RefCell<RemapCaches>,
 }
 
 impl PositionRemapper {
@@ -84,7 +91,7 @@ impl PositionRemapper {
     pub fn from_json(input_sm_json: &str) -> Option<Self> {
         let sm = srcmap_sourcemap::SourceMap::from_json(input_sm_json).ok()?;
         resolve_primary_source(&sm)?;
-        Some(Self { sm })
+        Some(Self { sm, caches: RefCell::new(RemapCaches::default()) })
     }
 
     /// Whether an istanbul `Location` survives `getMapping` resolution, i.e.
@@ -108,8 +115,9 @@ impl PositionRemapper {
         if loc.start.line == 0 || loc.end.line == 0 {
             return self.legacy_position_maps(&loc.start) && self.legacy_position_maps(&loc.end);
         }
-        let mut ctx = RemapContext::new(&self.sm);
-        get_mapping_location(loc, &mut ctx).is_some()
+        let mut caches = self.caches.borrow_mut();
+        let mut ctx = RemapContext::new(&self.sm, &mut caches);
+        get_mapping_location_cached(&mut ctx, loc).is_some()
     }
 
     /// Non-mutating mirror of [`legacy_try_remap_position`]: `true` when the
@@ -249,15 +257,24 @@ where
     out
 }
 
-struct RemapContext<'a> {
-    sm: &'a srcmap_sourcemap::SourceMap,
+/// getMapping lookup caches. Kept separate from the `&SourceMap` borrow so they
+/// can outlive a single [`RemapContext`]: [`PositionRemapper`] owns one set and
+/// reuses it across every eager-gate call, while `apply_source_map` uses a fresh
+/// set per coverage map.
+#[derive(Default)]
+struct RemapCaches {
     mapping_cache: BTreeMap<LocationKey, Option<Location>>,
     original_line_columns: BTreeMap<OriginalLineKey, Vec<u32>>,
 }
 
+struct RemapContext<'a> {
+    sm: &'a srcmap_sourcemap::SourceMap,
+    caches: &'a mut RemapCaches,
+}
+
 impl<'a> RemapContext<'a> {
-    fn new(sm: &'a srcmap_sourcemap::SourceMap) -> Self {
-        Self { sm, mapping_cache: BTreeMap::new(), original_line_columns: BTreeMap::new() }
+    fn new(sm: &'a srcmap_sourcemap::SourceMap, caches: &'a mut RemapCaches) -> Self {
+        Self { sm, caches }
     }
 }
 
@@ -298,7 +315,8 @@ fn apply_source_map(
     let mut out = coverage.clone();
     out.path = primary_source;
     out.input_source_map = None;
-    let mut ctx = RemapContext::new(sm);
+    let mut caches = RemapCaches::default();
+    let mut ctx = RemapContext::new(sm, &mut caches);
 
     if options.drop_unmapped {
         prune_unmapped(&mut out, &mut ctx);
@@ -720,7 +738,7 @@ fn matched_original_column(
     column: u32,
 ) -> Option<u32> {
     let key = OriginalLineKey { source: source_idx, line };
-    if !ctx.original_line_columns.contains_key(&key) {
+    if !ctx.caches.original_line_columns.contains_key(&key) {
         let mut columns: Vec<u32> = ctx
             .sm
             .all_mappings()
@@ -730,9 +748,9 @@ fn matched_original_column(
             .collect();
         columns.sort_unstable();
         columns.dedup();
-        ctx.original_line_columns.insert(key, columns);
+        ctx.caches.original_line_columns.insert(key, columns);
     }
-    let columns = ctx.original_line_columns.get(&key)?;
+    let columns = ctx.caches.original_line_columns.get(&key)?;
     let idx = columns.partition_point(|mapped| *mapped < column);
     columns.get(idx).copied()
 }
@@ -902,11 +920,11 @@ fn legacy_try_remap_location(loc: &mut Location, sm: &srcmap_sourcemap::SourceMa
 
 fn get_mapping_location_cached(ctx: &mut RemapContext<'_>, loc: &Location) -> Option<Location> {
     let key = LocationKey::from(loc);
-    if let Some(cached) = ctx.mapping_cache.get(&key) {
+    if let Some(cached) = ctx.caches.mapping_cache.get(&key) {
         return cached.clone();
     }
     let remapped = get_mapping_location(loc, ctx);
-    ctx.mapping_cache.insert(key, remapped.clone());
+    ctx.caches.mapping_cache.insert(key, remapped.clone());
     remapped
 }
 


### PR DESCRIPTION
Follow-ups from the v0.9.1 perf review.

**1. Reuse getMapping caches on the eager-gate hot path (`crates/oxc-coverage-source-maps/src/lib.rs`).**
`PositionRemapper::location_maps` (the issue #106/#122 eager AST-level drop gate) runs once per coverage node during instrumentation. It built a fresh `RemapContext` every call, so the per-`(source, line)` original-column index (issue #122 getMapping, built by scanning every mapping in the map) was rebuilt and discarded on every node, making the `b5e1264`/`7b3c6c8` caches dead weight on that path (they only helped `apply_source_map`'s single shared context).

Fix: `PositionRemapper` now holds a `RefCell<RemapCaches>` persisted across every `location_maps` call for one map, and the gate routes through `get_mapping_location_cached`. The caches are a pure function of `(location, source map)` and the source map is fixed per remapper, so results are byte-identical; only redundant per-node scanning is removed. `apply_source_map` keeps a fresh per-call cache set.

**2. Document the html skip path's intentional orphan-prune omission (`crates/oxc-coverage-reports/src/html/mod.rs`).**
The no-source-map fast path (`3f10800`) skips `remap_coverage_map` and therefore `prune_orphan_counters`. That is safe because every html counter consumer reads `s`/`f`/`b` via `.get(id).unwrap_or(0)` keyed by the corresponding map, so orphan slots are never observed. Comment-only; documents the invariant and when to revisit. (Adding a prune here would reintroduce the clone the fast path exists to avoid, for zero observable benefit.)

Validation: `cargo test --workspace` (conformance suites + source-map edge tests), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check` all green. Smoke-tested end to end via the napi `test.mjs` E2E (real `@babel/core`-emitted map through the eager compose gate, istanbul byte-diff) - all pass. CodSpeed will quantify the eager-gate improvement.

Closes: N/A (perf review follow-up, no tracking issue)