### PR TITLE
chore(deps): update Dependabot queue

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -76,7 +76,7 @@ jobs:
           cache-key: bench-${{ matrix.cache_key }}
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-codspeed@4.7.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1
+      - uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1
 
   version-sync:
     name: Version Sync
@@ -125,7 +125,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-audit
       - run: cargo audit
@@ -148,7 +148,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-shear
       - run: cargo shear

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           key: coverage
 
-      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2.81.11
+      - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -102,7 +102,7 @@ jobs:
           version: 0.14.1
 
       - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
         if: contains(matrix.target, 'musl')
         with:
           tool: cargo-zigbuild

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -746,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.9.3"
+version = "3.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd9f9295f3ff5921e78a71222c3361a8216f7760b1a99a6ad4e8441de18bbb9"
+checksum = "0c71997d6f7ad4a756966e452426848ac27d3b37a295302d63afbbcce0270f93"
 dependencies = [
  "bitflags",
  "ctor",
@@ -769,9 +769,9 @@ checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.6"
+version = "3.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
+checksum = "d4ba572deef53e2c386759a8c2014175a62679d74ff83adc205c8bc0e0285727"
 dependencies = [
  "convert_case",
  "ctor",
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.0.4"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+checksum = "ddd961eb2aa8965e3f29722d754f3a86907eb1984e2fbcbe3fe87b9a02d6bfba"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1409,9 +1409,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap",
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -1704,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "srcmap-generator"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631b47d31519c3e0b847c8b615ef57495bf4809377f0bcab31b8ae3b24820806"
+checksum = "ceb9043924adb7a987cbe5cf467a93463c8dcb177e97c169d78f586d66fd8191"
 dependencies = [
  "rustc-hash",
  "srcmap-codec",

--- a/crates/oxc-coverage-instrument-napi/Cargo.toml
+++ b/crates/oxc-coverage-instrument-napi/Cargo.toml
@@ -31,7 +31,7 @@ napi-build = "2"
 
 [dev-dependencies]
 criterion2 = { version = "3.0.2", default-features = false }
-srcmap-generator = "=0.3.8"
+srcmap-generator = "=0.3.9"
 
 [[bench]]
 name = "remap"

--- a/crates/oxc-coverage-instrument-napi/package-lock.json
+++ b/crates/oxc-coverage-instrument-napi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oxc-coverage-instrument",
-  "version": "0.9.1",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oxc-coverage-instrument",
-      "version": "0.9.1",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/wasm-runtime": "^1.1.4"
@@ -20,15 +20,15 @@
         "istanbul-lib-source-maps": "^5.0.6"
       },
       "optionalDependencies": {
-        "@oxc-coverage-instrument/binding-darwin-arm64": "0.9.1",
-        "@oxc-coverage-instrument/binding-darwin-x64": "0.9.1",
-        "@oxc-coverage-instrument/binding-linux-arm64-gnu": "0.9.1",
-        "@oxc-coverage-instrument/binding-linux-x64-gnu": "0.9.1",
-        "@oxc-coverage-instrument/binding-linux-x64-musl": "0.9.1",
-        "@oxc-coverage-instrument/binding-wasm32-wasi": "0.9.1",
-        "@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded": "0.9.1",
-        "@oxc-coverage-instrument/binding-win32-arm64-msvc": "0.9.1",
-        "@oxc-coverage-instrument/binding-win32-x64-msvc": "0.9.1"
+        "@oxc-coverage-instrument/binding-darwin-arm64": "0.10.1",
+        "@oxc-coverage-instrument/binding-darwin-x64": "0.10.1",
+        "@oxc-coverage-instrument/binding-linux-arm64-gnu": "0.10.1",
+        "@oxc-coverage-instrument/binding-linux-x64-gnu": "0.10.1",
+        "@oxc-coverage-instrument/binding-linux-x64-musl": "0.10.1",
+        "@oxc-coverage-instrument/binding-wasm32-wasi": "0.10.1",
+        "@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded": "0.10.1",
+        "@oxc-coverage-instrument/binding-win32-arm64-msvc": "0.10.1",
+        "@oxc-coverage-instrument/binding-win32-x64-msvc": "0.10.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1740,12 +1740,12 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "license": "MIT",
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -2170,9 +2170,9 @@
       }
     },
     "node_modules/@oxc-coverage-instrument/binding-darwin-arm64": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-darwin-arm64/-/binding-darwin-arm64-0.9.1.tgz",
-      "integrity": "sha512-fPsb4PXJgMOOr3YaGBX0fkhpb7Dy9/qqcmzcvokozLj9aqZFwRposwjVGiv9Gg+2GGTX2FCZXxHFfKIwWpG9VA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-darwin-arm64/-/binding-darwin-arm64-0.10.1.tgz",
+      "integrity": "sha512-SLt+w1Sv2NvkPQG54f3ewoM2dVf9s+hQgBsVLEVNMMSpNRyREWe6vTGKF5tHoLx/PlwJkkBi71mosB8ku57evA==",
       "cpu": [
         "arm64"
       ],
@@ -2183,9 +2183,9 @@
       ]
     },
     "node_modules/@oxc-coverage-instrument/binding-darwin-x64": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-darwin-x64/-/binding-darwin-x64-0.9.1.tgz",
