### PR TITLE
fix(instrument): resolve parenthesized callees in callback naming

### DIFF
--- a/crates/oxc-coverage-instrument/src/transform.rs
+++ b/crates/oxc-coverage-instrument/src/transform.rs
@@ -677,10 +677,18 @@ impl<'src, 'arena> CoverageTransform<'src, 'arena> {
 /// so a leading string literal (route path, test name) is not accessible here.
 fn callback_argument_name(ctx: &TraverseCtx<'_, CoverageState>) -> Option<String> {
     use oxc_traverse::Ancestor;
-    let callee = match ctx.ancestors().next()? {
-        Ancestor::CallExpressionArguments(call) => call.callee(),
-        Ancestor::NewExpressionArguments(new_expr) => new_expr.callee(),
-        _ => return None,
+    // Skip `ParenthesizedExpression` wrappers: Oxc keeps them as real nodes, so
+    // `foo((cb))` nests the callback inside a paren whose parent is the
+    // arguments position. Any non-paren, non-arguments ancestor (e.g. a callee
+    // position for an IIFE) means this is not a callback and stays anonymous.
+    let mut ancestors = ctx.ancestors();
+    let callee = loop {
+        match ancestors.next()? {
+            Ancestor::ParenthesizedExpressionExpression(_) => {}
+            Ancestor::CallExpressionArguments(call) => break call.callee(),
+            Ancestor::NewExpressionArguments(new_expr) => break new_expr.callee(),
+            _ => return None,
+        }
     };
     callee_name(callee)
 }
@@ -688,8 +696,9 @@ fn callback_argument_name(ctx: &TraverseCtx<'_, CoverageState>) -> Option<String
 /// Extract a display name from a call/`new` callee expression. Mirrors the
 /// binding-name rules used elsewhere: a bare identifier keeps its name, a
 /// member access uses the (last) property name, and a computed access uses the
-/// string-literal key. Anything else (a computed non-string index, a call
-/// result, a parenthesized expression) yields no name.
+/// string-literal key. Oxc preserves `ParenthesizedExpression` nodes (Babel
+/// strips them), so `(foo)(cb)` is unwrapped to `foo`. Anything else (a
+/// computed non-string index, a call result) yields no name.
 fn callee_name(callee: &Expression<'_>) -> Option<String> {
     match callee {
         Expression::Identifier(ident) => Some(ident.name.to_string()),
@@ -698,6 +707,7 @@ fn callee_name(callee: &Expression<'_>) -> Option<String> {
             Expression::StringLiteral(lit) => Some(lit.value.to_string()),
             _ => None,
         },
+        Expression::ParenthesizedExpression(paren) => callee_name(&paren.expression),
         _ => None,
     }
 }

--- a/crates/oxc-coverage-instrument/tests/callback_argument_names_test.rs
+++ b/crates/oxc-coverage-instrument/tests/callback_argument_names_test.rs
@@ -143,7 +143,7 @@ fn parenthesized_argument_is_named_from_callee() {
 fn iife_with_parenthesized_callee_stays_anonymous() {
     // `(() => 1)()` is an IIFE: the arrow is the (parenthesized) callee, not an
     // argument, so skipping the paren lands on the callee position and it stays
-    // anonymous. Guards that paren-unwrapping does not misname IIFEs.
+    // anonymous. Guards that paren-unwrapping does not misname an IIFE.
     let got = names("(() => 1)();", true);
     assert_eq!(got.len(), 1);
     assert!(got[0].starts_with("(anonymous_"), "IIFE must stay anonymous, got {}", got[0]);

--- a/crates/oxc-coverage-instrument/tests/callback_argument_names_test.rs
+++ b/crates/oxc-coverage-instrument/tests/callback_argument_names_test.rs
@@ -118,3 +118,33 @@ fn repeated_callee_names_are_stable_and_repeat() {
     let got = names("a.map((x) => x);\nb.map((y) => y);", true);
     assert_eq!(got, vec!["map", "map"]);
 }
+
+#[test]
+fn parenthesized_identifier_callee_names_the_callback() {
+    // Oxc keeps `ParenthesizedExpression` as a real node; `(foo)(cb)` unwraps
+    // the paren to name the callback "foo".
+    assert_eq!(names("(foo)(() => run());", true), vec!["foo"]);
+}
+
+#[test]
+fn parenthesized_member_callee_names_the_callback() {
+    // The paren wraps a member access: `(a.b)(cb)` -> "b".
+    assert_eq!(names("(a.b)(() => run());", true), vec!["b"]);
+}
+
+#[test]
+fn parenthesized_argument_is_named_from_callee() {
+    // The callback itself is parenthesized in the arguments position:
+    // `foo((function () {}))`. The paren ancestor is skipped to reach the call.
+    assert_eq!(names("foo((function () { return 1; }));", true), vec!["foo"]);
+}
+
+#[test]
+fn iife_with_parenthesized_callee_stays_anonymous() {
+    // `(() => 1)()` is an IIFE: the arrow is the (parenthesized) callee, not an
+    // argument, so skipping the paren lands on the callee position and it stays
+    // anonymous. Guards that paren-unwrapping does not misname IIFEs.
+    let got = names("(() => 1)();", true);
+    assert_eq!(got.len(), 1);
+    assert!(got[0].starts_with("(anonymous_"), "IIFE must stay anonymous, got {}", got[0]);
+}


### PR DESCRIPTION
Follow-up to #151 (opt-in `name_callback_arguments`), from the session review.

Oxc keeps `ParenthesizedExpression` as a real AST node (Babel strips it), so the callee-name resolution missed parenthesized forms and fell back to `(anonymous_N)`:
- `(foo)(cb)` and `(a.b)(cb)` (parenthesized callee)
- `foo((function () {}))` (parenthesized argument)

Fix: unwrap parens in `callee_name`, and skip `ParenthesizedExpression` ancestors in `callback_argument_name`. An IIFE whose parenthesized callee is a function stays anonymous (callee position is not an argument), guarded by a new test.

Naming-only: no counter, span, statementMap/fnMap/branchMap, or default-path (flag-off) change. Validated: 4 new tests + the full `callback_argument_names_test` (17) and conformance suites (189 + 8) pass; clippy + fmt clean.

Closes: N/A (review follow-up to #151, no tracking issue)