### PR TITLE
chore(deps): bump Swatinem/rust-cache pin to f0d9c38

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -43,6 +43,6 @@ runs:
         components: ${{ inputs.components }}
         targets: ${{ inputs.targets }}
 
-    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+    - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
       with:
         key: ${{ inputs.cache-key }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
           components: llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
         with:
           key: coverage
 


### PR DESCRIPTION
Supersedes #218. Dependabot's SHA-to-SHA commit header is 127 characters, so that PR can never pass the commitlint header-max-length check. Same pin refresh with a short subject, including the composite .github/actions/setup-rust/action.yml that Dependabot does not cover.