-      "integrity": "sha512-mGrphedm5+GRYvGhbXrj51+OqN1KnXLGBssApwpM6GC+NFVIiQQKQ5ZXqBWIzwsRR8VlZ1wjGdZ4VwENTgYYzg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-darwin-x64/-/binding-darwin-x64-0.10.1.tgz",
+      "integrity": "sha512-0sRrNb7tRCaRMHWqnB/8E51tfSQcF8KyBr0lSWuWiww97/cci4HVi8i5z/u+5hlPwAWpJQjN8i7bh69Kg5z++g==",
       "cpu": [
         "x64"
       ],
@@ -2196,9 +2196,9 @@
       ]
     },
     "node_modules/@oxc-coverage-instrument/binding-linux-arm64-gnu": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.9.1.tgz",
-      "integrity": "sha512-TyHRearUr3VUILPlR9Ur66cvgHVhjK9yazxHhKbF3kbXsIvjC5cVMVwR/+zYhey55lI19mm2jqiXpxj7Km5CFg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.10.1.tgz",
+      "integrity": "sha512-DkiuptNRn1KaMpjAs/BZoY9ySJD2wxlODNteCBH0yp65QmAU/jEryrAXomg7KniiqvhTn/9HwF1jG7PJMiUyEQ==",
       "cpu": [
         "arm64"
       ],
@@ -2209,9 +2209,9 @@
       ]
     },
     "node_modules/@oxc-coverage-instrument/binding-linux-x64-gnu": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.9.1.tgz",
-      "integrity": "sha512-OSr9PnM9lwX/c1+DxFJBgs2Blz1BTVeql6c8FoSvVdm5FE6lX6HoXoe70ecGx02zEOxwGlQ1gFO5GaFIQWAJWw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.10.1.tgz",
+      "integrity": "sha512-9lPHR87tsCDFBnrQ1lLMZFkfmLkMX3SZ1TmwQ5fYTgCBO3SPP0terwBTrfibRGCBLXnj3IV8j1ZOJClSxdeXBw==",
       "cpu": [
         "x64"
       ],
@@ -2222,9 +2222,9 @@
       ]
     },
     "node_modules/@oxc-coverage-instrument/binding-linux-x64-musl": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-linux-x64-musl/-/binding-linux-x64-musl-0.9.1.tgz",
