### PR TITLE
chore(deps): apply dependabot batch (actions and napi toolchain)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -90,7 +90,7 @@ jobs:
           rm target/codspeed/analysis/${{ matrix.package }}/*.d
 
       - name: Run benchmark shard
-        uses: CodSpeedHQ/action@9f3a37ece7abc84992501a7fcd54d1704f3458fa # v4.18.4
+        uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
           mode: simulation
           run: cargo codspeed run ${{ matrix.bench }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
       # Deterministic, no network: every internal version pin must equal the
@@ -213,7 +213,7 @@ jobs:
         with:
           cache-key: napi
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -267,7 +267,7 @@ jobs:
           cache-key: napi-wasm-${{ matrix.target }}
           targets: ${{ matrix.target }}
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -352,7 +352,7 @@ jobs:
         with:
           cache-key: istanbul-diff
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -402,7 +402,7 @@ jobs:
         with:
           cache-key: real-world-parity
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -453,7 +453,7 @@ jobs:
         with:
           cache-key: vitest-typescript
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -513,7 +513,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
 
@@ -581,7 +581,7 @@ jobs:
           cache-key: native-vs-wasm-parity-${{ matrix.target }}
           targets: ${{ matrix.target }}
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -659,7 +659,7 @@ jobs:
           cache-key: wasm-node-example-${{ matrix.target }}
           targets: ${{ matrix.target }}
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -735,7 +735,7 @@ jobs:
           cache-key: cloudflare-workers-example
           targets: wasm32-wasip1,wasm32-wasip1-threads
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -113,7 +113,7 @@ jobs:
           targets: ${{ matrix.target }}
           cache-key: release-${{ matrix.target }}
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -312,7 +312,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,6 +36,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      - uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/crates/oxc_coverage_instrument_napi/package-lock.json
+++ b/crates/oxc_coverage_instrument_napi/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@babel/core": "^7.29.0 || ^8.0.0",
         "@jridgewell/gen-mapping": "^0.3.13",
-        "@napi-rs/cli": "3.7.3",
+        "@napi-rs/cli": "3.7.4",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-instrument": "^6.0.3",
         "istanbul-lib-source-maps": "^5.0.6"
@@ -1016,9 +1016,9 @@
       }
     },
     "node_modules/@napi-rs/cli": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.7.3.tgz",
-      "integrity": "sha512-iu5BOoYjYVixp5jwE7JniHvg72XuKWXUfXteu+6Gt/XY4/mslsS+Qbipleg1+3CAUGHkWc+ebaMJj7Pc93BXSQ==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.7.4.tgz",
+      "integrity": "sha512-idELIUceJ9zPgx/shcMt1fSSsteFG68v56RIXi4qUm7OYuJOt7CoMj2KnHVmbOqXgUHWQU1lCULrtQdZDG4F5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/crates/oxc_coverage_instrument_napi/package.json
+++ b/crates/oxc_coverage_instrument_napi/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.0 || ^8.0.0",
     "@jridgewell/gen-mapping": "^0.3.13",
-    "@napi-rs/cli": "3.7.3",
+    "@napi-rs/cli": "3.7.4",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-instrument": "^6.0.3",
     "istanbul-lib-source-maps": "^5.0.6"


### PR DESCRIPTION
Batches the four open dependabot PRs into one validated change.

## Bumps

- actions/setup-node 6.4.0 to 7.0.0, pinned at 820762786026740c76f36085b0efc47a31fe5020 (major; all 14 call sites use only node-version and cache, both supported in v7, so no call-site porting was needed)
- github/codeql-action/upload-sarif 4.37.0 to 4.37.3, pinned at e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
- CodSpeedHQ/action 4.18.4 to 4.18.5, pinned at f99becdce5e5d51fd556489ebef684f4ecfd6286
- @napi-rs/cli 3.7.3 to 3.7.4 in crates/oxc_coverage_instrument_napi (napi-toolchain group)

## Skips

None.

## Local validation

- cargo fmt --all --check: pass
- cargo clippy --workspace --all-targets -D warnings: pass
- cargo test --workspace --all-targets and --doc: pass
- cargo doc --workspace --no-deps (RUSTDOCFLAGS=-D warnings): pass
- ./scripts/check.sh version-sync: pass
- uvx zizmor@1.27.0 on .github/: no findings
- napi: npm install, npx napi build --platform with @napi-rs/cli 3.7.4, node test.mjs: all pass

Closes #200
Closes #198
Closes #190
Closes #188