### PR TITLE
fix: resolve coverage correctness edge cases

### DIFF
--- a/crates/oxc_coverage_instrument/src/instrument.rs
+++ b/crates/oxc_coverage_instrument/src/instrument.rs
@@ -377,7 +377,7 @@ pub fn instrument(
     let mut parsed = parse_program(&allocator, source, filename)?;
 
     let (pragmas, unhandled_pragmas) = PragmaMap::from_program(&parsed.program, source);
-    if pragmas.ignore_file {
+    if pragmas.ignore_file && !options.strip_typescript {
         return Ok(empty_coverage_result(filename, source, unhandled_pragmas));
     }
 
@@ -387,6 +387,17 @@ pub fn instrument(
         program: &mut parsed.program,
         options,
     })?;
+    if pragmas.ignore_file {
+        let (code, _) = emit_code(EmitInputs {
+            program: &parsed.program,
+            scoping,
+            source,
+            filename,
+            preamble: "",
+            options,
+        });
+        return Ok(empty_coverage_result(filename, &code, unhandled_pragmas));
+    }
     let cov_fn_name = generate_cov_fn_name(filename);
 
     let (transform, scoping) = run_coverage_transform(CoverageTransformRun {
@@ -851,9 +862,6 @@ pub enum InstrumentError {
     ParseError(String),
     /// The coverage variable name is not a valid JavaScript identifier.
     InvalidCoverageVariable(String),
-    /// Coverage data serialization failed. [`instrument`] never produces this
-    /// variant: every type reachable from `FileCoverage` serializes infallibly.
-    SerializationError(String),
     /// The TypeScript strip pass produced diagnostics. Only emitted when
     /// `InstrumentOptions::strip_typescript` is enabled. The vector
     /// contains one entry per transformer diagnostic so callers can
@@ -866,7 +874,6 @@ impl std::fmt::Display for InstrumentError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ParseError(msg) => write!(f, "parse error: {msg}"),
-            Self::SerializationError(msg) => write!(f, "serialization error: {msg}"),
             Self::TransformError(msgs) => write!(f, "transform error: {}", msgs.join("; ")),
             Self::InvalidCoverageVariable(name) => {
                 write!(

--- a/crates/oxc_coverage_instrument/src/transform/functions.rs
+++ b/crates/oxc_coverage_instrument/src/transform/functions.rs
@@ -44,7 +44,14 @@ impl<'arena> CoverageTransform<'_, 'arena> {
         self.skip_next = false;
         self.skip_fn_counter_only = false;
         self.ignored_fn_stack.push(pragma_skip);
-        if pragma_skip || fn_counter_only_skip {
+        if pragma_skip {
+            self.pending_name = None;
+            return;
+        }
+        if fn_counter_only_skip {
+            if func.body.is_some() {
+                self.pending_fn_counters.push(None);
+            }
             self.pending_name = None;
             return;
         }

--- a/crates/oxc_coverage_instrument/src/v8_to_istanbul.rs
+++ b/crates/oxc_coverage_instrument/src/v8_to_istanbul.rs
@@ -38,7 +38,7 @@ impl std::error::Error for V8ToIstanbulError {}
 
 /// Convert V8 function coverage into Istanbul `FileCoverage`.
 ///
-/// `wrapper_length` is an explicit UTF-16 code-unit base for coverage producers
+/// `wrapper_length_utf16` is an explicit UTF-16 code-unit base for coverage producers
 /// that report wrapper-shifted ranges. Pass 0 for source-relative Node inspector
 /// coverage.
 ///
@@ -59,9 +59,9 @@ pub fn v8_to_istanbul(
     source: &str,
     filename: &str,
     functions: &[V8FunctionCoverage],
-    wrapper_length: u32,
+    wrapper_length_utf16: u32,
 ) -> Result<FileCoverage, V8ToIstanbulError> {
-    v8_to_istanbul_with_loader(source, filename, functions, wrapper_length, |_| None)
+    v8_to_istanbul_with_loader(source, filename, functions, wrapper_length_utf16, |_| None)
 }
 
 /// Like [`v8_to_istanbul`], but with a loader for external `sourceMappingURL`
@@ -110,7 +110,7 @@ pub fn v8_to_istanbul_with_loader<L>(
     source: &str,
     filename: &str,
     functions: &[V8FunctionCoverage],
-    wrapper_length: u32,
+    wrapper_length_utf16: u32,
     loader: L,
 ) -> Result<FileCoverage, V8ToIstanbulError>
 where
@@ -123,7 +123,7 @@ where
         &mut file_coverage,
         source,
         functions,
-        wrapper_length,
+        wrapper_length_utf16,
         &collected.arm_body_byte_spans,
     );
 

--- a/crates/oxc_coverage_instrument/tests/instrument/error_display.rs
+++ b/crates/oxc_coverage_instrument/tests/instrument/error_display.rs
@@ -6,12 +6,6 @@
 use oxc_coverage_instrument::{InstrumentError, V8ToIstanbulError};
 
 #[test]
-fn instrument_error_display_serialization_error() {
-    let err = InstrumentError::SerializationError("circular ref".to_string());
-    assert_eq!(format!("{err}"), "serialization error: circular ref");
-}
-
-#[test]
 fn transform_error_display_format() {
     let err = InstrumentError::TransformError(vec![
         "unsupported syntax at line 5".to_string(),

--- a/crates/oxc_coverage_instrument/tests/instrument/integration.rs
+++ b/crates/oxc_coverage_instrument/tests/instrument/integration.rs
@@ -1645,6 +1645,39 @@ fn private_class_method_does_not_add_function_counter() {
     assert_eq!(result.coverage_map.branch_map.len(), 1);
 }
 
+#[test]
+fn private_method_in_parameter_default_does_not_steal_enclosing_function_counter() {
+    let result = instrument_js("function f(x = class { #m() {} }) {}");
+    assert_eq!(result.coverage_map.fn_map.len(), 1);
+    assert_eq!(result.coverage_map.fn_map["0"].name, "f");
+
+    let counter = result.code.find(".f[0]").expect("function counter");
+    let enclosing_body = result.code.rfind(")) {").expect("enclosing function body");
+    assert!(
+        counter > enclosing_body,
+        "the counter for f must be emitted in f's body, not the nested private method: {}",
+        result.code
+    );
+}
+
+#[test]
+fn private_accessors_in_parameter_defaults_do_not_steal_enclosing_function_counters() {
+    for member in ["get #m() { return 1; }", "set #m(value) {}"] {
+        let source = format!("function f(x = class {{ {member} }}) {{}}");
+        let result = instrument_js(&source);
+        assert_eq!(result.coverage_map.fn_map.len(), 1, "{member}");
+        assert_eq!(result.coverage_map.fn_map["0"].name, "f", "{member}");
+
+        let counter = result.code.find(".f[0]").expect("function counter");
+        let enclosing_body = result.code.rfind(")) {").expect("enclosing function body");
+        assert!(
+            counter > enclosing_body,
+            "the counter for f must stay in f's body for {member}: {}",
+            result.code
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Source map composition: partial input maps
 // ---------------------------------------------------------------------------

--- a/crates/oxc_coverage_instrument/tests/instrument/source_maps.rs
+++ b/crates/oxc_coverage_instrument/tests/instrument/source_maps.rs
@@ -559,6 +559,35 @@ fn compose_input_source_map_keeps_entries_deferred_drop_keeps() {
     );
 }
 
+#[test]
+fn compose_input_source_map_uses_a_later_resolved_source_for_the_drop_gate() {
+    let intermediate = "f();\ng();\n";
+    let input_sm = r#"{"version":3,"sources":["","src/app.ts"],"sourcesContent":[null,"f();\n"],"mappings":"ACAA","names":[]}"#;
+
+    let eager = instrument(
+        intermediate,
+        "intermediate.js",
+        &InstrumentOptions {
+            input_source_map: Some(input_sm.to_string()),
+            compose_input_source_map: true,
+            ..InstrumentOptions::default()
+        },
+    )
+    .expect("eager instrumentation succeeds");
+    let deferred = remap_coverage_with_options(
+        &plain_with_map(intermediate, input_sm),
+        RemapOptions { drop_unmapped: true },
+    )
+    .expect("deferred remap accepts the later source");
+
+    assert_eq!(eager.coverage_map.statement_map.len(), 1, "unmapped line 2 is dropped eagerly");
+    assert_eq!(
+        serde_json::to_value(&eager.coverage_map).unwrap(),
+        serde_json::to_value(&deferred).unwrap(),
+        "eager and deferred admission agree when sources[0] is empty",
+    );
+}
+
 /// Instrument `intermediate` with `input_sm` embedded but without eager compose,
 /// returning the `FileCoverage` that still carries its `inputSourceMap` so the
 /// lazy remap helpers can be exercised against it.

--- a/crates/oxc_coverage_instrument/tests/instrument/typescript_direct.rs
+++ b/crates/oxc_coverage_instrument/tests/instrument/typescript_direct.rs
@@ -5,6 +5,8 @@
 
 use oxc_coverage_instrument::{DecoratorMode, InstrumentError, InstrumentOptions, instrument};
 
+use crate::common::assert_reparses;
+
 fn ts_opts() -> InstrumentOptions {
     InstrumentOptions { source_map: true, strip_typescript: true, ..InstrumentOptions::default() }
 }
@@ -28,6 +30,25 @@ fn ts_direct_output_is_valid_js() {
         "executable JS variable declaration expected, got: {}",
         result.code
     );
+}
+
+#[test]
+fn ts_direct_ignore_file_pragmas_still_strip_typescript() {
+    for tool in ["istanbul", "v8", "c8"] {
+        let src = format!(
+            "/* {tool} ignore file */\ninterface Hidden {{ value: number }}\nexport const add = (a: number, b: number): number => a + b;"
+        );
+        let result = instrument(&src, "app.ts", &ts_opts()).expect("instrument");
+
+        assert!(!result.code.contains("interface Hidden"), "{tool}: {code}", code = result.code);
+        assert!(!result.code.contains(": number"), "{tool}: {code}", code = result.code);
+        assert!(!result.code.contains("cov_"), "{tool}: ignored file must have no preamble");
+        assert_reparses(&result.code, "app.js");
+        assert!(result.coverage_map.statement_map.is_empty(), "{tool}");
+        assert!(result.coverage_map.fn_map.is_empty(), "{tool}");
+        assert!(result.coverage_map.branch_map.is_empty(), "{tool}");
+        assert!(result.source_map.is_none(), "{tool}: preserve ignored-file source-map contract");
+    }
 }
 
 #[test]

--- a/crates/oxc_coverage_instrument_cli/README.md
+++ b/crates/oxc_coverage_instrument_cli/README.md
@@ -24,6 +24,9 @@ oxc-coverage-instrument src/app.js --coverage-map           # coverage map only
 oxc-coverage-instrument src/app.js -o dist/app.js --source-map
 ```
 
+`--coverage-map` writes JSON to stdout and cannot be combined with `-o` or
+`--source-map`.
+
 Reporting, through the `report` subcommand:
 
 ```bash
@@ -37,6 +40,15 @@ oxc-coverage-instrument report --format html         --root . coverage-final.jso
 # Render, then exit 2 if aggregate line coverage falls below the floor
 oxc-coverage-instrument report --format text-summary coverage-final.json --fail-under 80
 ```
+
+Exit codes are part of the CLI contract:
+
+| Code | Meaning |
+| ---: | :--- |
+| 0 | Success |
+| 1 | Usage, parsing, I/O, or rendering failure |
+| 2 | Aggregate line coverage is below `--fail-under` |
+| 3 | The coverage map is valid but contains no files |
 
 `lcov` and `cobertura` use `--root` to relativize source paths, defaulting to the
 working directory. Repo-relative paths are required by self-hosted Codecov, the

--- a/crates/oxc_coverage_instrument_cli/src/main.rs
+++ b/crates/oxc_coverage_instrument_cli/src/main.rs
@@ -40,9 +40,11 @@ const DEFAULT_COVERAGE_VARIABLE: &str = "__coverage__";
 /// `--threshold` default: percentage at or above which html cells render green.
 const DEFAULT_GREEN_THRESHOLD: f64 = 80.0;
 
-/// Exit code for a coverage failure, as opposed to a usage or I/O failure:
-/// line coverage below `--fail-under`, or a coverage file with no entries.
-const EXIT_COVERAGE_FAILURE: u8 = 2;
+/// Exit code for line coverage below `--fail-under`.
+const EXIT_COVERAGE_THRESHOLD: u8 = 2;
+
+/// Exit code for a valid coverage map that contains no files.
+const EXIT_EMPTY_COVERAGE: u8 = 3;
 
 struct InstrumentArgs {
     filename: String,
@@ -61,6 +63,21 @@ impl InstrumentArgs {
             source_map: false,
             coverage_variable: DEFAULT_COVERAGE_VARIABLE.to_string(),
         }
+    }
+
+    fn validate_output_options(&self) -> Result<(), ExitCode> {
+        if !self.coverage_map_only {
+            return Ok(());
+        }
+        if self.output_file.is_some() {
+            eprintln!("error: --coverage-map cannot be combined with -o or --output");
+            return Err(ExitCode::FAILURE);
+        }
+        if self.source_map {
+            eprintln!("error: --coverage-map cannot be combined with --source-map");
+            return Err(ExitCode::FAILURE);
+        }
+        Ok(())
     }
 }
 
@@ -82,7 +99,7 @@ struct ReportArgs {
     /// "N of M files fall below the X% coverage threshold" sentence.
     green_threshold: f64,
     /// Aggregate line-coverage floor. When supplied, reports still render,
-    /// then the process exits with [`EXIT_COVERAGE_FAILURE`] if total line
+    /// then the process exits with [`EXIT_COVERAGE_THRESHOLD`] if total line
     /// coverage is below the configured percentage.
     fail_under: Option<f64>,
 }
@@ -286,13 +303,14 @@ fn parse_instrument_args(args: &[String]) -> Result<InstrumentArgs, ExitCode> {
             }
             other => {
                 eprintln!("error: unknown option: {other}");
-                print_usage();
+                print_instrument_usage();
                 return Err(ExitCode::FAILURE);
             }
         }
         i += 1;
     }
 
+    cli.validate_output_options()?;
     Ok(cli)
 }
 
@@ -451,7 +469,7 @@ fn read_coverage_map(args: &ReportArgs) -> Result<CoverageMap, ExitCode> {
     };
     if map.is_empty() {
         eprintln!("error: {} contains no files", args.coverage_file);
-        return Err(ExitCode::from(EXIT_COVERAGE_FAILURE));
+        return Err(ExitCode::from(EXIT_EMPTY_COVERAGE));
     }
 
     Ok(map)
@@ -507,7 +525,7 @@ fn apply_fail_under(root: &ReportNode, fail_under: Option<f64>) -> ExitCode {
         let actual = root.summary.lines.pct;
         if actual < floor {
             eprintln!("coverage {actual:.2}% is below --fail-under {floor:.2}%");
-            return ExitCode::from(EXIT_COVERAGE_FAILURE);
+            return ExitCode::from(EXIT_COVERAGE_THRESHOLD);
         }
     }
     ExitCode::SUCCESS

--- a/crates/oxc_coverage_instrument_cli/tests/instrument_cli.rs
+++ b/crates/oxc_coverage_instrument_cli/tests/instrument_cli.rs
@@ -68,10 +68,25 @@ fn bare_word_typo_hints_at_subcommands() {
 #[test]
 fn unknown_option_exits_failure() {
     let src = write_temp("unknown_opt.js", "const x = 1;");
-    let out = cli().arg(&src).arg("--totally-unknown").output().unwrap();
-    assert!(!out.status.success());
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("unknown option"), "should reject unknown option, got: {stderr}");
+    for explicit in [false, true] {
+        let mut command = cli();
+        if explicit {
+            command.arg("instrument");
+        }
+        let out = command.arg(&src).arg("--totally-unknown").output().unwrap();
+        assert!(!out.status.success());
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("unknown option"), "should reject unknown option, got: {stderr}");
+        assert!(stderr.contains("oxc-coverage-instrument instrument"), "got: {stderr}");
+        assert!(
+            !stderr.contains("--fail-under"),
+            "instrument usage must omit report flags: {stderr}"
+        );
+        assert!(
+            !stderr.contains("--threshold"),
+            "instrument usage must omit report flags: {stderr}"
+        );
+    }
 }
 
 #[test]
@@ -103,6 +118,56 @@ fn coverage_map_only_outputs_valid_json_with_expected_keys() {
         value["fnMap"]["0"]["name"], "add",
         "function name should be resolved from declaration"
     );
+}
+
+#[test]
+fn coverage_map_only_rejects_discarded_output_options() {
+    let src = write_temp("coverage_map_invalid_options.js", "const x = 1;");
+
+    for explicit in [false, true] {
+        let out_path = temp_path(if explicit {
+            "coverage_map_explicit_out.json"
+        } else {
+            "coverage_map_implicit_out.json"
+        });
+        let _ = std::fs::remove_file(&out_path);
+
+        let mut output_command = cli();
+        if explicit {
+            output_command.arg("instrument");
+        }
+        let output = output_command
+            .arg(&src)
+            .arg("--coverage-map")
+            .arg("-o")
+            .arg(&out_path)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(1));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("--coverage-map cannot be combined with -o or --output"),
+            "got: {stderr}"
+        );
+        assert!(!out_path.exists(), "invalid combination must not create an output file");
+
+        let mut source_map_command = cli();
+        if explicit {
+            source_map_command.arg("instrument");
+        }
+        let source_map = source_map_command
+            .arg(&src)
+            .arg("--coverage-map")
+            .arg("--source-map")
+            .output()
+            .unwrap();
+        assert_eq!(source_map.status.code(), Some(1));
+        let stderr = String::from_utf8_lossy(&source_map.stderr);
+        assert!(
+            stderr.contains("--coverage-map cannot be combined with --source-map"),
+            "got: {stderr}"
+        );
+    }
 }
 
 #[test]

--- a/crates/oxc_coverage_instrument_cli/tests/report_cli.rs
+++ b/crates/oxc_coverage_instrument_cli/tests/report_cli.rs
@@ -236,10 +236,10 @@ fn report_nonexistent_coverage_file_reports_read_error() {
 }
 
 #[test]
-fn report_empty_coverage_map_exits_two_and_writes_nothing() {
+fn report_empty_coverage_map_has_distinct_exit_code_and_writes_nothing() {
     let cov = write_temp("report_empty_cov.json", "{}");
     let out = cli().arg("report").arg("--format").arg("text").arg(&cov).output().unwrap();
-    assert_eq!(out.status.code(), Some(2));
+    assert_eq!(out.status.code(), Some(3));
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("contains no files"), "got:\n{stderr}");
     assert!(

--- a/crates/oxc_coverage_instrument_napi/benches/remap.rs
+++ b/crates/oxc_coverage_instrument_napi/benches/remap.rs
@@ -11,6 +11,9 @@ use oxc_coverage_instrument_napi::remap_coverage_map_with_loader;
 use srcmap_generator::SourceMapGenerator;
 
 const SOURCE_PATH: &str = "src/app.ts";
+const SOURCE_LINE_COLUMNS: u32 = 80;
+const MAPPING_STRIDE: u32 = 2;
+const MAPPINGS_PER_LINE: u32 = SOURCE_LINE_COLUMNS / MAPPING_STRIDE;
 const CASES: &[(&str, usize, u32)] = &[("small", 4, 80), ("large", 20, 200)];
 
 fn loc(line: u32, start_col: u32, end_col: u32) -> Location {
@@ -21,14 +24,20 @@ fn loc(line: u32, start_col: u32, end_col: u32) -> Location {
 }
 
 fn source_map_json(generated_path: &str, lines: u32) -> String {
-    let mut generator =
-        SourceMapGenerator::with_capacity(Some(generated_path.to_string()), lines as usize * 16);
+    let mut generator = SourceMapGenerator::with_capacity(
+        Some(generated_path.to_string()),
+        lines as usize * MAPPINGS_PER_LINE as usize,
+    );
     generator.set_assume_sorted(true);
     let source = generator.add_source(SOURCE_PATH);
-    generator.set_source_content(source, vec!["x".repeat(80); lines as usize].join("\n"));
+    generator.set_source_content(
+        source,
+        vec!["x".repeat(SOURCE_LINE_COLUMNS as usize); lines as usize].join("\n"),
+    );
     for line in 0..lines {
-        for column in 0..16 {
-            generator.add_mapping(line, column * 2, source, line, column * 2);
+        for mapping in 0..MAPPINGS_PER_LINE {
+            let column = mapping * MAPPING_STRIDE;
+            generator.add_mapping(line, column, source, line, column);
         }
     }
     generator.to_json()

--- a/crates/oxc_coverage_instrument_napi/src/lib.rs
+++ b/crates/oxc_coverage_instrument_napi/src/lib.rs
@@ -411,7 +411,7 @@ fn parse_v8_functions(
 /// outer container.
 fn invalid_coverage_json_error<E: fmt::Display>(coverage_json: &str, err: E) -> napi::Error {
     let hint = if looks_like_single_file_coverage(coverage_json) {
-        " (hint: input parses as a single FileCoverage; remapCoverageMap \
+        " (hint: input parses as a single FileCoverage; the remap API \
          expects an Istanbul CoverageMap shape `{[path]: FileCoverage}`. \
          Wrap with `{ [fc.path]: fc }` before calling.)"
     } else {
@@ -602,6 +602,16 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("input parses as a single FileCoverage"));
         assert!(message.contains("Wrap with `{ [fc.path]: fc }` before calling"));
+    }
+
+    #[test]
+    fn loader_remap_reports_a_function_neutral_single_file_hint() {
+        let err = remap_coverage_map_with_loader(SINGLE_FC.to_string(), HashMap::new(), None)
+            .expect_err("single FileCoverage is not a CoverageMap");
+        let message = err.to_string();
+
+        assert!(message.contains("the remap API expects an Istanbul CoverageMap shape"));
+        assert!(!message.contains("remapCoverageMap expects"));
     }
 
     #[test]

--- a/crates/oxc_coverage_instrument_napi/test.mjs
+++ b/crates/oxc_coverage_instrument_napi/test.mjs
@@ -1602,6 +1602,22 @@ function runInstrumented(result, filename, callExpression) {
     `error must spell out the expected shape, got: ${caught.message}`,
   );
 
+  let loaderCaught = null;
+  try {
+    remapCoverageMapWithLoader(r.coverageMap, {});
+  } catch (e) {
+    loaderCaught = e;
+  }
+  assert(loaderCaught !== null, 'loader remap must also reject a single FileCoverage');
+  assert(
+    loaderCaught.message.includes('the remap API expects'),
+    `loader error must use the shared remap API hint, got: ${loaderCaught.message}`,
+  );
+  assert(
+    !loaderCaught.message.includes('remapCoverageMap expects'),
+    `loader error must not name a different function, got: ${loaderCaught.message}`,
+  );
+
   // Sanity: the same input wrapped in the correct shape works.
   const fc = JSON.parse(r.coverageMap);
   const remapped = JSON.parse(remapCoverageMap(JSON.stringify({ [fc.path]: fc })));

--- a/crates/oxc_coverage_report/src/summarizer.rs
+++ b/crates/oxc_coverage_report/src/summarizer.rs
@@ -76,6 +76,7 @@ struct FolderBuilder {
 }
 
 fn insert(folder: &mut FolderBuilder, segments: &[&str], file: FileCoverage) {
+    debug_assert!(!segments.is_empty(), "summarizer insertion requires a file segment");
     match segments {
         // Unreachable: `prefix_len` is bounded by `paths[0].len() - 1`, and a
         // strict segment-prefix of `paths[0]` would sort before it in the
@@ -204,5 +205,15 @@ mod tests {
         let map = parse_coverage_map(&json).unwrap();
         let root = summarize(&map);
         assert_eq!(root.summary.statements, crate::Metric::new(2, 1));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "summarizer insertion requires a file segment")]
+    fn insert_rejects_empty_segments() {
+        let json = format!("{{\"a.js\":{}}}", empty_file("a.js", true));
+        let mut map = parse_coverage_map(&json).unwrap();
+        let file = map.remove("a.js").unwrap();
+        insert(&mut FolderBuilder::default(), &[], file);
     }
 }

--- a/crates/oxc_coverage_report/src/summary.rs
+++ b/crates/oxc_coverage_report/src/summary.rs
@@ -139,7 +139,12 @@ fn branches_metric(file: &FileCoverage) -> Metric {
 fn lines_metric(file: &FileCoverage) -> Metric {
     let mut all_lines: BTreeSet<u32> = BTreeSet::new();
     let mut hit_lines: BTreeSet<u32> = BTreeSet::new();
-    for (id, loc) in &file.statement_map {
+    // Istanbul treats the counter map as authoritative for line coverage.
+    // Metadata without a matching counter contributes no source line.
+    for (id, hits) in &file.s {
+        let Some(loc) = file.statement_map.get(id) else {
+            continue;
+        };
         let line = loc.start.line;
         // Istanbul lines are 1-based, so 0 is the unknown-position sentinel
         // rather than a source line.
@@ -147,7 +152,7 @@ fn lines_metric(file: &FileCoverage) -> Metric {
             continue;
         }
         all_lines.insert(line);
-        if file.s.get(id).copied().unwrap_or(0) > 0 {
+        if *hits > 0 {
             hit_lines.insert(line);
         }
     }
@@ -223,6 +228,13 @@ mod tests {
         let summary = CoverageSummary::from_file(&parse_single(json));
         assert_eq!(summary.statements, Metric::new(1, 0));
         assert_eq!(summary.functions, Metric::new(1, 0));
+    }
+
+    #[test]
+    fn lines_ignore_statement_map_entries_without_counters() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":5}},"1":{"start":{"line":7,"column":0},"end":{"line":7,"column":5}}},"fnMap":{},"branchMap":{},"s":{"0":3},"f":{},"b":{}}}"#;
+        let summary = CoverageSummary::from_file(&parse_single(json));
+        assert_eq!(summary.lines, Metric::new(1, 1));
     }
 
     #[test]

--- a/crates/oxc_coverage_reports/src/lcov/mod.rs
+++ b/crates/oxc_coverage_reports/src/lcov/mod.rs
@@ -30,7 +30,7 @@
 //!
 //! [be]: oxc_coverage_types::BranchEntry
 
-use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::io;
 use std::path::Path;
 
@@ -140,20 +140,7 @@ fn sanitize_fn_name(name: &str) -> String {
     reason = "istanbul counters are u32 on the wire, so a line count that does not fit is already outside the format"
 )]
 fn write_lines<W: io::Write>(out: &mut W, file: &FileCoverage) -> io::Result<()> {
-    // A line counts as covered when any statement starting on it ran, so the
-    // per-line rollup takes the maximum rather than the sum.
-    let mut by_line: BTreeMap<u32, u32> = BTreeMap::new();
-    for (id, loc) in &file.statement_map {
-        let line = loc.start.line;
-        if line == 0 {
-            continue;
-        }
-        let hits = file.s.get(id).copied().unwrap_or(0);
-        by_line
-            .entry(line)
-            .and_modify(|existing| *existing = (*existing).max(hits))
-            .or_insert(hits);
-    }
+    let by_line = crate::projection::line_hits(file);
 
     let total = by_line.len() as u32;
     let hit = by_line.values().filter(|&&v| v > 0).count() as u32;
@@ -175,10 +162,18 @@ fn write_branches<W: io::Write>(out: &mut W, file: &FileCoverage) -> io::Result<
     // The `block` field of `BRDA:` must be a stable per-file discriminator so
     // Codecov does not merge unrelated branches on the same line. Istanbul
     // ids are numeric strings, which keeps the diff against istanbul-reports
-    // small; the iteration index covers non-numeric ids from other emitters so
-    // a hand-crafted map cannot collapse every branch into block=0.
+    // small. If any id is non-numeric or two strings parse to the same number,
+    // use iteration indexes for the whole file so blocks cannot collide.
+    let numeric_blocks: Option<Vec<u32>> =
+        file.branch_map.keys().map(|id| id.parse::<u32>().ok()).collect();
+    let numeric_blocks = numeric_blocks
+        .filter(|blocks| blocks.iter().copied().collect::<BTreeSet<_>>().len() == blocks.len());
     for (block_idx, (id, entry)) in file.branch_map.iter().enumerate() {
-        let block: u32 = id.parse().unwrap_or(block_idx as u32);
+        let block = numeric_blocks
+            .as_ref()
+            .and_then(|blocks| blocks.get(block_idx))
+            .copied()
+            .unwrap_or(block_idx as u32);
         let arms = crate::projection::aligned_branch_hits(file, id, entry);
         let block_entered = arms.iter().any(|&c| c > 0);
         for (idx, count) in arms.iter().enumerate() {

--- a/crates/oxc_coverage_reports/src/lcov/tests.rs
+++ b/crates/oxc_coverage_reports/src/lcov/tests.rs
@@ -196,6 +196,50 @@ fn brda_block_falls_back_to_index_for_non_numeric_id() {
 }
 
 #[test]
+fn brda_blocks_use_one_scheme_for_mixed_ids() {
+    let json = r#"{
+        "a.js": {
+            "path": "a.js",
+            "statementMap": {},
+            "fnMap": {},
+            "branchMap": {
+                "1": {"loc": {"start": {"line": 5, "column": 0}, "end": {"line": 5, "column": 10}}, "line": 5, "type": "if", "locations": [{"start": {"line": 5, "column": 0}, "end": {"line": 5, "column": 5}}, {"start": {"line": 5, "column": 6}, "end": {"line": 5, "column": 10}}]},
+                "br_a": {"loc": {"start": {"line": 5, "column": 11}, "end": {"line": 5, "column": 20}}, "line": 5, "type": "if", "locations": [{"start": {"line": 5, "column": 11}, "end": {"line": 5, "column": 15}}, {"start": {"line": 5, "column": 16}, "end": {"line": 5, "column": 20}}]}
+            },
+            "s": {},
+            "f": {},
+            "b": {"1": [1, 0], "br_a": [0, 1]}
+        }
+    }"#;
+    let out = render(json);
+    assert!(out.contains("BRDA:5,0,0,1"), "got:\n{out}");
+    assert!(out.contains("BRDA:5,0,1,0"), "got:\n{out}");
+    assert!(out.contains("BRDA:5,1,0,0"), "got:\n{out}");
+    assert!(out.contains("BRDA:5,1,1,1"), "got:\n{out}");
+}
+
+#[test]
+fn brda_blocks_fall_back_when_numeric_ids_alias() {
+    let json = r#"{
+        "a.js": {
+            "path": "a.js",
+            "statementMap": {},
+            "fnMap": {},
+            "branchMap": {
+                "01": {"loc": {"start": {"line": 5, "column": 0}, "end": {"line": 5, "column": 5}}, "line": 5, "type": "if", "locations": [{"start": {"line": 5, "column": 0}, "end": {"line": 5, "column": 5}}]},
+                "1": {"loc": {"start": {"line": 5, "column": 6}, "end": {"line": 5, "column": 10}}, "line": 5, "type": "if", "locations": [{"start": {"line": 5, "column": 6}, "end": {"line": 5, "column": 10}}]}
+            },
+            "s": {},
+            "f": {},
+            "b": {"01": [1], "1": [0]}
+        }
+    }"#;
+    let out = render(json);
+    assert!(out.contains("BRDA:5,0,0,1"), "got:\n{out}");
+    assert!(out.contains("BRDA:5,1,0,-"), "got:\n{out}");
+}
+
+#[test]
 fn lf_lh_counts_unique_lines() {
     let json = r#"{
         "a.js": {
@@ -214,5 +258,15 @@ fn lf_lh_counts_unique_lines() {
     }"#;
     let out = render(json);
     assert!(out.contains("LF:2"), "got:\n{out}");
+    assert!(out.contains("LH:1"), "got:\n{out}");
+}
+
+#[test]
+fn lines_ignore_statement_map_entries_without_counters() {
+    let json = r#"{"a.js":{"path":"a.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":5}},"1":{"start":{"line":7,"column":0},"end":{"line":7,"column":5}}},"fnMap":{},"branchMap":{},"s":{"0":3},"f":{},"b":{}}}"#;
+    let out = render(json);
+    assert!(out.contains("DA:1,3"), "got:\n{out}");
+    assert!(!out.contains("DA:7,"), "got:\n{out}");
+    assert!(out.contains("LF:1"), "got:\n{out}");
     assert!(out.contains("LH:1"), "got:\n{out}");
 }

--- a/crates/oxc_coverage_reports/src/projection.rs
+++ b/crates/oxc_coverage_reports/src/projection.rs
@@ -37,17 +37,19 @@ pub fn branch_counts(file: &FileCoverage) -> (u32, u32) {
 /// Hit counts keyed by the source line a statement starts on.
 ///
 /// A line is covered when any statement starting on it ran, so overlapping
-/// statements collapse to their maximum rather than their sum. Statements at
-/// the `line == 0` unknown-position sentinel are skipped: they belong to no
-/// source line.
+/// statements collapse to their maximum rather than their sum. The counter map
+/// is authoritative, matching Istanbul: metadata without a counter contributes
+/// no line. Statements at the `line == 0` unknown-position sentinel are skipped.
 pub fn line_hits(file: &FileCoverage) -> BTreeMap<u32, u32> {
     let mut by_line: BTreeMap<u32, u32> = BTreeMap::new();
-    for (id, loc) in &file.statement_map {
+    for (id, &hits) in &file.s {
+        let Some(loc) = file.statement_map.get(id) else {
+            continue;
+        };
         let line = loc.start.line;
         if line == 0 {
             continue;
         }
-        let hits = file.s.get(id).copied().unwrap_or(0);
         by_line
             .entry(line)
             .and_modify(|existing| *existing = (*existing).max(hits))
@@ -119,5 +121,12 @@ mod tests {
         let entry = &file.branch_map["0"];
         assert_eq!(aligned_branch_hits(file, "0", entry), vec![4, 0]);
         assert_eq!(branch_counts(file), (2, 1));
+    }
+
+    #[test]
+    fn line_hits_ignore_statement_map_entries_without_counters() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":5}},"1":{"start":{"line":7,"column":0},"end":{"line":7,"column":5}}},"fnMap":{},"branchMap":{},"s":{"0":3},"f":{},"b":{}}}"#;
+        let map = parse_coverage_map(json).unwrap();
+        assert_eq!(line_hits(&map["a.js"]), BTreeMap::from([(1, 3)]));
     }
 }

--- a/crates/oxc_coverage_reports/src/text.rs
+++ b/crates/oxc_coverage_reports/src/text.rs
@@ -139,12 +139,16 @@ fn format_pct(pct: f64) -> String {
 /// Collapse uncovered statement line numbers into a compact range list.
 fn uncovered_lines(file: &FileCoverage) -> String {
     let mut lines: BTreeSet<u32> = BTreeSet::new();
-    for (id, loc) in &file.statement_map {
-        if file.s.get(id).copied().unwrap_or(0) == 0 {
-            let line = loc.start.line;
-            if line != 0 {
-                lines.insert(line);
-            }
+    for (id, &hits) in &file.s {
+        if hits > 0 {
+            continue;
+        }
+        let Some(loc) = file.statement_map.get(id) else {
+            continue;
+        };
+        let line = loc.start.line;
+        if line != 0 {
+            lines.insert(line);
         }
     }
     collapse_ranges(&lines)
@@ -225,5 +229,12 @@ mod tests {
         let json = r#"{"a.js":{"path":"a.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":1}},"1":{"start":{"line":2,"column":0},"end":{"line":2,"column":1}},"2":{"start":{"line":5,"column":0},"end":{"line":5,"column":1}}},"fnMap":{},"branchMap":{},"s":{"0":1,"1":0,"2":0},"f":{},"b":{}}}"#;
         let out = render(json);
         assert!(out.contains("2,5"), "expected 2,5 in: {out}");
+    }
+
+    #[test]
+    fn uncovered_column_ignores_statement_map_entries_without_counters() {
+        let json = r#"{"a.js":{"path":"a.js","statementMap":{"0":{"start":{"line":1,"column":0},"end":{"line":1,"column":5}},"1":{"start":{"line":7,"column":0},"end":{"line":7,"column":5}}},"fnMap":{},"branchMap":{},"s":{"0":3},"f":{},"b":{}}}"#;
+        let map = parse_coverage_map(json).unwrap();
+        assert_eq!(uncovered_lines(&map["a.js"]), "");
     }
 }

--- a/crates/oxc_coverage_source_maps/src/get_mapping.rs
+++ b/crates/oxc_coverage_source_maps/src/get_mapping.rs
@@ -132,9 +132,10 @@ fn original_end_position_for(
     // afterEndMappings = allGeneratedPositionsFor(LUB) one column to the right;
     // map each back (GLB) and take the first that lands on the same original
     // line. That segment's start is the exclusive end of the span.
+    let next_column = before.column.checked_add(1)?;
     let after = all_generated_positions_for_lub(
         ctx,
-        OriginalLookup { source, line: before.line, column: before.column + 1 },
+        OriginalLookup { source, line: before.line, column: next_column },
     );
     for gen_pos in &after {
         if let Some(orig) = ctx.sm.original_position_for_with_bias(

--- a/crates/oxc_coverage_source_maps/src/position_remapper.rs
+++ b/crates/oxc_coverage_source_maps/src/position_remapper.rs
@@ -8,7 +8,7 @@ use srcmap_sourcemap::SourceMap;
 use crate::{
     context::{RemapCaches, RemapContext},
     get_mapping::get_mapping_location_cached,
-    sources::resolve_primary_source,
+    sources::has_resolved_source,
 };
 
 /// A position-remap predicate over a parsed `inputSourceMap`.
@@ -29,12 +29,14 @@ pub struct PositionRemapper {
 impl PositionRemapper {
     /// Parse a source map from JSON.
     ///
-    /// Returns `None` when the JSON fails to parse, or when `sources[0]`
-    /// resolves to no path (the `resolve_primary_source` bail).
+    /// Returns `None` when the JSON fails to parse, or when none of its
+    /// `sources` entries resolves to a path.
     #[must_use]
     pub fn from_json(input_sm_json: &str) -> Option<Self> {
         let sm = SourceMap::from_json(input_sm_json).ok()?;
-        resolve_primary_source(&sm)?;
+        if !has_resolved_source(&sm) {
+            return None;
+        }
         Some(Self { sm, caches: RefCell::new(RemapCaches::default()) })
     }
 

--- a/crates/oxc_coverage_source_maps/src/sources.rs
+++ b/crates/oxc_coverage_source_maps/src/sources.rs
@@ -4,13 +4,13 @@ use std::collections::BTreeSet;
 
 use srcmap_sourcemap::SourceMap;
 
-/// Coverage path for `sources[0]`, or `None` when that entry is empty.
+/// Whether at least one `sources` entry resolves to a coverage path.
 #[expect(
     clippy::redundant_pub_crate,
     reason = "`pub(crate)` marks the API boundary; the module is private by construction"
 )]
-pub(crate) fn resolve_primary_source(sm: &SourceMap) -> Option<String> {
-    resolve_source_path(sm, 0)
+pub(crate) fn has_resolved_source(sm: &SourceMap) -> bool {
+    sm.sources.iter().any(|source| !source.is_empty())
 }
 
 /// Coverage path for one `sources` entry, `None` when it is absent or empty.

--- a/crates/oxc_coverage_source_maps/tests/source_maps/get_mapping.rs
+++ b/crates/oxc_coverage_source_maps/tests/source_maps/get_mapping.rs
@@ -2,7 +2,7 @@
 //! greatest-lower-bound, ends resolve to the next original segment or the end
 //! of the original line.
 
-use oxc_coverage_source_maps::remap_coverage;
+use oxc_coverage_source_maps::{RemapOptions, remap_coverage, remap_coverage_with_options};
 use oxc_coverage_types::FileCoverage;
 use srcmap_generator::SourceMapGenerator;
 
@@ -102,6 +102,28 @@ fn get_mapping_mappings_only_handles_sparse_huge_original_line() {
     let remapped = remap_coverage(&fc).expect("remap succeeds");
     let loc = &remapped.statement_map["0"];
     assert_eq!(loc.end.column, 17, "sparse mappings retain their greatest original column");
+}
+
+#[test]
+fn get_mapping_drops_original_column_that_cannot_advance() {
+    let map = serde_json::from_str(
+        r#"{"version":3,"sources":["src/app.ts"],"sourcesContent":["const x = 1;\n"],"names":[],"mappings":"AAAA,KAA+/////H"}"#,
+    )
+    .expect("source map is valid JSON");
+    let fc = single_statement_coverage(map, 1, 0, 1, 6);
+
+    let remapped = remap_coverage_with_options(&fc, RemapOptions { drop_unmapped: true })
+        .expect("malformed mapping is handled without panicking");
+
+    assert!(
+        remapped.statement_map.is_empty(),
+        "an original column that cannot advance has no valid exclusive end",
+    );
+    assert!(remapped.s.is_empty(), "the dropped statement's counter is removed");
+
+    let kept = remap_coverage(&fc).expect("default mode also handles malformed input safely");
+    assert_eq!(kept.statement_map.len(), 1, "default mode retains the generated entry");
+    assert_eq!(kept.s.len(), 1, "default mode retains the aligned counter");
 }
 
 #[test]

--- a/crates/oxc_coverage_source_maps/tests/source_maps/position_remapper.rs
+++ b/crates/oxc_coverage_source_maps/tests/source_maps/position_remapper.rs
@@ -34,3 +34,12 @@ fn location_maps_matches_deferred_get_mapping_keep_decision() {
     // direct-lookup route the remap path sends it down.
     assert!(remapper.location_maps(&loc(0, 0, 0, 0)), "line-0 sentinel is a keep no-op");
 }
+
+#[test]
+fn admits_map_when_a_later_source_resolves() {
+    let input_sm = r#"{"version":3,"sources":["","src/app.ts"],"sourcesContent":[null,"const a = 1;\n"],"mappings":"ACAA","names":[]}"#;
+    let remapper = PositionRemapper::from_json(input_sm)
+        .expect("a map with a usable later source is admitted like deferred remapping");
+
+    assert!(remapper.location_maps(&loc(1, 0, 1, 4)), "source index 1 maps");
+}

--- a/crates/oxc_coverage_v8/src/lib.rs
+++ b/crates/oxc_coverage_v8/src/lib.rs
@@ -88,7 +88,7 @@ struct CoverageContext<'a> {
     ranges: &'a [V8CoverageRange],
     arm_ranges: &'a [V8CoverageRange],
     inheritance_ranges: &'a [CoverageRangeWithMode],
-    wrapper_length: u32,
+    wrapper_length_utf16: u32,
 }
 
 impl CoverageContext<'_> {
@@ -141,8 +141,8 @@ impl CoverageContext<'_> {
     fn arm_utf16_span(&self, arm_loc: &Location, body_byte_span: Option<(u32, u32)>) -> (u32, u32) {
         match body_byte_span {
             Some((start, end)) => (
-                self.source_index.byte_to_utf16(start).saturating_add(self.wrapper_length),
-                self.source_index.byte_to_utf16(end).saturating_add(self.wrapper_length),
+                self.source_index.byte_to_utf16(start).saturating_add(self.wrapper_length_utf16),
+                self.source_index.byte_to_utf16(end).saturating_add(self.wrapper_length_utf16),
             ),
             None => self.location_utf16_span(arm_loc),
         }
@@ -152,10 +152,10 @@ impl CoverageContext<'_> {
         (
             self.source_index
                 .position_to_utf16(loc.start.line, loc.start.column)
-                .saturating_add(self.wrapper_length),
+                .saturating_add(self.wrapper_length_utf16),
             self.source_index
                 .position_to_utf16(loc.end.line, loc.end.column)
-                .saturating_add(self.wrapper_length),
+                .saturating_add(self.wrapper_length_utf16),
         )
     }
 
@@ -207,13 +207,13 @@ impl CoverageContext<'_> {
 /// non-empty body span is matched against V8's block ranges before falling back
 /// to the arm's [`Location`].
 ///
-/// `wrapper_length` is the UTF-16 code-unit base for producers that report
+/// `wrapper_length_utf16` is the UTF-16 code-unit base for producers that report
 /// wrapper-shifted ranges. Pass 0 for source-relative inspector output.
 pub fn apply_v8_coverage(
     file_coverage: &mut FileCoverage,
     source: &str,
     functions: &[V8FunctionCoverage],
-    wrapper_length: u32,
+    wrapper_length_utf16: u32,
     arm_body_byte_spans: &BTreeMap<String, Vec<(u32, u32)>>,
 ) {
     let source_index = SourceIndex::new(source);
@@ -246,7 +246,7 @@ pub fn apply_v8_coverage(
         ranges: &ranges,
         arm_ranges: &arm_ranges,
         inheritance_ranges: &inheritance_ranges,
-        wrapper_length,
+        wrapper_length_utf16,
     };
 
     apply_statement_counts(file_coverage, &context);

--- a/crates/oxc_coverage_v8/src/source_map_url.rs
+++ b/crates/oxc_coverage_v8/src/source_map_url.rs
@@ -119,9 +119,9 @@ fn decode_percent_encoded(input: &str) -> Option<String> {
     let bytes = input.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            let hi = hex_digit(bytes[i + 1])?;
-            let lo = hex_digit(bytes[i + 2])?;
+        if bytes[i] == b'%' {
+            let hi = hex_digit(*bytes.get(i + 1)?)?;
+            let lo = hex_digit(*bytes.get(i + 2)?)?;
             out.push((hi << 4) | lo);
             i += 3;
         } else {
@@ -130,4 +130,15 @@ fn decode_percent_encoded(input: &str) -> Option<String> {
         }
     }
     String::from_utf8(out).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_percent_encoded;
+
+    #[test]
+    fn rejects_truncated_percent_escape_at_payload_end() {
+        assert_eq!(decode_percent_encoded("payload%"), None);
+        assert_eq!(decode_percent_encoded("payload%4"), None);
+    }
 }

--- a/crates/oxc_coverage_v8/tests/api_edges.rs
+++ b/crates/oxc_coverage_v8/tests/api_edges.rs
@@ -218,6 +218,32 @@ fn statement_counts_resolve_across_every_ecmascript_line_terminator() {
 }
 
 #[test]
+fn wrapper_length_uses_utf16_code_units_for_non_ascii_wrappers() {
+    let wrapper = "/* 🦀 */";
+    let wrapper_length_utf16 = utf16_len(wrapper);
+    assert_ne!(wrapper_length_utf16, byte_len(wrapper), "fixture distinguishes UTF-16 from bytes");
+
+    let source = "x();";
+    let mut coverage = single_statement_coverage(Location {
+        start: Position { line: 1, column: 0 },
+        end: Position { line: 1, column: 4 },
+    });
+    let functions = [V8FunctionCoverage {
+        function_name: String::new(),
+        ranges: vec![V8CoverageRange {
+            start_offset: wrapper_length_utf16,
+            end_offset: wrapper_length_utf16 + utf16_len(source),
+            count: 7,
+        }],
+        is_block_coverage: true,
+    }];
+
+    apply_v8_coverage(&mut coverage, source, &functions, wrapper_length_utf16, &BTreeMap::new());
+
+    assert_eq!(coverage.s["0"], 7, "the wrapper offset is measured in UTF-16 code units");
+}
+
+#[test]
 fn arm_tiebreaker_prefers_tighter_v8_range_at_equal_distance() {
     // Branch arm on line 3, columns 4..6, mapping to byte offsets [26, 28).
     // Two V8 block ranges flank it within the 4-byte tolerance:

--- a/scripts/real-world-output.mjs
+++ b/scripts/real-world-output.mjs
@@ -258,6 +258,16 @@ globalThis.serviceResults = [service.find('1')?.name, service.find('2')];`,
     },
   },
   {
+    name: 'private method in parameter default',
+    filename: 'runtime/private-method-default.js',
+    source: `function f(x = class { #m() {} }) {}
+f();`,
+    verify: ({ coverageMap, coverage }) => {
+      assert.equal(coverageMap.fnMap['0'].name, 'f');
+      assert.equal(coverage.f['0'], 1, 'the enclosing function counter must increment');
+    },
+  },
+  {
     name: 'async function paths',
     filename: 'runtime/async.js',
     source: `async function load(flag) {


### PR DESCRIPTION
## Summary

- fix function counter placement for private methods in parameter defaults
- strip ignored TypeScript files without adding coverage counters or a preamble
- align line and LCOV projections with Istanbul on partial coverage maps
- reject conflicting CLI output options and document distinct report exit codes
- harden source-map, V8 URL, UTF-16 offset, and N-API edge cases
- remove the unreachable `InstrumentError::SerializationError` variant
- make the remap benchmark mapping density match its 80-column source fixture

## Verification

- `./scripts/check.sh all-local`
- Istanbul differential and upstream runtime checks
- real-world output, real-world parity, and Node inspector smokes
- Vitest TypeScript typecheck, coverage, and verification
- native N-API tests and CodSpeed benchmark build and discovery

## Breaking change

Removing the public `InstrumentError::SerializationError` variant requires the next release containing this change to be 0.11.0 or another explicitly breaking release.

Closes #171
Closes #172
Closes #173
Closes #174
Closes #175
Closes #176
Closes #177
Closes #178
Closes #179
Closes #180
Closes #181
Closes #182
Closes #183
Closes #184
Closes #185