-      "integrity": "sha512-mC0NBb0Auyo2JPxQdLOCSO4pAYtF17jaft1g2P0RBPXgeGFQ8A7wjUiu4eNIFT8rM2IsuBIdsDZUDtilgQ2dtA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-linux-x64-musl/-/binding-linux-x64-musl-0.10.1.tgz",
+      "integrity": "sha512-WSwSPirj421K47EHWGgF2tNlX5DFaaGhzjMckwSacGRjTHwzNYoPs7BGkGgwpEASCp6NgewfCi+cPjlU0JC1jg==",
       "cpu": [
         "x64"
       ],
@@ -2235,9 +2235,9 @@
       ]
     },
     "node_modules/@oxc-coverage-instrument/binding-wasm32-wasi": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-wasm32-wasi/-/binding-wasm32-wasi-0.9.1.tgz",
-      "integrity": "sha512-Dd8Trzg9kTVnZKggaz5n3Tv6kp3LDcvztdzoYaaA27NDG57DiOIpqOWuL4TVeQuLu0tyjoVDDRsM+bZ6GbBtwA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-wasm32-wasi/-/binding-wasm32-wasi-0.10.1.tgz",
+      "integrity": "sha512-GDFT4KkaMtPlyxOHC+4KkjdhgcnW9OufzWxi3VjA78HbPE8YgTCi7f2Rii8qld/78NMyrSSn6xk1cVQcE7ukcw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2245,9 +2245,9 @@
       }
     },
     "node_modules/@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded/-/binding-wasm32-wasi-singlethreaded-0.9.1.tgz",
-      "integrity": "sha512-PGfDbzaglxKoxpnTnBvIp6tlFgI1qa+cuo0ebmcDgFheffSq1dKLTfWRo24qg46dGbbhO9ocyBJ8s5WoVbmepA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-wasm32-wasi-singlethreaded/-/binding-wasm32-wasi-singlethreaded-0.10.1.tgz",
+      "integrity": "sha512-cETrcY0EVyu0d2IbvsAwLfYVoPIsZeJ9JU0ivfuxZ/oki53YGfkKY43rSFCflh6CgdKLgvqxRT3vKH3UjlIRcA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/@oxc-coverage-instrument/binding-win32-arm64-msvc": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.9.1.tgz",
-      "integrity": "sha512-0VwvFm2p1UYf7KsxG5e6otXkfEV2tRnUjknBk7ypoSe9xYQflI9wQvsTudKxMbDg+2M4Bkh/pQHJ30GGo2TFEA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.10.1.tgz",
+      "integrity": "sha512-aqhd/zxpraavp877rpqDeuUhtdwUEW8ulCgQsEKX2ZX7mjr2b+TmnrpUNhMgXKwQLP3d0QMmxtDtvnUX4v4Z0A==",
       "cpu": [
         "arm64"
       ],
@@ -2268,9 +2268,9 @@
       ]
     },
     "node_modules/@oxc-coverage-instrument/binding-win32-x64-msvc": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.9.1.tgz",
-      "integrity": "sha512-4g0H75dz6WcGRw5xSnuQ3c0FqWKdXx2+JbC9nZI5L0qdz87zDcan0WQLOOKaohbUW2GLt2/EhRFceTK2vEUL5Q==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@oxc-coverage-instrument/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.10.1.tgz",
+      "integrity": "sha512-Rl8OZ3OERse+j+P6WUaIaXOjPM2OZGMJ7XKHd6JS+u2R9BOyg2e41nO0Yha3xoDsBh+mTP242jVI+XZL2ZVP6A==",
       "cpu": [
         "x64"
       ],

--- a/crates/oxc-coverage-source-maps/Cargo.toml
+++ b/crates/oxc-coverage-source-maps/Cargo.toml
@@ -31,7 +31,7 @@ srcmap-sourcemap = "=0.3.9"
 
 [dev-dependencies]
 criterion2 = { version = "3.0.2", default-features = false }
-srcmap-generator = "=0.3.8"
+srcmap-generator = "=0.3.9"
 
 [[bench]]
 name = "remap"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
