### PR TITLE
chore: add commit-msg hook + resync commitlint lockfile

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# commit-msg hook: lint the commit message against the Conventional Commits
+# rules (commitlint.config.mjs), mirroring the CI "Commit messages" job that
+# blocks PR merges. Catching a malformed subject here saves an amend + repush.
+#
+# Setup (one-time, per clone):
+#   git config core.hooksPath .githooks
+#
+# commitlint is a root devDependency; run `npm ci` at the repo root to install
+# it. This is a Rust-first repo, so the hook SKIPS (does not block) when
+# commitlint is absent, so a pure-Rust contributor is not forced to install the
+# JS toolchain. CI still enforces the rule on every PR.
+#
+# Bypass (use sparingly):
+#   SKIP_COMMIT_MSG=1 git commit ...   (or git commit --no-verify)
+
+set -euo pipefail
+
+if [ "${SKIP_COMMIT_MSG:-0}" = "1" ]; then
+  echo "[commit-msg] SKIP_COMMIT_MSG=1, skipping commitlint"
+  exit 0
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ ! -x node_modules/.bin/commitlint ]; then
+  echo "[commit-msg] commitlint not installed (run 'npm ci' at repo root to enable); skipping"
+  exit 0
+fi
+
+echo "[commit-msg] commitlint"
+node_modules/.bin/commitlint --edit "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,12 @@ cargo test --workspace
 cargo run --example instrument
 ```
 
-## Pre-push hook
+## Git hooks
 
-A versioned pre-push hook at `.githooks/pre-push` runs the fast CI checks (`cargo fmt --check`, `cargo clippy -D warnings`, `typos .`) before every push. It mirrors the CI jobs that block PR merges, so catching the failure locally saves a round-trip.
+Versioned hooks under `.githooks/` mirror the CI jobs that block PR merges, so catching a failure locally saves a round-trip:
+
+- **`pre-push`** runs the fast checks (`cargo fmt --check`, `cargo clippy -D warnings`, `typos .`) before every push.
+- **`commit-msg`** lints the commit message against the Conventional Commits rules (the CI "Commit messages" job). It skips itself when commitlint is not installed, so a pure-Rust contributor is never blocked.
 
 **Enable once per clone:**
 
@@ -27,6 +30,12 @@ git config core.hooksPath .githooks
 
 ```bash
 cargo install typos-cli
+```
+
+**Enable `commit-msg` linting (optional):** install the commitlint toolchain at the repo root.
+
+```bash
+npm ci   # installs @commitlint/cli from package.json
 ```
 
 **Opt-in extras:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1105,6 +1105,25 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",


### PR DESCRIPTION
From the /sweep follow-up on git hooks (mirroring the fallow repo's `.githooks/` approach).

**Two changes:**

1. **`fix(ci)`: resync root `package-lock.json`.** The CI "Commit messages" job has been failing on `main` (every recent commit) at `npm ci --ignore-scripts` with EUSAGE: the root lockfile drifted out of sync with `package.json` (a dependabot commitlint bump left the transitive `conventional-commits-parser@6.4.0` entry out of the lock). Re-sync adds the one missing entry; `npm ci` passes again. (This job is not part of the `CI` aggregate, so branch protection did not surface it.)

2. **`chore`: add `.githooks/commit-msg`.** Mirrors the existing `.githooks/pre-push` (fmt/clippy/typos): lints the commit message against Conventional Commits (the "Commit messages" job) at commit time. Skips gracefully when commitlint is not installed, so a pure-Rust contributor is never blocked. `CONTRIBUTING.md` now documents both hooks under one "Git hooks" section.

Separately (config, not in this diff): activated the already-tracked `.githooks/pre-push` on the working clone via `git config core.hooksPath .githooks` — it was dormant, which is why an `IIFEs` typo reached CI in #153. The hook (and now the commit-msg hook) validated end to end locally.

Closes: N/A (CI hygiene + dev-tooling follow-up)