-        "@commitlint/cli": "21.1.0",
-        "@commitlint/config-conventional": "21.1.0",
+        "@commitlint/cli": "21.2.0",
+        "@commitlint/config-conventional": "21.2.0",
         "istanbul-lib-instrument": "^6.0.3"
       }
     },
@@ -275,18 +275,18 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.1.0.tgz",
-      "integrity": "sha512-CVwY6TxGv5naEaWxBdgNHko1xgL95Mb4WcIqp9iik33H0ctVqRv6YtekCntayhEP0T/apuiGvHu5HcCwFuVxEA==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.0.tgz",
+      "integrity": "sha512-4GLVIhUaT3c3GBlQ0GB80/5H3xXdn/Tgw4lrsuoOQVDu2wl4Xw0GuzSar8xZKSMv4H3xaKaQXmvH91GmdyYBZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-conventional": "21.1.0",
-        "@commitlint/format": "^21.1.0",
-        "@commitlint/lint": "^21.1.0",
-        "@commitlint/load": "^21.1.0",
-        "@commitlint/read": "^21.1.0",
-        "@commitlint/types": "^21.1.0",
+        "@commitlint/config-conventional": "^21.2.0",
+        "@commitlint/format": "^21.2.0",
+        "@commitlint/lint": "^21.2.0",
+        "@commitlint/load": "^21.2.0",
+        "@commitlint/read": "^21.2.0",
+        "@commitlint/types": "^21.2.0",
         "tinyexec": "^1.0.0",
         "yargs": "^18.0.0"
       },
@@ -298,14 +298,14 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.1.0.tgz",
-      "integrity": "sha512-BIFl8xM+3SLy3jrblUC3wmQLCVbLty+++6o859BDCmybVrQdXmIWO+dlkGIbv/M2bBoC55wGuh0zGiw3TPjL1g==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.2.0.tgz",
+      "integrity": "sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^21.1.0",
-        "conventional-changelog-conventionalcommits": "^9.2.0"
+        "@commitlint/types": "^21.2.0",
+        "conventional-changelog-conventionalcommits": "^10.0.0"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -526,9 +526,9 @@
       }
     },
     "node_modules/@conventional-changelog/template": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.0.tgz",
-      "integrity": "sha512-12qHxvlKjHmP0PQ+17EREgC7lWyLwbph1RKcZQZ7k7ZWGmrxfxC9gadHGfvzr0g0u8BhiBGg3tks93txodlyRQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
+      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -698,13 +698,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/array-ify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.16",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
@@ -798,17 +791,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/compare-func": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^5.1.0"
-      }
-    },
     "node_modules/conventional-changelog-angular": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.0.tgz",
@@ -823,16 +805,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
-      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "compare-func": "^2.0.0"
+        "@conventional-changelog/template": "^1.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/conventional-commits-parser": {
@@ -920,19 +902,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/dot-prop": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1196,16 +1165,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "homepage": "https://github.com/fallow-rs/oxc-coverage-instrument#readme",
   "devDependencies": {
-    "@commitlint/cli": "21.1.0",
-    "@commitlint/config-conventional": "21.1.0",
+    "@commitlint/cli": "21.2.0",
+    "@commitlint/config-conventional": "21.2.0",
     "istanbul-lib-instrument": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

- consolidate the open Dependabot updates for commitlint, napi, srcmap-generator, wasm-runtime, typos, and install-action
- use a compatible napi/napi-derive pair instead of the broken partial update
- update transitive Rust dependencies to resolve the current crossbeam-epoch and quick-xml advisories
- regenerate both npm lockfiles so clean installs remain reproducible

Supersedes #155, #156, #157, #158, #159, #160, and #161.

## Closes

N/A

## Verification

- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm --prefix crates/oxc-coverage-instrument-napi ci --ignore-scripts --no-audit --no-fund`
- `cargo check --workspace`
- `cargo +1.92.0 check --workspace`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `cargo test --workspace --doc`
- `cargo audit`
- `cargo deny check`
- native napi build and test suite
- upstream Istanbul smoke